### PR TITLE
Upgrade dependencies for CVE-2022-3171 and CVE-2022-42003

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -205,8 +205,8 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -636,13 +636,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.19.2.jar
-Source available at https://github.com/google/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-3.19.6.jar
+Source available at https://github.com/google/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.19.2.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-util-3.19.6.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -205,8 +205,8 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -563,13 +563,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.19.2.jar
-Source available at https://github.com/google/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-3.19.6.jar
+Source available at https://github.com/google/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.19.2.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-util-3.19.6.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -205,8 +205,8 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
 - lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.2.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.2.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
 - lib/com.google.guava-guava-31.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -627,13 +627,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.19.2.jar
-Source available at https://github.com/google/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-3.19.6.jar
+Source available at https://github.com/google/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.19.2.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.2
+  - lib/com.google.protobuf-protobuf-java-util-3.19.6.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.19.6
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,11 @@
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
 
       <!-- libthrift dependency -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <hadoop.version>3.2.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.14.0-rc1</jackson.version>
     <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jmh.version>1.19</jmh.version>
@@ -161,8 +161,8 @@
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <protobuf.version>3.19.2</protobuf.version>
-    <protoc3.version>3.19.2</protoc3.version>
+    <protobuf.version>3.19.6</protobuf.version>
+    <protoc3.version>3.19.6</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>6.29.4.1</rocksdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <hadoop.version>3.2.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.13.4.2</jackson.version>
+    <jackson.version>2.13.4.20221013</jackson.version>
     <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jmh.version>1.19</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <hadoop.version>3.2.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.14.0-rc1</jackson.version>
+    <jackson.version>2.13.4.2</jackson.version>
     <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jmh.version>1.19</jmh.version>


### PR DESCRIPTION
### Motivation

[CVE-2022-3171](https://ubuntu.com/security/CVE-2022-3171)
[CVE-2022-42003](https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33)

<img width="998" alt="截屏2022-10-26 10 46 13" src="https://user-images.githubusercontent.com/25195800/197922540-fa58ae0a-7bc4-4c62-91b5-61209090552c.png">


### Changes
- upgrade `jackson.version` from `2.13.4 -> 2.14.0-rc1` 
- upgrade `protobuf.version` from `2.19.2 -> 3.19.6` 