### PR TITLE
Single thread executor should not have max capacity by default

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
@@ -187,6 +187,10 @@ public class GrowableMpScArrayConsumerBlockingQueue<T> extends AbstractQueue<T> 
             // Double check that size has not changed after we have registered ourselves for notification
             if (size.get() == 0) {
                 LockSupport.parkUntil(deadline);
+                if (Thread.interrupted()) {
+                    throw new InterruptedException();
+                }
+
                 if (System.currentTimeMillis() >= deadline) {
                     return null;
                 }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
@@ -26,9 +26,9 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.StampedLock;
 import org.apache.bookkeeper.util.MathUtils;
 
 
@@ -37,31 +37,26 @@ import org.apache.bookkeeper.util.MathUtils;
  *
  * <p>When the capacity is reached, data will be moved to a bigger array.
  *
+ * <p>This queue only allows 1 consumer thread to dequeue items and multiple producer threads.
  */
-public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
+public class GrowableMpScArrayConsumerBlockingQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
 
-    private final ReentrantLock headLock = new ReentrantLock();
+    private final StampedLock headLock = new StampedLock();
     private final PaddedInt headIndex = new PaddedInt();
     private final PaddedInt tailIndex = new PaddedInt();
-    private final ReentrantLock tailLock = new ReentrantLock();
-    private final Condition isNotEmpty = headLock.newCondition();
+    private final StampedLock tailLock = new StampedLock();
 
     private T[] data;
-    @SuppressWarnings("rawtypes")
-    private static final AtomicIntegerFieldUpdater<GrowableArrayBlockingQueue> SIZE_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(GrowableArrayBlockingQueue.class, "size");
-    @SuppressWarnings("unused")
-    private volatile int size = 0;
+    private final AtomicInteger size = new AtomicInteger(0);
 
-    public GrowableArrayBlockingQueue() {
+    private volatile Thread waitingConsumer;
+
+    public GrowableMpScArrayConsumerBlockingQueue() {
         this(64);
     }
 
     @SuppressWarnings("unchecked")
-    public GrowableArrayBlockingQueue(int initialCapacity) {
-        headIndex.value = 0;
-        tailIndex.value = 0;
-
+    public GrowableMpScArrayConsumerBlockingQueue(int initialCapacity) {
         int capacity = MathUtils.findNextPositivePowerOfTwo(initialCapacity);
         data = (T[]) new Object[capacity];
     }
@@ -78,19 +73,22 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public T poll() {
-        headLock.lock();
-        try {
-            if (SIZE_UPDATER.get(this) > 0) {
+        if (size.get() > 0) {
+            // Since this is a single-consumer queue, we don't expect multiple threads calling poll(), though we need
+            // to protect against array expansions
+            long stamp = headLock.readLock();
+
+            try {
                 T item = data[headIndex.value];
                 data[headIndex.value] = null;
                 headIndex.value = (headIndex.value + 1) & (data.length - 1);
-                SIZE_UPDATER.decrementAndGet(this);
+                size.decrementAndGet();
                 return item;
-            } else {
-                return null;
+            } finally {
+                headLock.unlockRead(stamp);
             }
-        } finally {
-            headLock.unlock();
+        } else {
+            return null;
         }
     }
 
@@ -106,15 +104,16 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public T peek() {
-        headLock.lock();
-        try {
-            if (SIZE_UPDATER.get(this) > 0) {
+        if (size.get() > 0) {
+            long stamp = headLock.readLock();
+
+            try {
                 return data[headIndex.value];
-            } else {
-                return null;
+            } finally {
+                headLock.unlockRead(stamp);
             }
-        } finally {
-            headLock.unlock();
+        } else {
+            return null;
         }
     }
 
@@ -127,31 +126,24 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public void put(T e) {
-        tailLock.lock();
-
-        boolean wasEmpty = false;
+        long stamp = tailLock.writeLock();
 
         try {
-            if (SIZE_UPDATER.get(this) == data.length) {
+            int oldSize = size.get();
+            if (oldSize == data.length) {
                 expandArray();
             }
 
             data[tailIndex.value] = e;
             tailIndex.value = (tailIndex.value + 1) & (data.length - 1);
-            if (SIZE_UPDATER.getAndIncrement(this) == 0) {
-                wasEmpty = true;
+
+            if (size.getAndIncrement() == 0 && waitingConsumer != null) {
+                Thread waitingConsumer = this.waitingConsumer;
+                this.waitingConsumer = null;
+                LockSupport.unpark(waitingConsumer);
             }
         } finally {
-            tailLock.unlock();
-        }
-
-        if (wasEmpty) {
-            headLock.lock();
-            try {
-                isNotEmpty.signal();
-            } finally {
-                headLock.unlock();
-            }
+            tailLock.unlockWrite(stamp);
         }
     }
 
@@ -170,51 +162,35 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public T take() throws InterruptedException {
-        headLock.lockInterruptibly();
+        while (size() == 0) {
+            waitingConsumer = Thread.currentThread();
 
-        try {
-            while (SIZE_UPDATER.get(this) == 0) {
-                isNotEmpty.await();
+            // Double check that size has not changed after we have registered ourselves for notification
+            if (size() == 0) {
+                LockSupport.park();
             }
-
-            T item = data[headIndex.value];
-            data[headIndex.value] = null;
-            headIndex.value = (headIndex.value + 1) & (data.length - 1);
-            if (SIZE_UPDATER.decrementAndGet(this) > 0) {
-                // There are still entries to consume
-                isNotEmpty.signal();
-            }
-            return item;
-        } finally {
-            headLock.unlock();
         }
+
+        return poll();
     }
 
     @Override
     public T poll(long timeout, TimeUnit unit) throws InterruptedException {
-        headLock.lockInterruptibly();
+        long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
 
-        try {
-            long timeoutNanos = unit.toNanos(timeout);
-            while (SIZE_UPDATER.get(this) == 0) {
-                if (timeoutNanos <= 0) {
+        while (size.get() == 0) {
+            waitingConsumer = Thread.currentThread();
+
+            // Double check that size has not changed after we have registered ourselves for notification
+            if (size.get() == 0) {
+                LockSupport.parkUntil(deadline);
+                if (System.currentTimeMillis() >= deadline) {
                     return null;
                 }
-
-                timeoutNanos = isNotEmpty.awaitNanos(timeoutNanos);
             }
-
-            T item = data[headIndex.value];
-            data[headIndex.value] = null;
-            headIndex.value = (headIndex.value + 1) & (data.length - 1);
-            if (SIZE_UPDATER.decrementAndGet(this) > 0) {
-                // There are still entries to consume
-                isNotEmpty.signal();
-            }
-            return item;
-        } finally {
-            headLock.unlock();
         }
+
+        return poll();
     }
 
     @Override
@@ -229,57 +205,47 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public int drainTo(Collection<? super T> c, int maxElements) {
-        headLock.lock();
+        long stamp = headLock.readLock();
 
         try {
-            int drainedItems = 0;
-            int size = SIZE_UPDATER.get(this);
+            int toDrain = Math.min(size.get(), maxElements);
 
-            while (size > 0 && drainedItems < maxElements) {
+            for (int i = 0; i < toDrain; i++) {
                 T item = data[headIndex.value];
                 data[headIndex.value] = null;
                 c.add(item);
 
                 headIndex.value = (headIndex.value + 1) & (data.length - 1);
-                --size;
-                ++drainedItems;
             }
 
-            if (SIZE_UPDATER.addAndGet(this, -drainedItems) > 0) {
-                // There are still entries to consume
-                isNotEmpty.signal();
-            }
-
-            return drainedItems;
+            this.size.addAndGet(-toDrain);
+            return toDrain;
         } finally {
-            headLock.unlock();
+            headLock.unlockRead(stamp);
         }
     }
 
     @Override
     public void clear() {
-        headLock.lock();
+        long stamp = headLock.readLock();
 
         try {
-            int size = SIZE_UPDATER.get(this);
+            int size = this.size.get();
 
             for (int i = 0; i < size; i++) {
                 data[headIndex.value] = null;
                 headIndex.value = (headIndex.value + 1) & (data.length - 1);
             }
 
-            if (SIZE_UPDATER.addAndGet(this, -size) > 0) {
-                // There are still entries to consume
-                isNotEmpty.signal();
-            }
+            this.size.addAndGet(-size);
         } finally {
-            headLock.unlock();
+            headLock.unlockRead(stamp);
         }
     }
 
     @Override
     public int size() {
-        return SIZE_UPDATER.get(this);
+        return size.get();
     }
 
     @Override
@@ -291,12 +257,12 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        tailLock.lock();
-        headLock.lock();
+        long tailStamp = tailLock.writeLock();
+        long headStamp = headLock.writeLock();
 
         try {
             int headIndex = this.headIndex.value;
-            int size = SIZE_UPDATER.get(this);
+            int size = this.size.get();
 
             sb.append('[');
 
@@ -313,8 +279,8 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
             sb.append(']');
         } finally {
-            headLock.unlock();
-            tailLock.unlock();
+            headLock.unlockWrite(headStamp);
+            tailLock.unlockWrite(tailStamp);
         }
         return sb.toString();
     }
@@ -322,31 +288,30 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
     @SuppressWarnings("unchecked")
     private void expandArray() {
         // We already hold the tailLock
-        headLock.lock();
+        long headLockStamp = headLock.writeLock();
 
         try {
-            int size = SIZE_UPDATER.get(this);
+            int size = this.size.get();
             int newCapacity = data.length * 2;
             T[] newData = (T[]) new Object[newCapacity];
 
-            int oldHeadIndex = headIndex.value;
-            int newTailIndex = 0;
 
-            for (int i = 0; i < size; i++) {
-                newData[newTailIndex++] = data[oldHeadIndex];
-                oldHeadIndex = (oldHeadIndex + 1) & (data.length - 1);
-            }
+            int oldHeadIndex = headIndex.value;
+            int lenHeadToEnd = Math.min(size, data.length - oldHeadIndex);
+
+            System.arraycopy(data, oldHeadIndex, newData, 0, lenHeadToEnd);
+            System.arraycopy(data, 0, newData, lenHeadToEnd, size - lenHeadToEnd);
 
             data = newData;
             headIndex.value = 0;
             tailIndex.value = size;
         } finally {
-            headLock.unlock();
+            headLock.unlockWrite(headLockStamp);
         }
     }
 
-    static final class PaddedInt {
-        private int value;
+    private static final class PaddedInt {
+        int value = 0;
 
         // Padding to avoid false sharing
         public volatile int pi1 = 1;

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/GrowableMpScArrayConsumerBlockingQueue.java
@@ -168,6 +168,9 @@ public class GrowableMpScArrayConsumerBlockingQueue<T> extends AbstractQueue<T> 
             // Double check that size has not changed after we have registered ourselves for notification
             if (size() == 0) {
                 LockSupport.park();
+                if (Thread.interrupted()) {
+                    throw new InterruptedException();
+                }
             }
         }
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
@@ -18,7 +18,6 @@
 
 package org.apache.bookkeeper.common.util;
 
-import com.google.common.base.Preconditions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.common.collections.BlockingMpscQueue;
 import org.apache.bookkeeper.common.collections.GrowableMpScArrayConsumerBlockingQueue;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -73,8 +71,8 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
     @SneakyThrows
     @SuppressFBWarnings(value = {"SC_START_IN_CTOR"})
     public SingleThreadExecutor(ThreadFactory tf, int maxQueueCapacity, boolean rejectExecution) {
-        if (rejectExecution) {
-            Preconditions.checkArgument(maxQueueCapacity > 0);
+        if (rejectExecution && maxQueueCapacity == 0) {
+            throw new IllegalArgumentException("Executor cannot reject new items if the queue is unbound");
         }
 
         if (maxQueueCapacity > 0) {

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
@@ -246,7 +246,7 @@ public class GrowableArrayBlockingQueueTest {
     }
 
     public static void main(String[] args) throws Exception {
-        int N = 10_000;
+        int n = 10_000;
         BlockingQueue<Integer> q1 = new GrowableMpScArrayConsumerBlockingQueue<>();
         BlockingQueue<Integer> q2 = new GrowableMpScArrayConsumerBlockingQueue<>();
 //        BlockingQueue<Integer> q1 = new ArrayBlockingQueue<>(N * 2);
@@ -257,7 +257,7 @@ public class GrowableArrayBlockingQueueTest {
         TestThread t1 = new TestThread(q1, q2);
         TestThread t2 = new TestThread(q2, q1);
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             q1.add(i);
         }
 

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/collections/GrowableArrayBlockingQueueTest.java
@@ -31,6 +31,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 
 /**
@@ -40,7 +41,7 @@ public class GrowableArrayBlockingQueueTest {
 
     @Test
     public void simple() throws Exception {
-        BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(4);
+        BlockingQueue<Integer> queue = new GrowableMpScArrayConsumerBlockingQueue<>(4);
 
         assertEquals(null, queue.poll());
 
@@ -99,7 +100,7 @@ public class GrowableArrayBlockingQueueTest {
 
     @Test
     public void blockingTake() throws Exception {
-        BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>();
+        BlockingQueue<Integer> queue = new GrowableMpScArrayConsumerBlockingQueue<>();
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -137,7 +138,7 @@ public class GrowableArrayBlockingQueueTest {
 
     @Test
     public void growArray() throws Exception {
-        BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(4);
+        BlockingQueue<Integer> queue = new GrowableMpScArrayConsumerBlockingQueue<>(4);
 
         assertEquals(null, queue.poll());
 
@@ -166,7 +167,7 @@ public class GrowableArrayBlockingQueueTest {
 
     @Test
     public void pollTimeout() throws Exception {
-        BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(4);
+        BlockingQueue<Integer> queue = new GrowableMpScArrayConsumerBlockingQueue<>(4);
 
         assertEquals(null, queue.poll(1, TimeUnit.MILLISECONDS));
 
@@ -184,7 +185,7 @@ public class GrowableArrayBlockingQueueTest {
 
     @Test
     public void pollTimeout2() throws Exception {
-        BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>();
+        BlockingQueue<Integer> queue = new GrowableMpScArrayConsumerBlockingQueue<>();
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -203,5 +204,70 @@ public class GrowableArrayBlockingQueueTest {
         queue.put(1);
 
         latch.await();
+    }
+
+
+    static class TestThread extends Thread {
+
+        private volatile boolean stop;
+        private final BlockingQueue<Integer> readQ;
+        private final BlockingQueue<Integer> writeQ;
+
+        private final AtomicLong counter = new AtomicLong();
+
+        TestThread(BlockingQueue<Integer> readQ, BlockingQueue<Integer> writeQ) {
+            this.readQ = readQ;
+            this.writeQ = writeQ;
+        }
+
+        @Override
+        public void run() {
+            ArrayList<Integer> localQ = new ArrayList<>();
+
+            while (!stop) {
+                int items = readQ.drainTo(localQ);
+                if (items > 0) {
+                    for (int i = 0; i < items; i++) {
+                        writeQ.add(localQ.get(i));
+                    }
+
+                    counter.addAndGet(items);
+                    localQ.clear();
+                } else {
+                    try {
+                        writeQ.add(readQ.take());
+                        counter.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int N = 10_000;
+        BlockingQueue<Integer> q1 = new GrowableMpScArrayConsumerBlockingQueue<>();
+        BlockingQueue<Integer> q2 = new GrowableMpScArrayConsumerBlockingQueue<>();
+//        BlockingQueue<Integer> q1 = new ArrayBlockingQueue<>(N * 2);
+//        BlockingQueue<Integer> q2 = new ArrayBlockingQueue<>(N * 2);
+//        BlockingQueue<Integer> q1 = new LinkedBlockingQueue<>();
+//        BlockingQueue<Integer> q2 = new LinkedBlockingDeque<>();
+
+        TestThread t1 = new TestThread(q1, q2);
+        TestThread t2 = new TestThread(q2, q1);
+
+        for (int i = 0; i < N; i++) {
+            q1.add(i);
+        }
+
+        t1.start();
+        t2.start();
+
+        Thread.sleep(10_000);
+
+        System.out.println("Throughput " + (t1.counter.get() / 10 / 1e6) + " Millions items/s");
+        t1.stop = true;
+        t2.stop = true;
     }
 }

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -291,7 +291,7 @@ public class TestSingleThreadExecutor {
 
     @Test
     public void testExecutorQueueIsNotFixedSize() throws Exception {
-        int N = 1_000_000;
+        int n = 1_000_000;
         @Cleanup("shutdown")
         SingleThreadExecutor ste = new SingleThreadExecutor(THREAD_FACTORY);
 
@@ -305,7 +305,7 @@ public class TestSingleThreadExecutor {
             }
         });
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             ste.execute(() -> {});
         }
 

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -286,5 +287,33 @@ public class TestSingleThreadExecutor {
         ste.awaitTermination(10, TimeUnit.SECONDS);
         assertTrue(ste.isShutdown());
         assertTrue(ste.isTerminated());
+    }
+
+    @Test
+    public void testExecutorQueueIsNotFixedSize() throws Exception {
+        int N = 1_000_000;
+        @Cleanup("shutdown")
+        SingleThreadExecutor ste = new SingleThreadExecutor(THREAD_FACTORY);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        // First task is blocking
+        ste.execute(() -> {
+            try {
+                latch.await();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        for (int i = 0; i < N; i++) {
+            ste.execute(() -> {});
+        }
+
+        // Submit last task and wait for completion
+        Future<?> future = ste.submit(() -> {});
+
+        latch.countDown();
+
+        future.get();
     }
 }


### PR DESCRIPTION
### Motivation

The OrderedExecutor queue must be really unbounded or we are subject to deadlocks when a large number of tasks are submitted and may be depending on tasks that are going to be executed on the same executor.

Renamed the `GrowableArrayBlockingQueue` into `GrowableMpScArrayConsumerBlockingQueue` and optimized for single consumer scenario. 

Added test to ensure the `SingleThreadExecutor` is really unbound.

Added simple benchmark test scenario that uses 2 queues and 2 threads passing a bounded number of messages between each others, as fast as possible:

https://github.com/apache/bookkeeper/compare/master...merlimat:bookkeeper:fix-ordered-executor-max-size?expand=1#diff-e8f29aa89f5bf7b81642d51409ab37e220c9a066c009f24b82bafbfb8bc3e4e6R248
```
ArrayBlockingQueue: Throughput 27.433703 Millions items/s
LinkedBlockingQueue: Throughput 17.744839 Millions items/s
GrowableMpScArrayConsumerBlockingQueue: Throughput 61.425191 Millions items/s
```