### PR TITLE
Issue 3588: write meta to log header before fsync in DirectIO mode

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
@@ -30,6 +30,7 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap.BiConsumerLong;
 
 class LogMetadata {
+
     /**
      * Ledgers map is composed of multiple parts that can be split into separated entries. Each of them is composed of:
      *
@@ -108,8 +109,6 @@ class LogMetadata {
         } finally {
             serializedMap.release();
         }
-        writer.flush();
-
         ByteBuf buf = allocator.buffer(Buffer.ALIGNMENT);
         try {
             Header.writeHeader(buf, ledgerMapOffset, numberOfLedgers);
@@ -117,6 +116,7 @@ class LogMetadata {
         } finally {
             buf.release();
         }
+        writer.flush();
     }
 
     static EntryLogMetadata read(LogReader reader) throws IOException {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
@@ -26,6 +26,9 @@ import static org.hamcrest.Matchers.equalTo;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
 import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
 import org.apache.bookkeeper.slogger.Slogger;
@@ -34,9 +37,6 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
 import org.junit.After;
 import org.junit.Test;
-import java.io.File;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class TestMetadata {
     private static final Slogger slog = Slogger.CONSOLE;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
@@ -1,0 +1,61 @@
+package org.apache.bookkeeper.bookie.storage.directentrylogger;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import org.apache.bookkeeper.bookie.EntryLogMetadata;
+import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
+import org.apache.bookkeeper.slogger.Slogger;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.test.TmpDirs;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.bookkeeper.bookie.storage.directentrylogger.DirectEntryLogger.logFilename;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TestMetadata {
+    private static final Slogger slog = Slogger.CONSOLE;
+    private final OpStatsLogger opLogger = NullStatsLogger.INSTANCE.getOpStatsLogger("null");
+
+    private final TmpDirs tmpDirs = new TmpDirs();
+    private final ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
+
+    @After
+    public void cleanup() throws Exception {
+        tmpDirs.cleanup();
+        writeExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testReadMetaFromHeader() throws Exception {
+        File ledgerDir = tmpDirs.createNew("writeMetadataBeforeFsync", "logs");
+        int logId = 5678;
+        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), Buffer.ALIGNMENT, 8);
+             LogWriter writer = new DirectWriter(logId, logFilename(ledgerDir, logId),
+                     1 << 24, writeExecutor,
+                     buffers, new NativeIOImpl(), Slogger.CONSOLE)) {
+            long offset = 4096L;
+            writer.position(offset);
+            EntryLogMetadata entryLogMetadata = new EntryLogMetadata(logId);
+            entryLogMetadata.addLedgerSize(1, 10);
+            entryLogMetadata.addLedgerSize(2, 11);
+            LogMetadata.write(writer, entryLogMetadata, ByteBufAllocator.DEFAULT);
+            try (LogReader reader = new DirectReader(logId, logFilename(ledgerDir, logId),
+                    ByteBufAllocator.DEFAULT,
+                    new NativeIOImpl(), Buffer.ALIGNMENT,
+                    1 << 20, opLogger)) {
+                ByteBuf header = reader.readBufferAt(0, Header.LOGFILE_LEGACY_HEADER_SIZE);
+                assertThat(Header.HEADER_V1, equalTo(Header.extractVersion(header)));
+                assertThat(offset, equalTo(Header.extractLedgerMapOffset(header)));
+                assertThat(2, equalTo(Header.extractLedgerCount(header)));
+            }
+        }
+    }
+
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
@@ -1,3 +1,23 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package org.apache.bookkeeper.bookie.storage.directentrylogger;
 
 import io.netty.buffer.ByteBuf;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
@@ -20,6 +20,10 @@
  */
 package org.apache.bookkeeper.bookie.storage.directentrylogger;
 
+import static org.apache.bookkeeper.bookie.storage.directentrylogger.DirectEntryLogger.logFilename;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
@@ -30,14 +34,9 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
 import org.junit.After;
 import org.junit.Test;
-
 import java.io.File;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static org.apache.bookkeeper.bookie.storage.directentrylogger.DirectEntryLogger.logFilename;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 
 public class TestMetadata {
     private static final Slogger slog = Slogger.CONSOLE;


### PR DESCRIPTION
Descriptions of the changes in this PR:
Write meta to log header before fsync in DirectIO mode


### Motivation
Fix READ_METADATA_FALLBACK issue, details can be seen in https://github.com/apache/bookkeeper/issues/3588

### Changes

Write meta to log header before fsync in DirectIO mode

### FAQ

- Why the last close call fsync to ensure metadata is flushed to the log file: the close triggers fsync only when nativebuffer is not null, however native buffer is not used when flush metadata into header 
- Does the metadata write overwrite the ledger content: No. The metadata is written in reserved locations for header, which from offset 0 to offset 1024.

Master Issue: #3588

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
