### PR TITLE
Replace sleep with await to avoid flaky test in SlowBookieTest

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -89,8 +89,10 @@ public abstract class HttpRouter<Handler> {
                 handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_STATE_READONLY));
         this.endpointHandlers.put(BOOKIE_IS_READY, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_IS_READY));
         this.endpointHandlers.put(BOOKIE_INFO, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_INFO));
-        this.endpointHandlers.put(SUSPEND_GC_COMPACTION, handlerFactory.newHandler(HttpServer.ApiType.SUSPEND_GC_COMPACTION));
-        this.endpointHandlers.put(RESUME_GC_COMPACTION, handlerFactory.newHandler(HttpServer.ApiType.RESUME_GC_COMPACTION));
+        this.endpointHandlers.put(SUSPEND_GC_COMPACTION,
+            handlerFactory.newHandler(HttpServer.ApiType.SUSPEND_GC_COMPACTION));
+        this.endpointHandlers.put(RESUME_GC_COMPACTION,
+            handlerFactory.newHandler(HttpServer.ApiType.RESUME_GC_COMPACTION));
 
         // autorecovery
         this.endpointHandlers.put(AUTORECOVERY_STATUS, handlerFactory

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -421,7 +421,7 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
             // waitForWritable async
             new Thread(() -> isWriteable.set(lh.waitForWritable(writeSet, 0, timeout))).start();
 
-            Awaitility.await().untilAsserted(() -> assertFalse(isWriteable.get()));
+            Awaitility.await().pollDelay(5, TimeUnit.SECONDS).untilAsserted(() -> assertFalse(isWriteable.get()));
 
             // enable channel writable
             setTargetChannelState(bkc, curEns.get(slowBookieIndex), 0, true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/SlowBookieTest.java
@@ -91,8 +91,8 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
                 };
             lh.asyncAddEntry(entry, cb, null);
 
-            Thread.sleep(3000); // sleep 3 seconds to allow time to complete
-            assertEquals("Successfully added entry!", 0xdeadbeef, i.get());
+            Awaitility.await().untilAsserted(() ->
+                assertEquals("Successfully added entry!", 0xdeadbeef, i.get()));
             b0latch.countDown();
             b1latch.countDown();
             addEntrylatch.await(4000, TimeUnit.MILLISECONDS);
@@ -419,11 +419,9 @@ public class SlowBookieTest extends BookKeeperClusterTestCase {
             final long timeout = 10000;
 
             // waitForWritable async
-           new Thread(() -> {
-                isWriteable.set(lh.waitForWritable(writeSet, 0, timeout));
-            }).start();
-            TimeUnit.MILLISECONDS.sleep(5000);
-            assertFalse(isWriteable.get());
+            new Thread(() -> isWriteable.set(lh.waitForWritable(writeSet, 0, timeout))).start();
+
+            Awaitility.await().untilAsserted(() -> assertFalse(isWriteable.get()));
 
             // enable channel writable
             setTargetChannelState(bkc, curEns.get(slowBookieIndex), 0, true);


### PR DESCRIPTION
### Motivation
There is a lot of `Thread.sleep()` in Bookie tests, which may lead to flaky tests.

### Changes
Replace sleep with await to avoid flaky test in SlowBookieTest
