### PR TITLE
Add example for multiple server list in metadataServiceUri configuration

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -89,8 +89,10 @@ public abstract class HttpRouter<Handler> {
                 handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_STATE_READONLY));
         this.endpointHandlers.put(BOOKIE_IS_READY, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_IS_READY));
         this.endpointHandlers.put(BOOKIE_INFO, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_INFO));
-        this.endpointHandlers.put(SUSPEND_GC_COMPACTION, handlerFactory.newHandler(HttpServer.ApiType.SUSPEND_GC_COMPACTION));
-        this.endpointHandlers.put(RESUME_GC_COMPACTION, handlerFactory.newHandler(HttpServer.ApiType.RESUME_GC_COMPACTION));
+        this.endpointHandlers.put(SUSPEND_GC_COMPACTION,
+            handlerFactory.newHandler(HttpServer.ApiType.SUSPEND_GC_COMPACTION));
+        this.endpointHandlers.put(RESUME_GC_COMPACTION,
+            handlerFactory.newHandler(HttpServer.ApiType.RESUME_GC_COMPACTION));
 
         // autorecovery
         this.endpointHandlers.put(AUTORECOVERY_STATUS, handlerFactory

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -775,6 +775,8 @@ gcEntryLogMetadataCacheEnabled=false
 #############################################################################
 
 # metadata service uri that bookkeeper is used for loading corresponding metadata driver and resolving its metadata service location
+# The server list can be semicolon separated values, for example:
+# metadataServiceUri=zk+hierarchical://zk1:2181;zk2:2181;zk3:2181/ledgers
 metadataServiceUri=zk+hierarchical://localhost:2181/ledgers
 
 # @Deprecated - `ledgerManagerFactoryClass` is deprecated in favor of using `metadataServiceUri`


### PR DESCRIPTION
### Motivation
When users configure multiple servers for `metadataServiceUri`, they will be confused about how to separate the server list.

### Changes
Add an example to explain how to configure multiple servers for `metadataServiceUri`
