### PR TITLE
Add javadoc comments for test classes

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryUseIOThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieRecoveryUseIOThreadTest.java
@@ -26,6 +26,9 @@ import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Tests for Bookie recovery use IO threads.
+ */
 public class BookieRecoveryUseIOThreadTest extends BookKeeperClusterTestCase {
 
     public BookieRecoveryUseIOThreadTest() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersOpenLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersOpenLedgerTest.java
@@ -42,6 +42,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/**
+ * Tests for BookKeeper open ledger operations.
+ */
 @RunWith(Parameterized.class)
 public class BookKeeperBuildersOpenLedgerTest extends MockBookKeeperTestCase {
 


### PR DESCRIPTION

### Motivation
When running the check style, it fails with the following exception.
```
Error:  /home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersOpenLedgerTest.java:45: Missing a Javadoc comment. [JavadocType]
Audit done.
[INFO] There is 1 error reported by Checkstyle 6.19 with buildtools/src/main/resources/bookkeeper/checkstyle.xml ruleset.
Error:  src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersOpenLedgerTest.java:[45] (javadoc) JavadocType: Missing a Javadoc comment.
```

### Changes
Add javadoc comments for test classes.

