### PR TITLE
[improve] Optimize log4j configuration

### DIFF
--- a/bookkeeper-benchmark/conf/log4j2.xml
+++ b/bookkeeper-benchmark/conf/log4j2.xml
@@ -22,13 +22,13 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="bookkeeper_trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}][%ndc] - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="bookkeeper-benchmark.log" filePattern="bookkeeper-benchmark.log%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/bookkeeper-server/src/main/resources/log4j2.xml
+++ b/bookkeeper-server/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/conf/log4j2.cli.xml
+++ b/conf/log4j2.cli.xml
@@ -34,7 +34,7 @@
             <PatternLayout pattern="%m%n"/>
         </Console>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}" filePattern="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:bookkeeper.log.dir}/bookkeeper-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}][%ndc] - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}" filePattern="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}] - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/stream/conf/log4j2.cli.xml
+++ b/stream/conf/log4j2.cli.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}][%ndc] - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}] - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/stream/conf/log4j2.xml
+++ b/stream/conf/log4j2.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}][%ndc] - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%c{1}] - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/tests/integration-tests-utils/src/main/resources/log4j2.xml
+++ b/tests/integration-tests-utils/src/main/resources/log4j2.xml
@@ -18,7 +18,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.}@%L - %msg%n" />
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.} - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>

--- a/testtools/src/main/resources/log4j2.xml
+++ b/testtools/src/main/resources/log4j2.xml
@@ -18,7 +18,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.}@%L - %msg%n" />
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.} - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
### Motivation

Log output with [location information is very expensive][1], we should avoid use it in our log configuration. In most cases, we are able to find which line print specific log by logger name and log content.

### Changes

- remove log line information
- use logger name instead of caller class name

[1]: https://logging.apache.org/log4j/2.x/manual/layouts.html#LocationInformation