### PR TITLE
Removed the necessity of SafeRunnable

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -49,13 +49,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
 
 /**
- * This class provides 2 things over the java {@link ExecutorService}.
- *
- * <p>1. It takes {@link SafeRunnable objects} instead of plain Runnable objects.
- * This means that exceptions in scheduled tasks wont go unnoticed and will be
- * logged.
- *
- * <p>2. It supports submitting tasks with an ordering key, so that tasks submitted
+ * This class supports submitting tasks with an ordering key, so that tasks submitted
  * with the same key will always be executed in order, but tasks across
  * different keys can be unordered. This retains parallelism while retaining the
  * basic amount of ordering we want (e.g. , per ledger handle). Ordering is
@@ -526,7 +520,7 @@ public class OrderedExecutor implements ExecutorService {
      * @param orderingKey
      * @param r
      */
-    public void executeOrdered(Object orderingKey, SafeRunnable r) {
+    public void executeOrdered(Object orderingKey, Runnable r) {
         chooseThread(orderingKey).execute(r);
     }
 
@@ -535,7 +529,7 @@ public class OrderedExecutor implements ExecutorService {
      * @param orderingKey
      * @param r
      */
-    public void executeOrdered(long orderingKey, SafeRunnable r) {
+    public void executeOrdered(long orderingKey, Runnable r) {
         chooseThread(orderingKey).execute(r);
     }
 
@@ -544,7 +538,7 @@ public class OrderedExecutor implements ExecutorService {
      * @param orderingKey
      * @param r
      */
-    public void executeOrdered(int orderingKey, SafeRunnable r) {
+    public void executeOrdered(int orderingKey, Runnable r) {
         chooseThread(orderingKey).execute(r);
     }
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedScheduler.java
@@ -38,13 +38,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.bookkeeper.stats.StatsLogger;
 
 /**
- * This class provides 2 things over the java {@link ScheduledExecutorService}.
- *
- * <p>1. It takes {@link SafeRunnable objects} instead of plain Runnable objects.
- * This means that exceptions in scheduled tasks wont go unnoticed and will be
- * logged.
- *
- * <p>2. It supports submitting tasks with an ordering key, so that tasks submitted
+ * This class provides supports submitting tasks with an ordering key, so that tasks submitted
  * with the same key will always be executed in order, but tasks across
  * different keys can be unordered. This retains parallelism while retaining the
  * basic amount of ordering we want (e.g. , per ledger handle). Ordering is
@@ -118,7 +112,9 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
 
     @Override
     protected ExecutorService createSingleThreadExecutor(ThreadFactory factory) {
-        return new BoundedScheduledExecutorService(new ScheduledThreadPoolExecutor(1, factory), this.maxTasksInQueue);
+        return new BoundedScheduledExecutorService(
+                new SingleThreadSafeScheduledExecutorService(factory),
+                this.maxTasksInQueue);
     }
 
     @Override
@@ -163,27 +159,14 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
     /**
      * Creates and executes a one-shot action that becomes enabled after the given delay.
      *
-     * @param command - the SafeRunnable to execute
-     * @param delay - the time from now to delay execution
-     * @param unit - the time unit of the delay parameter
-     * @return a ScheduledFuture representing pending completion of the task and whose get() method
-     *         will return null upon completion
-     */
-    public ScheduledFuture<?> schedule(SafeRunnable command, long delay, TimeUnit unit) {
-        return chooseThread().schedule(command, delay, unit);
-    }
-
-    /**
-     * Creates and executes a one-shot action that becomes enabled after the given delay.
-     *
      * @param orderingKey - the key used for ordering
-     * @param command - the SafeRunnable to execute
+     * @param command - the Runnable to execute
      * @param delay - the time from now to delay execution
      * @param unit - the time unit of the delay parameter
      * @return a ScheduledFuture representing pending completion of the task and whose get() method
      *         will return null upon completion
      */
-    public ScheduledFuture<?> scheduleOrdered(Object orderingKey, SafeRunnable command, long delay, TimeUnit unit) {
+    public ScheduledFuture<?> scheduleOrdered(Object orderingKey, Runnable command, long delay, TimeUnit unit) {
         return chooseThread(orderingKey).schedule(command, delay, unit);
     }
 
@@ -193,32 +176,15 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
      *
      * <p>For more details check {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}.
      *
-     * @param command - the SafeRunnable to execute
-     * @param initialDelay - the time to delay first execution
-     * @param period - the period between successive executions
-     * @param unit - the time unit of the initialDelay and period parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get()
-     * method will throw an exception upon cancellation
-     */
-    public ScheduledFuture<?> scheduleAtFixedRate(SafeRunnable command, long initialDelay, long period, TimeUnit unit) {
-        return chooseThread().scheduleAtFixedRate(command, initialDelay, period, unit);
-    }
-
-    /**
-     * Creates and executes a periodic action that becomes enabled first after
-     * the given initial delay, and subsequently with the given period.
-     *
-     * <p>For more details check {@link ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}.
-     *
      * @param orderingKey - the key used for ordering
-     * @param command - the SafeRunnable to execute
+     * @param command - the Runnable to execute
      * @param initialDelay - the time to delay first execution
      * @param period - the period between successive executions
      * @param unit - the time unit of the initialDelay and period parameters
      * @return a ScheduledFuture representing pending completion of the task, and whose get() method
      * will throw an exception upon cancellation
      */
-    public ScheduledFuture<?> scheduleAtFixedRateOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
+    public ScheduledFuture<?> scheduleAtFixedRateOrdered(Object orderingKey, Runnable command, long initialDelay,
             long period, TimeUnit unit) {
         return chooseThread(orderingKey).scheduleAtFixedRate(command, initialDelay, period, unit);
     }
@@ -230,34 +196,15 @@ public class OrderedScheduler extends OrderedExecutor implements ScheduledExecut
      * <p>For more details check {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
      * .
      *
-     * @param command - the SafeRunnable to execute
-     * @param initialDelay - the time to delay first execution
-     * @param delay - the delay between the termination of one execution and the commencement of the next
-     * @param unit - the time unit of the initialDelay and delay parameters
-     * @return a ScheduledFuture representing pending completion of the task, and whose get() method
-     * will throw an exception upon cancellation
-     */
-    public ScheduledFuture<?> scheduleWithFixedDelay(SafeRunnable command, long initialDelay, long delay,
-            TimeUnit unit) {
-        return chooseThread().scheduleWithFixedDelay(command, initialDelay, delay, unit);
-    }
-
-    /**
-     * Creates and executes a periodic action that becomes enabled first after the given initial delay, and subsequently
-     * with the given delay between the termination of one execution and the commencement of the next.
-     *
-     * <p>For more details check {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
-     * .
-     *
      * @param orderingKey - the key used for ordering
-     * @param command - the SafeRunnable to execute
+     * @param command - the Runnable to execute
      * @param initialDelay - the time to delay first execution
      * @param delay - the delay between the termination of one execution and the commencement of the next
      * @param unit - the time unit of the initialDelay and delay parameters
      * @return a ScheduledFuture representing pending completion of the task, and whose get() method
      * will throw an exception upon cancellation
      */
-    public ScheduledFuture<?> scheduleWithFixedDelayOrdered(Object orderingKey, SafeRunnable command, long initialDelay,
+    public ScheduledFuture<?> scheduleWithFixedDelayOrdered(Object orderingKey, Runnable command, long initialDelay,
             long delay, TimeUnit unit) {
         return chooseThread(orderingKey).scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadSafeScheduledExecutorService.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadSafeScheduledExecutorService.java
@@ -17,9 +17,6 @@
  */
 package org.apache.bookkeeper.common.util;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableScheduledFuture;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadSafeScheduledExecutorService.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadSafeScheduledExecutorService.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.common.util;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SingleThreadSafeScheduledExecutorService extends ScheduledThreadPoolExecutor
+        implements ScheduledExecutorService {
+
+    public SingleThreadSafeScheduledExecutorService(ThreadFactory threadFactory) {
+        super(1, threadFactory);
+    }
+
+    private static final class SafeRunnable implements Runnable {
+        private final Runnable task;
+
+        SafeRunnable(Runnable task) {
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            try {
+                task.run();
+            } catch (Throwable t) {
+                log.warn("Unexpected throwable from task {}: {}", task.getClass(), t.getMessage(), t);
+            }
+        }
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return super.schedule(new SafeRunnable(command), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command,
+                                                  long initialDelay, long period, TimeUnit unit) {
+        return super.scheduleAtFixedRate(new SafeRunnable(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
+                                                     long initialDelay, long delay, TimeUnit unit) {
+        return super.scheduleWithFixedDelay(new SafeRunnable(command), initialDelay, delay, unit);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return super.submit(new SafeRunnable(task));
+    }
+}

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/concurrent/TestFutureUtils.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/concurrent/TestFutureUtils.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.junit.Test;
 
@@ -175,7 +174,7 @@ public class TestFutureUtils {
         assertFalse(withinFuture.isCancelled());
         assertFalse(withinFuture.isCompletedExceptionally());
         verify(scheduler, times(0))
-            .scheduleOrdered(eq(1234L), isA(SafeRunnable.class), eq(10), eq(TimeUnit.MILLISECONDS));
+            .scheduleOrdered(eq(1234L), isA(Runnable.class), eq(10), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -194,14 +193,14 @@ public class TestFutureUtils {
         assertFalse(withinFuture.isCancelled());
         assertFalse(withinFuture.isCompletedExceptionally());
         verify(scheduler, times(0))
-            .scheduleOrdered(eq(1234L), isA(SafeRunnable.class), eq(10), eq(TimeUnit.MILLISECONDS));
+            .scheduleOrdered(eq(1234L), isA(Runnable.class), eq(10), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test
     public void testWithinCompleteBeforeTimeout() throws Exception {
         OrderedScheduler scheduler = mock(OrderedScheduler.class);
         ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
-        when(scheduler.scheduleOrdered(any(Object.class), any(SafeRunnable.class), anyLong(), any(TimeUnit.class)))
+        when(scheduler.scheduleOrdered(any(Object.class), any(Runnable.class), anyLong(), any(TimeUnit.class)))
             .thenAnswer(invocationOnMock -> scheduledFuture);
         CompletableFuture<Long> newFuture = FutureUtils.createFuture();
         CompletableFuture<Long> withinFuture = FutureUtils.within(

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutorDecorators.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutorDecorators.java
@@ -21,7 +21,6 @@
 
 package org.apache.bookkeeper.common.util;
 
-import static org.apache.bookkeeper.common.util.SafeRunnable.safeRun;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 import static org.mockito.AdditionalAnswers.answerVoid;
@@ -129,9 +128,7 @@ public class TestOrderedExecutorDecorators {
 
         try {
             ThreadContext.put(MDC_KEY, "testMDCInvokeOrdered");
-            scheduler.scheduleOrdered(10, safeRun(() -> {
-                        log.info("foobar");
-                    }), 0, TimeUnit.DAYS).get();
+            scheduler.scheduleOrdered(10, () -> log.info("foobar"), 0, TimeUnit.DAYS).get();
             assertThat(capturedEvents,
                        hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
         } finally {
@@ -146,9 +143,7 @@ public class TestOrderedExecutorDecorators {
 
         try {
             ThreadContext.put(MDC_KEY, "testMDCInvokeOrdered");
-            scheduler.chooseThread(10).schedule(safeRun(() -> {
-                        log.info("foobar");
-                    }), 0, TimeUnit.DAYS).get();
+            scheduler.chooseThread(10).schedule(() -> log.info("foobar"), 0, TimeUnit.DAYS).get();
             assertThat(capturedEvents,
                        hasItem(mdcFormat("testMDCInvokeOrdered", "foobar")));
         } finally {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -46,7 +46,6 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * This is the garbage collector thread that runs in the background to
  * remove any entry log files that no longer contains any active ledger.
  */
-public class GarbageCollectorThread extends SafeRunnable {
+public class GarbageCollectorThread implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(GarbageCollectorThread.class);
     private static final int SECOND = 1000;
 
@@ -382,7 +381,7 @@ public class GarbageCollectorThread extends SafeRunnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         boolean force = forceGarbageCollection.get();
         boolean suspendMajor = suspendMajorCompaction.get();
         boolean suspendMinor = suspendMinorCompaction.get();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -88,7 +88,6 @@ import org.apache.bookkeeper.proto.DataFormats;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.EventLoopUtil;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zookeeper.KeeperException;
@@ -602,13 +601,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
     void scheduleBookieHealthCheckIfEnabled(ClientConfiguration conf) {
         if (conf.isBookieHealthCheckEnabled()) {
-            scheduler.scheduleAtFixedRate(new SafeRunnable() {
-
-                @Override
-                public void safeRun() {
-                    checkForFaultyBookies();
-                }
-                    }, conf.getBookieHealthCheckIntervalSeconds(), conf.getBookieHealthCheckIntervalSeconds(),
+            scheduler.scheduleAtFixedRate(
+                    () -> checkForFaultyBookies(),
+                    conf.getBookieHealthCheckIntervalSeconds(),
+                    conf.getBookieHealthCheckIntervalSeconds(),
                     TimeUnit.SECONDS);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ExplicitLacFlushPolicy.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.SyncCallbackUtils.LastAddConfirmedCallback;
 import org.apache.bookkeeper.util.ByteBufList;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,9 +83,9 @@ interface ExplicitLacFlushPolicy {
         }
 
         private void scheduleExplictLacFlush() {
-            final SafeRunnable updateLacTask = new SafeRunnable() {
+            final Runnable updateLacTask = new Runnable() {
                 @Override
-                public void safeRun() {
+                public void run() {
                     // Made progress since previous explicitLAC through
                     // Piggyback, so no need to send an explicit LAC update to
                     // bookies.
@@ -138,13 +137,10 @@ interface ExplicitLacFlushPolicy {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Sending Explicit LAC: {}", explicitLac);
                 }
-                clientCtx.getMainWorkerPool().submit(new SafeRunnable() {
-                    @Override
-                    public void safeRun() {
-                        ByteBufList toSend = lh.macManager
-                                .computeDigestAndPackageForSendingLac(lh.getLastAddConfirmed());
-                        op.initiate(toSend);
-                    }
+                clientCtx.getMainWorkerPool().submit(() -> {
+                    ByteBufList toSend = lh.macManager
+                            .computeDigestAndPackageForSendingLac(lh.getLastAddConfirmed());
+                    op.initiate(toSend);
                 });
             } catch (RejectedExecutionException e) {
                 cb.addLacComplete(BookKeeper.getReturnRc(clientCtx.getBookieClient(),

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -25,14 +25,13 @@ import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ForceLedgerCallback;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This represents a request to sync the ledger on every bookie.
  */
-class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
+class ForceLedgerOp implements Runnable, ForceLedgerCallback {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForceLedgerOp.class);
     final CompletableFuture<Void> cb;
@@ -62,7 +61,7 @@ class ForceLedgerOp extends SafeRunnable implements ForceLedgerCallback {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         initiate();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerCreateOp.java
@@ -46,7 +46,6 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -273,12 +272,7 @@ class LedgerCreateOp {
             createOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
         }
         if (lh != null) { // lh is null in case of errors
-            lh.executeOrdered(new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    cb.createComplete(rc, lh, ctx);
-                }
-            });
+            lh.executeOrdered(() -> cb.createComplete(rc, lh, ctx));
         } else {
             cb.createComplete(rc, null, ctx);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.client;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.bookkeeper.client.api.BKException.Code.ClientClosedException;
 import static org.apache.bookkeeper.client.api.BKException.Code.WriteException;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -81,7 +80,6 @@ import org.apache.bookkeeper.proto.checksum.DigestManager;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
@@ -283,14 +281,8 @@ public class LedgerHandle implements WriteHandle {
         }
 
         if (clientCtx.getConf().addEntryQuorumTimeoutNanos > 0) {
-            SafeRunnable monitor = new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    monitorPendingAddOps();
-                }
-            };
             this.timeoutFuture = clientCtx.getScheduler().scheduleAtFixedRate(
-                    monitor,
+                    () -> monitorPendingAddOps(),
                     clientCtx.getConf().timeoutMonitorIntervalSec,
                     clientCtx.getConf().timeoutMonitorIntervalSec,
                     TimeUnit.SECONDS);
@@ -538,15 +530,13 @@ public class LedgerHandle implements WriteHandle {
      * @param rc
      */
     void doAsyncCloseInternal(final CloseCallback cb, final Object ctx, final int rc) {
-        executeOrdered(new SafeRunnable() {
-            @Override
-            public void safeRun() {
-                final HandleState prevHandleState;
-                final List<PendingAddOp> pendingAdds;
-                final long lastEntry;
-                final long finalLength;
+        executeOrdered(() -> {
+                    final HandleState prevHandleState;
+                    final List<PendingAddOp> pendingAdds;
+                    final long lastEntry;
+                    final long finalLength;
 
-                closePromise.whenComplete((ignore, ex) -> {
+                    closePromise.whenComplete((ignore, ex) -> {
                         if (ex != null) {
                             cb.closeComplete(
                                     BKException.getExceptionCode(ex, BKException.Code.UnexpectedConditionException),
@@ -556,73 +546,76 @@ public class LedgerHandle implements WriteHandle {
                         }
                     });
 
-                synchronized (LedgerHandle.this) {
-                    prevHandleState = handleState;
+                    synchronized (LedgerHandle.this) {
+                        prevHandleState = handleState;
 
-                    // drain pending adds first
-                    pendingAdds = drainPendingAddsAndAdjustLength();
+                        // drain pending adds first
+                        pendingAdds = drainPendingAddsAndAdjustLength();
 
-                    // taking the length must occur after draining, as draining changes the length
-                    lastEntry = lastAddPushed = LedgerHandle.this.lastAddConfirmed;
-                    finalLength = LedgerHandle.this.length;
-                    handleState = HandleState.CLOSED;
-                }
-
-                // error out all pending adds during closing, the callbacks shouldn't be
-                // running under any bk locks.
-                try {
-                    errorOutPendingAdds(rc, pendingAdds);
-                } catch (Throwable e) {
-                    closePromise.completeExceptionally(e);
-                    return;
-                }
-
-                if (prevHandleState != HandleState.CLOSED) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Closing ledger: {} at entryId {} with {} bytes", getId(), lastEntry, finalLength);
+                        // taking the length must occur after draining, as draining changes the length
+                        lastEntry = lastAddPushed = LedgerHandle.this.lastAddConfirmed;
+                        finalLength = LedgerHandle.this.length;
+                        handleState = HandleState.CLOSED;
                     }
 
-                    tearDownWriteHandleState();
-                    new MetadataUpdateLoop(
-                            clientCtx.getLedgerManager(), getId(),
-                            LedgerHandle.this::getVersionedLedgerMetadata,
-                            (metadata) -> {
-                                if (metadata.isClosed()) {
-                                    /* If the ledger has been closed with the same lastEntry
-                                     * and length that we planned to close with, we have nothing to do,
-                                     * so just return success */
-                                    if (lastEntry == metadata.getLastEntryId()
-                                        && finalLength == metadata.getLength()) {
-                                        return false;
+                    // error out all pending adds during closing, the callbacks shouldn't be
+                    // running under any bk locks.
+                    try {
+                        errorOutPendingAdds(rc, pendingAdds);
+                    } catch (Throwable e) {
+                        closePromise.completeExceptionally(e);
+                        return;
+                    }
+
+                    if (prevHandleState != HandleState.CLOSED) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Closing ledger: {} at entryId {} with {} bytes", getId(), lastEntry,
+                                    finalLength);
+                        }
+
+                        tearDownWriteHandleState();
+                        new MetadataUpdateLoop(
+                                clientCtx.getLedgerManager(), getId(),
+                                LedgerHandle.this::getVersionedLedgerMetadata,
+                                (metadata) -> {
+                                    if (metadata.isClosed()) {
+                                        /* If the ledger has been closed with the same lastEntry
+                                         * and length that we planned to close with, we have nothing to do,
+                                         * so just return success */
+                                        if (lastEntry == metadata.getLastEntryId()
+                                                && finalLength == metadata.getLength()) {
+                                            return false;
+                                        } else {
+                                            LOG.error("Metadata conflict when closing ledger {}."
+                                                            + " Another client may have recovered the ledger while "
+                                                            + "there"
+                                                            + " were writes outstanding. (local lastEntry:{} "
+                                                            + "length:{}) "
+                                                            + " (metadata lastEntry:{} length:{})",
+                                                    getId(), lastEntry, finalLength,
+                                                    metadata.getLastEntryId(), metadata.getLength());
+                                            throw new BKException.BKMetadataVersionException();
+                                        }
                                     } else {
-                                        LOG.error("Metadata conflict when closing ledger {}."
-                                                  + " Another client may have recovered the ledger while there"
-                                                  + " were writes outstanding. (local lastEntry:{} length:{}) "
-                                                  + " (metadata lastEntry:{} length:{})",
-                                                  getId(), lastEntry, finalLength,
-                                                  metadata.getLastEntryId(), metadata.getLength());
-                                        throw new BKException.BKMetadataVersionException();
+                                        return true;
                                     }
-                                } else {
-                                    return true;
-                                }
-                            },
-                            (metadata) -> {
-                                return LedgerMetadataBuilder.from(metadata)
-                                    .withClosedState().withLastEntryId(lastEntry)
-                                    .withLength(finalLength).build();
-                            },
-                            LedgerHandle.this::setLedgerMetadata)
-                        .run().whenComplete((metadata, ex) -> {
-                                if (ex != null) {
-                                    closePromise.completeExceptionally(ex);
-                                } else {
-                                    FutureUtils.complete(closePromise, null);
-                                }
-                        });
+                                },
+                                (metadata) -> {
+                                    return LedgerMetadataBuilder.from(metadata)
+                                            .withClosedState().withLastEntryId(lastEntry)
+                                            .withLength(finalLength).build();
+                                },
+                                LedgerHandle.this::setLedgerMetadata)
+                                .run().whenComplete((metadata, ex) -> {
+                                    if (ex != null) {
+                                        closePromise.completeExceptionally(ex);
+                                    } else {
+                                        FutureUtils.complete(closePromise, null);
+                                    }
+                                });
+                    }
                 }
-            }
-        });
+        );
     }
 
     /**
@@ -1158,9 +1151,9 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                executeOrdered(new SafeRunnable() {
+                executeOrdered(new Runnable() {
                     @Override
-                    public void safeRun() {
+                    public void run() {
                         LOG.warn("Force() attempted on a closed ledger: {}", ledgerId);
                         result.completeExceptionally(new BKException.BKLedgerClosedException());
                     }
@@ -1178,9 +1171,9 @@ public class LedgerHandle implements WriteHandle {
 
         // early exit: no write has been issued yet
         if (pendingAddsSequenceHead == INVALID_ENTRY_ID) {
-            executeOrdered(new SafeRunnable() {
+            executeOrdered(new Runnable() {
                     @Override
-                    public void safeRun() {
+                    public void run() {
                         FutureUtils.complete(result, null);
                     }
 
@@ -1327,9 +1320,9 @@ public class LedgerHandle implements WriteHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                executeOrdered(new SafeRunnable() {
+                executeOrdered(new Runnable() {
                     @Override
-                    public void safeRun() {
+                    public void run() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
                         op.cb.addCompleteWithLatency(BKException.Code.LedgerClosedException,
                                 LedgerHandle.this, INVALID_ENTRY_ID, 0, op.ctx);
@@ -2090,7 +2083,7 @@ public class LedgerHandle implements WriteHandle {
      * @param runnable
      * @throws RejectedExecutionException
      */
-    void executeOrdered(org.apache.bookkeeper.common.util.SafeRunnable runnable) throws RejectedExecutionException {
+    void executeOrdered(Runnable runnable) throws RejectedExecutionException {
         clientCtx.getMainWorkerPool().executeOrdered(ledgerId, runnable);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -23,6 +23,7 @@ package org.apache.bookkeeper.client;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.bookkeeper.client.api.BKException.Code.ClientClosedException;
 import static org.apache.bookkeeper.client.api.BKException.Code.WriteException;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandleAdv.java
@@ -37,7 +37,6 @@ import org.apache.bookkeeper.client.SyncCallbackUtils.SyncAddCallback;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteAdvHandle;
 import org.apache.bookkeeper.client.api.WriteFlag;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -243,9 +242,9 @@ public class LedgerHandleAdv extends LedgerHandle implements WriteAdvHandle {
         if (wasClosed) {
             // make sure the callback is triggered in main worker pool
             try {
-                clientCtx.getMainWorkerPool().submit(new SafeRunnable() {
+                clientCtx.getMainWorkerPool().submit(new Runnable() {
                     @Override
-                    public void safeRun() {
+                    public void run() {
                         LOG.warn("Attempt to add to closed ledger: {}", ledgerId);
                         op.cb.addCompleteWithLatency(BKException.Code.LedgerClosedException,
                                 LedgerHandleAdv.this, op.getEntryId(), 0, op.ctx);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -39,7 +39,6 @@ import org.apache.bookkeeper.client.impl.OpenBuilderBase;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.OrderedGenericCallback;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -248,12 +247,7 @@ class LedgerOpenOp {
         }
 
         if (lh != null) { // lh is null in case of errors
-            lh.executeOrdered(new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    cb.openComplete(rc, lh, ctx);
-                }
-            });
+            lh.executeOrdered(() -> cb.openComplete(rc, lh, ctx));
         } else {
             cb.openComplete(rc, null, ctx);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_HIGH_PRIORITY;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_NONE;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
-
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
@@ -38,9 +37,7 @@ import org.apache.bookkeeper.client.AsyncCallback.AddCallbackWithLatency;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
-import org.apache.bookkeeper.util.ByteBufList;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  *
  */
-class PendingAddOp extends SafeRunnable implements WriteCallback {
+class PendingAddOp implements Runnable, WriteCallback {
     private static final Logger LOG = LoggerFactory.getLogger(PendingAddOp.class);
 
     ByteBuf payload;
@@ -163,9 +160,9 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
 
     void timeoutQuorumWait() {
         try {
-            clientCtx.getMainWorkerPool().executeOrdered(lh.ledgerId, new SafeRunnable() {
+            clientCtx.getMainWorkerPool().executeOrdered(lh.ledgerId, new Runnable() {
                 @Override
-                public void safeRun() {
+                public void run() {
                     if (completed) {
                         return;
                     } else if (addEntrySuccessBookies.size() >= lh.getLedgerMetadata().getAckQuorumSize()) {
@@ -244,7 +241,7 @@ class PendingAddOp extends SafeRunnable implements WriteCallback {
      * Initiate the add operation.
      */
     @Override
-    public void safeRun() {
+    public void run() {
         hasRun = true;
         if (callbackTriggered) {
             // this should only be true if the request was failed due

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.client.AsyncCallback.AddCallbackWithLatency;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.WriteCallback;
+import org.apache.bookkeeper.util.ByteBufList;
 import org.apache.bookkeeper.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_HIGH_PRIORITY;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_NONE;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
+
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
@@ -55,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * application as soon as it arrives rather than waiting for the whole thing.
  *
  */
-class PendingReadOp implements ReadEntryCallback, SafeRunnable {
+class PendingReadOp implements ReadEntryCallback, Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(PendingReadOp.class);
 
     private ScheduledFuture<?> speculativeTask = null;
@@ -540,7 +539,7 @@ class PendingReadOp implements ReadEntryCallback, SafeRunnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         initiate();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -42,7 +42,6 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.LedgerMetadataListener;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryListener;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.TimedGenericCallback;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
@@ -60,7 +59,7 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
     private Object metadataLock = new Object();
     private final NavigableMap<Long, List<BookieId>> newEnsemblesFromRecovery = new TreeMap<>();
 
-    class MetadataUpdater extends SafeRunnable {
+    class MetadataUpdater implements Runnable {
 
         final Versioned<LedgerMetadata> newMetadata;
 
@@ -69,7 +68,7 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
         }
 
         @Override
-        public void safeRun() {
+        public void run() {
             while (true) {
                 Versioned<LedgerMetadata> currentMetadata = getVersionedLedgerMetadata();
                 Version.Occurred occurred = currentMetadata.getVersion().compare(newMetadata.getVersion());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationClient.java
@@ -43,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.ZKException;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
 import org.apache.bookkeeper.versioning.LongVersion;
@@ -68,7 +67,7 @@ public class ZKRegistrationClient implements RegistrationClient {
     static final int ZK_CONNECT_BACKOFF_MS = 200;
 
     class WatchTask
-        implements SafeRunnable,
+        implements Runnable,
                    Watcher,
                    BiConsumer<Versioned<Set<BookieId>>, Throwable>,
                    AutoCloseable {
@@ -119,7 +118,7 @@ public class ZKRegistrationClient implements RegistrationClient {
         }
 
         @Override
-        public void safeRun() {
+        public void run() {
             if (isClosed()) {
                 return;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -21,7 +21,6 @@
 package org.apache.bookkeeper.proto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.bookkeeper.util.SafeRunnable.safeRun;
 
 import com.google.common.collect.Lists;
 import com.google.protobuf.ExtensionRegistry;
@@ -50,7 +49,6 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookieInfoReader.BookieInfo;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
@@ -124,13 +122,11 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
 
         this.scheduler = scheduler;
         if (conf.getAddEntryTimeout() > 0 || conf.getReadEntryTimeout() > 0) {
-            SafeRunnable monitor = safeRun(() -> {
-                monitorPendingOperations();
-            });
-            this.timeoutFuture = this.scheduler.scheduleAtFixedRate(monitor,
-                                                                    conf.getTimeoutMonitorIntervalSec(),
-                                                                    conf.getTimeoutMonitorIntervalSec(),
-                                                                    TimeUnit.SECONDS);
+            this.timeoutFuture = this.scheduler.scheduleAtFixedRate(
+                    () -> monitorPendingOperations(),
+                    conf.getTimeoutMonitorIntervalSec(),
+                    conf.getTimeoutMonitorIntervalSec(),
+                    TimeUnit.SECONDS);
         } else {
             this.timeoutFuture = null;
         }
@@ -239,9 +235,8 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         client.obtain((rc, pcbc) -> {
             if (rc != BKException.Code.OK) {
                 try {
-                    executor.executeOrdered(ledgerId, safeRun(() -> {
-                        cb.forceLedgerComplete(rc, ledgerId, addr, ctx);
-                    }));
+                    executor.executeOrdered(ledgerId,
+                            () -> cb.forceLedgerComplete(rc, ledgerId, addr, ctx));
                 } catch (RejectedExecutionException re) {
                     cb.forceLedgerComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
                 }
@@ -265,9 +260,8 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         client.obtain((rc, pcbc) -> {
             if (rc != BKException.Code.OK) {
                 try {
-                    executor.executeOrdered(ledgerId, safeRun(() -> {
-                        cb.writeLacComplete(rc, ledgerId, addr, ctx);
-                    }));
+                    executor.executeOrdered(ledgerId,
+                            () -> cb.writeLacComplete(rc, ledgerId, addr, ctx));
                 } catch (RejectedExecutionException re) {
                     cb.writeLacComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
                 }
@@ -286,9 +280,9 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                              final WriteCallback cb,
                              final Object ctx) {
         try {
-            executor.executeOrdered(ledgerId, new SafeRunnable() {
+            executor.executeOrdered(ledgerId, new Runnable() {
                 @Override
-                public void safeRun() {
+                public void run() {
                     cb.writeComplete(rc, ledgerId, entryId, addr, ctx);
                 }
                 @Override
@@ -342,9 +336,9 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         client.obtain((rc, pcbc) -> {
             if (rc != BKException.Code.OK) {
                 try {
-                    executor.executeOrdered(ledgerId, safeRun(() -> {
-                        futureResult.getListOfEntriesOfLedgerComplete(rc, ledgerId, null);
-                    }));
+                    executor.executeOrdered(ledgerId, () ->
+                            futureResult.getListOfEntriesOfLedgerComplete(rc, ledgerId, null)
+                    );
                 } catch (RejectedExecutionException re) {
                     futureResult.getListOfEntriesOfLedgerComplete(getRc(BKException.Code.InterruptedException),
                             ledgerId, null);
@@ -363,12 +357,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                               final ReadEntryCallback cb,
                               final Object ctx) {
         try {
-            executor.executeOrdered(ledgerId, new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    cb.readEntryComplete(rc, ledgerId, entryId, entry, ctx);
-                }
-            });
+            executor.executeOrdered(ledgerId, () -> cb.readEntryComplete(rc, ledgerId, entryId, entry, ctx));
         } catch (RejectedExecutionException ree) {
             cb.readEntryComplete(getRc(BKException.Code.InterruptedException),
                                  ledgerId, entryId, entry, ctx);
@@ -467,9 +456,8 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         client.obtain((rc, pcbc) -> {
             if (rc != BKException.Code.OK) {
                 try {
-                    executor.executeOrdered(ledgerId, safeRun(() -> {
-                        cb.readLacComplete(rc, ledgerId, null, null, ctx);
-                    }));
+                    executor.executeOrdered(ledgerId,
+                            () -> cb.readLacComplete(rc, ledgerId, null, null, ctx));
                 } catch (RejectedExecutionException re) {
                     cb.readLacComplete(getRc(BKException.Code.InterruptedException),
                             ledgerId, null, null, ctx);
@@ -551,9 +539,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         client.obtain((rc, pcbc) -> {
             if (rc != BKException.Code.OK) {
                 try {
-                    executor.submit(safeRun(() -> {
-                        cb.getBookieInfoComplete(rc, new BookieInfo(), ctx);
-                    }));
+                    executor.execute(() -> cb.getBookieInfoComplete(rc, new BookieInfo(), ctx));
                 } catch (RejectedExecutionException re) {
                     cb.getBookieInfoComplete(getRc(BKException.Code.InterruptedException),
                             new BookieInfo(), ctx);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ForceLedgerProcessorV3.java
@@ -116,7 +116,7 @@ class ForceLedgerProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         ForceLedgerResponse forceLedgerResponse = getForceLedgerResponse();
         if (null != forceLedgerResponse) {
             Response.Builder response = Response.newBuilder()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetBookieInfoProcessorV3.java
@@ -84,7 +84,7 @@ public class GetBookieInfoProcessorV3 extends PacketProcessorBaseV3 implements R
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         GetBookieInfoResponse getBookieInfoResponse = getGetBookieInfoResponse();
         sendResponse(getBookieInfoResponse);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetListOfEntriesOfLedgerProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/GetListOfEntriesOfLedgerProcessorV3.java
@@ -97,7 +97,7 @@ public class GetListOfEntriesOfLedgerProcessorV3 extends PacketProcessorBaseV3 i
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         GetListOfEntriesOfLedgerResponse listOfEntriesOfLedgerResponse = getListOfEntriesOfLedgerResponse();
         Response.Builder response = Response.newBuilder().setHeader(getHeader())
                 .setStatus(listOfEntriesOfLedgerResponse.getStatus())

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.proto.BookieProtocol.Request;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A base class for bookeeper packet processors.
  */
-abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
+abstract class PacketProcessorBase<T extends Request> implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(PacketProcessorBase.class);
     T request;
     Channel channel;
@@ -166,7 +165,7 @@ abstract class PacketProcessorBase<T extends Request> extends SafeRunnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
                 .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         if (!isVersionCompatible()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBaseV3.java
@@ -24,19 +24,20 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.util.StringUtils;
 
 /**
  * A base class for bookkeeper protocol v3 packet processors.
  */
-public abstract class PacketProcessorBaseV3 extends SafeRunnable {
+@Slf4j
+public abstract class PacketProcessorBaseV3 implements Runnable {
 
     final Request request;
     final Channel channel;
@@ -76,7 +77,7 @@ public abstract class PacketProcessorBaseV3 extends SafeRunnable {
             }
 
             if (!channel.isWritable()) {
-                LOGGER.warn("cannot write response to non-writable channel {} for request {}", channel,
+                log.warn("cannot write response to non-writable channel {} for request {}", channel,
                         StringUtils.requestToString(request));
                 requestProcessor.getRequestStats().getChannelWriteStats()
                         .registerFailedEvent(MathUtils.elapsedNanos(writeNanos), TimeUnit.NANOSECONDS);
@@ -106,7 +107,7 @@ public abstract class PacketProcessorBaseV3 extends SafeRunnable {
                 }
             });
         } else {
-            LOGGER.debug("Netty channel {} is inactive, "
+            log.debug("Netty channel {} is inactive, "
                     + "hence bypassing netty channel writeAndFlush during sendResponse", channel);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -139,7 +139,6 @@ import org.apache.bookkeeper.tls.SecurityHandlerFactory.NodeType;
 import org.apache.bookkeeper.util.AvailabilityOfEntriesOfLedger;
 import org.apache.bookkeeper.util.ByteBufList;
 import org.apache.bookkeeper.util.MathUtils;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.bookkeeper.util.StringUtils;
 import org.apache.bookkeeper.util.collections.ConcurrentOpenHashMap;
 import org.apache.bookkeeper.util.collections.SynchronizedHashMultiMap;
@@ -1369,7 +1368,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private static class ReadV2ResponseCallback extends SafeRunnable {
+    private static class ReadV2ResponseCallback implements Runnable {
         CompletionValue completionValue;
         long ledgerId;
         long entryId;
@@ -1388,7 +1387,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         }
 
         @Override
-        public void safeRun() {
+        public void run() {
             completionValue.handleV2Response(ledgerId, entryId, status, response);
             response.release();
             response.recycle();
@@ -1478,9 +1477,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             }
         } else {
             long orderingKey = completionValue.ledgerId;
-            executor.executeOrdered(orderingKey, new SafeRunnable() {
+            executor.executeOrdered(orderingKey, new Runnable() {
                 @Override
-                public void safeRun() {
+                public void run() {
                     completionValue.restoreMdcContext();
                     completionValue.handleV3Response(response);
                 }
@@ -1673,23 +1672,19 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         }
 
         protected void errorOutAndRunCallback(final Runnable callback) {
-            executor.executeOrdered(ledgerId,
-                    new SafeRunnable() {
-                        @Override
-                        public void safeRun() {
-                            String bAddress = "null";
-                            Channel c = channel;
-                            if (c != null && c.remoteAddress() != null) {
-                                bAddress = c.remoteAddress().toString();
-                            }
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Could not write {} request to bookie {} for ledger {}, entry {}",
-                                          operationName, bAddress,
-                                          ledgerId, entryId);
-                            }
-                            callback.run();
-                        }
-                    });
+            executor.executeOrdered(ledgerId, () -> {
+                String bAddress = "null";
+                Channel c = channel;
+                if (c != null && c.remoteAddress() != null) {
+                    bAddress = c.remoteAddress().toString();
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not write {} request to bookie {} for ledger {}, entry {}",
+                            operationName, bAddress,
+                            ledgerId, entryId);
+                }
+                callback.run();
+            });
         }
 
         public void handleV2Response(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -246,7 +246,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats().registerSuccessfulEvent(
             MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         if (!channel.isOpen()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadLacProcessorV3.java
@@ -118,7 +118,7 @@ class ReadLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         ReadLacResponse readLacResponse = getReadLacResponse();
         sendResponse(readLacResponse);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -160,7 +160,7 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
                 .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         AddResponse addResponse = getAddResponse();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -137,7 +137,7 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         WriteLacResponse writeLacResponse = getWriteLacResponse();
         if (null != writeLacResponse) {
             Response.Builder response = Response.newBuilder()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -1608,9 +1608,11 @@ public class Auditor implements AutoCloseable {
         private final ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries;
         private final ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies;
 
-        ReadLedgerMetadataCallbackForReplicasCheck(long ledgerInRange, MultiCallback mcbForThisLedgerRange,
-                                                   ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
-                                                   ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies) {
+        ReadLedgerMetadataCallbackForReplicasCheck(
+                long ledgerInRange,
+                MultiCallback mcbForThisLedgerRange,
+                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
+                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies) {
             this.ledgerInRange = ledgerInRange;
             this.mcbForThisLedgerRange = mcbForThisLedgerRange;
             this.ledgersWithMissingEntries = ledgersWithMissingEntries;
@@ -1767,12 +1769,16 @@ public class Auditor implements AutoCloseable {
         private final ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies;
         private final MultiCallback mcbForThisLedger;
 
-        private GetListOfEntriesOfLedgerCallbackForReplicasCheck(long ledgerInRange, int ensembleSize,
-                                                                 int writeQuorumSize, int ackQuorumSize, BookieId bookieInEnsemble,
-                                                                 List<BookieExpectedToContainSegmentInfo> bookieExpectedToContainSegmentInfoList,
-                                                                 ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
-                                                                 ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies,
-                                                                 MultiCallback mcbForThisLedger) {
+        private GetListOfEntriesOfLedgerCallbackForReplicasCheck(
+                long ledgerInRange,
+                int ensembleSize,
+                int writeQuorumSize,
+                int ackQuorumSize,
+                BookieId bookieInEnsemble,
+                List<BookieExpectedToContainSegmentInfo> bookieExpectedToContainSegmentInfoList,
+                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
+                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies,
+                MultiCallback mcbForThisLedger) {
             this.ledgerInRange = ledgerInRange;
             this.ensembleSize = ensembleSize;
             this.writeQuorumSize = writeQuorumSize;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -634,6 +634,7 @@ public class Auditor implements AutoCloseable {
             return f;
         }
         return executor.submit(() -> {
+            int lostBookieRecoveryDelay = -1;
             try {
                 waitIfLedgerReplicationDisabled();
                 lostBookieRecoveryDelay = Auditor.this.ledgerUnderreplicationManager

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -126,8 +126,8 @@ import org.slf4j.LoggerFactory;
  * <p>TODO: eliminate the direct usage of zookeeper here {@link https://github.com/apache/bookkeeper/issues/1332}
  */
 @StatsDoc(
-    name = AUDITOR_SCOPE,
-    help = "Auditor related stats"
+        name = AUDITOR_SCOPE,
+        help = "Auditor related stats"
 )
 public class Auditor implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(Auditor.class);
@@ -169,8 +169,8 @@ public class Auditor implements AutoCloseable {
 
     private final StatsLogger statsLogger;
     @StatsDoc(
-        name = NUM_UNDER_REPLICATED_LEDGERS,
-        help = "the distribution of num under_replicated ledgers on each auditor run"
+            name = NUM_UNDER_REPLICATED_LEDGERS,
+            help = "the distribution of num under_replicated ledgers on each auditor run"
     )
     private final OpStatsLogger numUnderReplicatedLedger;
 
@@ -180,58 +180,58 @@ public class Auditor implements AutoCloseable {
     )
     private final OpStatsLogger underReplicatedLedgerTotalSize;
     @StatsDoc(
-        name = URL_PUBLISH_TIME_FOR_LOST_BOOKIE,
-        help = "the latency distribution of publishing under replicated ledgers for lost bookies"
+            name = URL_PUBLISH_TIME_FOR_LOST_BOOKIE,
+            help = "the latency distribution of publishing under replicated ledgers for lost bookies"
     )
     private final OpStatsLogger uRLPublishTimeForLostBookies;
     @StatsDoc(
-        name = BOOKIE_TO_LEDGERS_MAP_CREATION_TIME,
-        help = "the latency distribution of creating bookies-to-ledgers map"
+            name = BOOKIE_TO_LEDGERS_MAP_CREATION_TIME,
+            help = "the latency distribution of creating bookies-to-ledgers map"
     )
     private final OpStatsLogger bookieToLedgersMapCreationTime;
     @StatsDoc(
-        name = CHECK_ALL_LEDGERS_TIME,
-        help = "the latency distribution of checking all ledgers"
+            name = CHECK_ALL_LEDGERS_TIME,
+            help = "the latency distribution of checking all ledgers"
     )
     private final OpStatsLogger checkAllLedgersTime;
     @StatsDoc(
             name = PLACEMENT_POLICY_CHECK_TIME,
             help = "the latency distribution of placementPolicy check"
-        )
+    )
     private final OpStatsLogger placementPolicyCheckTime;
     @StatsDoc(
             name = REPLICAS_CHECK_TIME,
             help = "the latency distribution of replicas check"
-        )
+    )
     private final OpStatsLogger replicasCheckTime;
     @StatsDoc(
-        name = AUDIT_BOOKIES_TIME,
-        help = "the latency distribution of auditing all the bookies"
+            name = AUDIT_BOOKIES_TIME,
+            help = "the latency distribution of auditing all the bookies"
     )
     private final OpStatsLogger auditBookiesTime;
     @StatsDoc(
-        name = NUM_LEDGERS_CHECKED,
-        help = "the number of ledgers checked by the auditor"
+            name = NUM_LEDGERS_CHECKED,
+            help = "the number of ledgers checked by the auditor"
     )
     private final Counter numLedgersChecked;
     @StatsDoc(
-        name = NUM_FRAGMENTS_PER_LEDGER,
-        help = "the distribution of number of fragments per ledger"
+            name = NUM_FRAGMENTS_PER_LEDGER,
+            help = "the distribution of number of fragments per ledger"
     )
     private final OpStatsLogger numFragmentsPerLedger;
     @StatsDoc(
-        name = NUM_BOOKIES_PER_LEDGER,
-        help = "the distribution of number of bookies per ledger"
+            name = NUM_BOOKIES_PER_LEDGER,
+            help = "the distribution of number of bookies per ledger"
     )
     private final OpStatsLogger numBookiesPerLedger;
     @StatsDoc(
-        name = NUM_BOOKIE_AUDITS_DELAYED,
-        help = "the number of bookie-audits delayed"
+            name = NUM_BOOKIE_AUDITS_DELAYED,
+            help = "the number of bookie-audits delayed"
     )
     private final Counter numBookieAuditsDelayed;
     @StatsDoc(
-        name = NUM_DELAYED_BOOKIE_AUDITS_DELAYES_CANCELLED,
-        help = "the number of delayed-bookie-audits cancelled"
+            name = NUM_DELAYED_BOOKIE_AUDITS_DELAYES_CANCELLED,
+            help = "the number of delayed-bookie-audits cancelled"
     )
     private final Counter numDelayedBookieAuditsCancelled;
     @StatsDoc(
@@ -293,7 +293,7 @@ public class Auditor implements AutoCloseable {
     }
 
     static BookKeeper createBookKeeperClientThrowUnavailableException(ServerConfiguration conf)
-        throws UnavailableException {
+            throws UnavailableException {
         try {
             return createBookKeeperClient(conf);
         } catch (InterruptedException e) {
@@ -308,21 +308,21 @@ public class Auditor implements AutoCloseable {
     public Auditor(final String bookieIdentifier,
                    ServerConfiguration conf,
                    StatsLogger statsLogger)
-        throws UnavailableException {
+            throws UnavailableException {
         this(
-            bookieIdentifier,
-            conf,
-            createBookKeeperClientThrowUnavailableException(conf),
-            true,
-            statsLogger);
+                bookieIdentifier,
+                conf,
+                createBookKeeperClientThrowUnavailableException(conf),
+                true,
+                statsLogger);
     }
 
     public Auditor(final String bookieIdentifier,
-            ServerConfiguration conf,
-            BookKeeper bkc,
-            boolean ownBkc,
-            StatsLogger statsLogger)
-                    throws UnavailableException {
+                   ServerConfiguration conf,
+                   BookKeeper bkc,
+                   boolean ownBkc,
+                   StatsLogger statsLogger)
+            throws UnavailableException {
         this(bookieIdentifier,
                 conf,
                 bkc,
@@ -333,13 +333,13 @@ public class Auditor implements AutoCloseable {
     }
 
     public Auditor(final String bookieIdentifier,
-            ServerConfiguration conf,
-            BookKeeper bkc,
-            boolean ownBkc,
-            BookKeeperAdmin admin,
-            boolean ownAdmin,
-            StatsLogger statsLogger)
-        throws UnavailableException {
+                   ServerConfiguration conf,
+                   BookKeeper bkc,
+                   boolean ownBkc,
+                   BookKeeperAdmin admin,
+                   boolean ownAdmin,
+                   StatsLogger statsLogger)
+            throws UnavailableException {
         this.conf = conf;
         this.underreplicatedLedgerRecoveryGracePeriod = conf.getUnderreplicatedLedgerRecoveryGracePeriod();
         this.zkOpTimeoutMs = conf.getZkTimeout() * 2;
@@ -368,10 +368,10 @@ public class Auditor implements AutoCloseable {
         if (conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec() < 0) {
             LOG.error("auditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec should be greater than or equal to 0");
             throw new UnavailableException("auditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec "
-                + "should be greater than or equal to 0");
+                    + "should be greater than or equal to 0");
         }
         this.openLedgerNoRecoverySemaphoreWaitTimeoutMSec =
-            conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec();
+                conf.getAuditorAcquireConcurrentOpenLedgerOperationsTimeoutMSec();
 
         this.underReplicatedLedgersGuageValue = new AtomicInteger(0);
         numUnderReplicatedLedger = this.statsLogger.getOpStatsLogger(ReplicationStats.NUM_UNDER_REPLICATED_LEDGERS);
@@ -491,13 +491,13 @@ public class Auditor implements AutoCloseable {
         initialize(conf, bkc);
 
         executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-                @Override
-                public Thread newThread(Runnable r) {
-                    Thread t = new Thread(r, "AuditorBookie-" + bookieIdentifier);
-                    t.setDaemon(true);
-                    return t;
-                }
-            });
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "AuditorBookie-" + bookieIdentifier);
+                t.setDaemon(true);
+                return t;
+            }
+        });
     }
 
     private void initialize(ServerConfiguration conf, BookKeeper bkc)
@@ -510,7 +510,7 @@ public class Auditor implements AutoCloseable {
             this.ledgerUnderreplicationManager = ledgerManagerFactory
                     .newLedgerUnderreplicationManager();
             LOG.info("AuthProvider used by the Auditor is {}",
-                admin.getConf().getClientAuthProviderFactoryClass());
+                    admin.getConf().getClientAuthProviderFactoryClass());
             if (this.ledgerUnderreplicationManager
                     .initializeLostBookieRecoveryDelay(conf.getLostBookieRecoveryDelay())) {
                 LOG.info("Initializing lostBookieRecoveryDelay zNode to the conf value: {}",
@@ -537,7 +537,7 @@ public class Auditor implements AutoCloseable {
                 LOG.info("executor is already shutdown");
                 return;
             }
-            executor.execute(() -> {
+            executor.submit(() -> {
                 synchronized (Auditor.this) {
                     LOG.info("Shutting down Auditor's Executor");
                     executor.shutdown();
@@ -633,56 +633,52 @@ public class Auditor implements AutoCloseable {
             f.setException(new BKAuditException("Auditor shutting down"));
             return f;
         }
-        return executor.submit(new Runnable() {
-            int lostBookieRecoveryDelay = -1;
-            @Override
-            public void run() {
-                try {
-                    waitIfLedgerReplicationDisabled();
-                    lostBookieRecoveryDelay = Auditor.this.ledgerUnderreplicationManager
-                            .getLostBookieRecoveryDelay();
-                    // if there is pending auditTask, cancel the task. So that it can be rescheduled
-                    // after new lostBookieRecoveryDelay period
-                    if (auditTask != null) {
-                        LOG.info("lostBookieRecoveryDelay period has been changed so canceling the pending AuditTask");
-                        auditTask.cancel(false);
-                        numDelayedBookieAuditsCancelled.inc();
-                    }
+        return executor.submit(() -> {
+            try {
+                waitIfLedgerReplicationDisabled();
+                lostBookieRecoveryDelay = Auditor.this.ledgerUnderreplicationManager
+                        .getLostBookieRecoveryDelay();
+                // if there is pending auditTask, cancel the task. So that it can be rescheduled
+                // after new lostBookieRecoveryDelay period
+                if (auditTask != null) {
+                    LOG.info("lostBookieRecoveryDelay period has been changed so canceling the pending AuditTask");
+                    auditTask.cancel(false);
+                    numDelayedBookieAuditsCancelled.inc();
+                }
 
-                    // if lostBookieRecoveryDelay is set to its previous value then consider it as
-                    // signal to trigger the Audit immediately.
-                    if ((lostBookieRecoveryDelay == 0)
-                            || (lostBookieRecoveryDelay == lostBookieRecoveryDelayBeforeChange)) {
-                        LOG.info(
-                                "lostBookieRecoveryDelay has been set to 0 or reset to its previous value, "
-                                + "so starting AuditTask. Current lostBookieRecoveryDelay: {}, "
-                                + "previous lostBookieRecoveryDelay: {}",
-                                lostBookieRecoveryDelay, lostBookieRecoveryDelayBeforeChange);
+                // if lostBookieRecoveryDelay is set to its previous value then consider it as
+                // signal to trigger the Audit immediately.
+                if ((lostBookieRecoveryDelay == 0)
+                        || (lostBookieRecoveryDelay == lostBookieRecoveryDelayBeforeChange)) {
+                    LOG.info(
+                            "lostBookieRecoveryDelay has been set to 0 or reset to its previous value, "
+                                    + "so starting AuditTask. Current lostBookieRecoveryDelay: {}, "
+                                    + "previous lostBookieRecoveryDelay: {}",
+                            lostBookieRecoveryDelay, lostBookieRecoveryDelayBeforeChange);
+                    startAudit(false);
+                    auditTask = null;
+                    bookiesToBeAudited.clear();
+                } else if (auditTask != null) {
+                    LOG.info("lostBookieRecoveryDelay has been set to {}, so rescheduling AuditTask accordingly",
+                            lostBookieRecoveryDelay);
+                    auditTask = executor.schedule(() -> {
                         startAudit(false);
                         auditTask = null;
                         bookiesToBeAudited.clear();
-                    } else if (auditTask != null) {
-                        LOG.info("lostBookieRecoveryDelay has been set to {}, so rescheduling AuditTask accordingly",
-                                lostBookieRecoveryDelay);
-                        auditTask = executor.schedule(() -> {
-                            startAudit(false);
-                            auditTask = null;
-                            bookiesToBeAudited.clear();
-                        }, lostBookieRecoveryDelay, TimeUnit.SECONDS);
-                        numBookieAuditsDelayed.inc();
-                    }
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    LOG.error("Interrupted while for LedgersReplication to be enabled ", ie);
-                } catch (ReplicationException.NonRecoverableReplicationException nre) {
-                    LOG.error("Non Recoverable Exception while reading from ZK", nre);
-                    submitShutdownTask();
-                } catch (UnavailableException ue) {
-                    LOG.error("Exception while reading from ZK", ue);
-                } finally {
-                    if (lostBookieRecoveryDelay != -1) {
-                        lostBookieRecoveryDelayBeforeChange = lostBookieRecoveryDelay;
-                    }
+                    }, lostBookieRecoveryDelay, TimeUnit.SECONDS);
+                    numBookieAuditsDelayed.inc();
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.error("Interrupted while for LedgersReplication to be enabled ", ie);
+            } catch (ReplicationException.NonRecoverableReplicationException nre) {
+                LOG.error("Non Recoverable Exception while reading from ZK", nre);
+                submitShutdownTask();
+            } catch (UnavailableException ue) {
+                LOG.error("Exception while reading from ZK", ue);
+            } finally {
+                if (lostBookieRecoveryDelay != -1) {
+                    lostBookieRecoveryDelayBeforeChange = lostBookieRecoveryDelay;
                 }
             }
         });
@@ -734,7 +730,7 @@ public class Auditor implements AutoCloseable {
         long bookieCheckInterval = conf.getAuditorPeriodicBookieCheckInterval();
         if (bookieCheckInterval == 0) {
             LOG.info("Auditor periodic bookie checking disabled, running once check now anyhow");
-            executor.execute(bookieCheck);
+            executor.submit(bookieCheck);
         } else {
             LOG.info("Auditor periodic bookie checking enabled" + " 'auditorPeriodicBookieCheckInterval' {} seconds",
                     bookieCheckInterval);
@@ -989,6 +985,10 @@ public class Auditor implements AutoCloseable {
 
         executor.scheduleAtFixedRate(() -> {
             try {
+                if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
+                    LOG.info("Ledger replication disabled, skipping replicasCheck task.");
+                    return;
+                }
                 Stopwatch stopwatch = Stopwatch.createStarted();
                 LOG.info("Starting ReplicasCheck");
                 replicasCheck();
@@ -1044,6 +1044,8 @@ public class Auditor implements AutoCloseable {
                     numLedgersHavingLessThanWQReplicasOfAnEntryGuageValue
                             .set(numLedgersFoundHavingLessThanWQReplicasOfAnEntryValue);
                 }
+            } catch (ReplicationException.UnavailableException ue) {
+                LOG.error("Underreplication manager unavailable running periodic check", ue);
             }
         }, initialDelay, interval, TimeUnit.SECONDS);
     }
@@ -1137,7 +1139,7 @@ public class Auditor implements AutoCloseable {
             return;
         } catch (UnavailableException ue) {
             LOG.error("Underreplication unavailable, skipping audit."
-                      + "Will retry after a period");
+                    + "Will retry after a period");
             return;
         }
         LOG.info("Starting auditBookies");
@@ -1148,12 +1150,12 @@ public class Auditor implements AutoCloseable {
             if (!ledgerUnderreplicationManager.isLedgerReplicationEnabled()) {
                 // has been disabled while we were generating the index
                 // discard this run, and schedule a new one
-                executor.execute(bookieCheck);
+                executor.submit(bookieCheck);
                 return;
             }
         } catch (UnavailableException ue) {
             LOG.error("Underreplication unavailable, skipping audit."
-                      + "Will retry after a period");
+                    + "Will retry after a period");
             return;
         }
 
@@ -1168,7 +1170,7 @@ public class Auditor implements AutoCloseable {
         if (lostBookies.size() > 0) {
             try {
                 FutureUtils.result(
-                    handleLostBookiesAsync(lostBookies, ledgerDetails), ReplicationException.EXCEPTION_HANDLER);
+                        handleLostBookiesAsync(lostBookies, ledgerDetails), ReplicationException.EXCEPTION_HANDLER);
             } catch (ReplicationException e) {
                 throw new BKAuditException(e.getMessage(), e.getCause());
             }
@@ -1191,10 +1193,10 @@ public class Auditor implements AutoCloseable {
                 + " and searching its ledgers for re-replication", lostBookies);
 
         return FutureUtils.processList(
-            Lists.newArrayList(lostBookies),
-            bookieIP -> publishSuspectedLedgersAsync(
-                Lists.newArrayList(bookieIP), ledgerDetails.get(bookieIP)),
-            null
+                Lists.newArrayList(lostBookies),
+                bookieIP -> publishSuspectedLedgersAsync(
+                        Lists.newArrayList(bookieIP), ledgerDetails.get(bookieIP)),
+                null
         );
     }
 
@@ -1211,18 +1213,18 @@ public class Auditor implements AutoCloseable {
         FutureUtils.processList(
                 Lists.newArrayList(ledgers),
                 ledgerId ->
-                    ledgerManager.readLedgerMetadata(ledgerId).whenComplete((metadata, exception) -> {
-                        if (exception == null) {
-                            underReplicatedSize.add(metadata.getValue().getLength());
-                        }
-                    }), null).whenComplete((res, e) -> {
+                        ledgerManager.readLedgerMetadata(ledgerId).whenComplete((metadata, exception) -> {
+                            if (exception == null) {
+                                underReplicatedSize.add(metadata.getValue().getLength());
+                            }
+                        }), null).whenComplete((res, e) -> {
             underReplicatedLedgerTotalSize.registerSuccessfulValue(underReplicatedSize.longValue());
         });
 
         return FutureUtils.processList(
-            Lists.newArrayList(ledgers),
-            ledgerId -> ledgerUnderreplicationManager.markLedgerUnderreplicatedAsync(ledgerId, missingBookies),
-            null
+                Lists.newArrayList(ledgers),
+                ledgerId -> ledgerUnderreplicationManager.markLedgerUnderreplicatedAsync(ledgerId, missingBookies),
+                null
         );
     }
 
@@ -1251,11 +1253,11 @@ public class Auditor implements AutoCloseable {
                     return;
                 }
                 publishSuspectedLedgersAsync(bookies.stream().map(BookieId::toString).collect(Collectors.toList()),
-                    Sets.newHashSet(lh.getId())
+                        Sets.newHashSet(lh.getId())
                 ).whenComplete((result, cause) -> {
                     if (null != cause) {
                         LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
-                            lh.getId(), bookies, cause);
+                                lh.getId(), bookies, cause);
                         callback.processResult(Code.ReplicationException, null, null);
                     } else {
                         callback.processResult(Code.OK, null, null);
@@ -1323,9 +1325,9 @@ public class Auditor implements AutoCloseable {
 
                 try {
                     if (!openLedgerNoRecoverySemaphore.tryAcquire(openLedgerNoRecoverySemaphoreWaitTimeoutMSec,
-                        TimeUnit.MILLISECONDS)) {
+                            TimeUnit.MILLISECONDS)) {
                         LOG.warn("Failed to acquire semaphore for {} ms, ledgerId: {}",
-                            openLedgerNoRecoverySemaphoreWaitTimeoutMSec, ledgerId);
+                                openLedgerNoRecoverySemaphoreWaitTimeoutMSec, ledgerId);
                         FutureUtils.complete(processFuture, null);
                         return;
                     }
@@ -1362,13 +1364,13 @@ public class Auditor implements AutoCloseable {
             };
 
             ledgerManager.asyncProcessLedgers(checkLedgersProcessor,
-                (rc, path, ctx) -> {
-                    if (Code.OK == rc) {
-                        FutureUtils.complete(processFuture, null);
-                    } else {
-                        FutureUtils.completeExceptionally(processFuture, BKException.create(rc));
-                    }
-                }, null, BKException.Code.OK, BKException.Code.ReadException);
+                    (rc, path, ctx) -> {
+                        if (Code.OK == rc) {
+                            FutureUtils.complete(processFuture, null);
+                        } else {
+                            FutureUtils.completeExceptionally(processFuture, BKException.create(rc));
+                        }
+                    }, null, BKException.Code.OK, BKException.Code.ReadException);
             FutureUtils.result(processFuture, BKException.HANDLER);
             try {
                 ledgerUnderreplicationManager.setCheckAllLedgersCTime(System.currentTimeMillis());
@@ -1460,7 +1462,7 @@ public class Auditor implements AutoCloseable {
                                             Collections.emptyList()).whenComplete((res, e) -> {
                                         if (e != null) {
                                             LOG.error("For ledger: {}, the placement policy not adhering bookie "
-                                                    + "storage, mark it to under replication manager failed.",
+                                                            + "storage, mark it to under replication manager failed.",
                                                     ledgerId, e);
                                             return;
                                         }
@@ -1538,7 +1540,7 @@ public class Auditor implements AutoCloseable {
         private final List<Long> unavailableEntriesList;
 
         private MissingEntriesInfo(long ledgerId, Entry<Long, ? extends List<BookieId>> segmentEnsemble,
-                BookieId bookieMissingEntries, List<Long> unavailableEntriesList) {
+                                   BookieId bookieMissingEntries, List<Long> unavailableEntriesList) {
             this.ledgerId = ledgerId;
             this.segmentEnsemble = segmentEnsemble;
             this.bookieMissingEntries = bookieMissingEntries;
@@ -1570,7 +1572,7 @@ public class Auditor implements AutoCloseable {
         private final List<MissingEntriesInfo> missingEntriesInfoList;
 
         private MissingEntriesInfoOfLedger(long ledgerId, int ensembleSize, int writeQuorumSize, int ackQuorumSize,
-                List<MissingEntriesInfo> missingEntriesInfoList) {
+                                           List<MissingEntriesInfo> missingEntriesInfoList) {
             this.ledgerId = ledgerId;
             this.ensembleSize = ensembleSize;
             this.writeQuorumSize = writeQuorumSize;
@@ -1607,8 +1609,8 @@ public class Auditor implements AutoCloseable {
         private final ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies;
 
         ReadLedgerMetadataCallbackForReplicasCheck(long ledgerInRange, MultiCallback mcbForThisLedgerRange,
-                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
-                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies) {
+                                                   ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
+                                                   ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies) {
             this.ledgerInRange = ledgerInRange;
             this.mcbForThisLedgerRange = mcbForThisLedgerRange;
             this.ledgersWithMissingEntries = ledgersWithMissingEntries;
@@ -1681,7 +1683,7 @@ public class Auditor implements AutoCloseable {
                     final BookieId bookieInEnsemble = ensembleOfSegment.get(bookieIndex);
                     final BitSet entriesStripedToThisBookie = emptySegment ? EMPTY_BITSET
                             : distributionSchedule.getEntriesStripedToTheBookie(bookieIndex, startEntryIdOfSegment,
-                                    lastEntryIdOfSegment);
+                            lastEntryIdOfSegment);
                     if (entriesStripedToThisBookie.cardinality() == 0) {
                         /*
                          * if no entry is expected to contain in this bookie,
@@ -1709,7 +1711,7 @@ public class Auditor implements AutoCloseable {
                 }
             }
             for (Entry<BookieId, List<BookieExpectedToContainSegmentInfo>> bookiesSegmentInfoTuple :
-                bookiesSegmentInfoMap.entrySet()) {
+                    bookiesSegmentInfoMap.entrySet()) {
                 final BookieId bookieInEnsemble = bookiesSegmentInfoTuple.getKey();
                 final List<BookieExpectedToContainSegmentInfo> bookieSegmentInfoList = bookiesSegmentInfoTuple
                         .getValue();
@@ -1728,8 +1730,8 @@ public class Auditor implements AutoCloseable {
         private final BitSet entriesOfSegmentStripedToThisBookie;
 
         private BookieExpectedToContainSegmentInfo(long startEntryIdOfSegment, long lastEntryIdOfSegment,
-                Entry<Long, ? extends List<BookieId>> segmentEnsemble,
-                BitSet entriesOfSegmentStripedToThisBookie) {
+                                                   Entry<Long, ? extends List<BookieId>> segmentEnsemble,
+                                                   BitSet entriesOfSegmentStripedToThisBookie) {
             this.startEntryIdOfSegment = startEntryIdOfSegment;
             this.lastEntryIdOfSegment = lastEntryIdOfSegment;
             this.segmentEnsemble = segmentEnsemble;
@@ -1766,11 +1768,11 @@ public class Auditor implements AutoCloseable {
         private final MultiCallback mcbForThisLedger;
 
         private GetListOfEntriesOfLedgerCallbackForReplicasCheck(long ledgerInRange, int ensembleSize,
-                int writeQuorumSize, int ackQuorumSize, BookieId bookieInEnsemble,
-                List<BookieExpectedToContainSegmentInfo> bookieExpectedToContainSegmentInfoList,
-                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
-                ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies,
-                MultiCallback mcbForThisLedger) {
+                                                                 int writeQuorumSize, int ackQuorumSize, BookieId bookieInEnsemble,
+                                                                 List<BookieExpectedToContainSegmentInfo> bookieExpectedToContainSegmentInfoList,
+                                                                 ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries,
+                                                                 ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies,
+                                                                 MultiCallback mcbForThisLedger) {
             this.ledgerInRange = ledgerInRange;
             this.ensembleSize = ensembleSize;
             this.writeQuorumSize = writeQuorumSize;
@@ -1784,7 +1786,7 @@ public class Auditor implements AutoCloseable {
 
         @Override
         public void accept(AvailabilityOfEntriesOfLedger availabilityOfEntriesOfLedger,
-                Throwable listOfEntriesException) {
+                           Throwable listOfEntriesException) {
 
             if (listOfEntriesException != null) {
                 if (BKException
@@ -1885,9 +1887,9 @@ public class Auditor implements AutoCloseable {
 
     void replicasCheck() throws BKAuditException {
         ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithMissingEntries =
-                    new ConcurrentHashMap<Long, MissingEntriesInfoOfLedger>();
+                new ConcurrentHashMap<Long, MissingEntriesInfoOfLedger>();
         ConcurrentHashMap<Long, MissingEntriesInfoOfLedger> ledgersWithUnavailableBookies =
-                    new ConcurrentHashMap<Long, MissingEntriesInfoOfLedger>();
+                new ConcurrentHashMap<Long, MissingEntriesInfoOfLedger>();
         LedgerRangeIterator ledgerRangeIterator = ledgerManager.getLedgerRanges(zkOpTimeoutMs);
         final Semaphore maxConcurrentSemaphore = new Semaphore(MAX_CONCURRENT_REPLICAS_CHECK_LEDGER_REQUESTS);
         while (true) {
@@ -2135,19 +2137,19 @@ public class Auditor implements AutoCloseable {
     }
 
     private final Runnable bookieCheck = new Runnable() {
-            @Override
-            public void run() {
-                if (auditTask == null) {
-                    startAudit(true);
-                } else {
-                    // if due to a lost bookie an audit task was scheduled,
-                    // let us not run this periodic bookie check now, if we
-                    // went ahead, we'll report under replication and the user
-                    // wanted to avoid that(with lostBookieRecoveryDelay option)
-                    LOG.info("Audit already scheduled; skipping periodic bookie check");
-                }
+        @Override
+        public void run() {
+            if (auditTask == null) {
+                startAudit(true);
+            } else {
+                // if due to a lost bookie an audit task was scheduled,
+                // let us not run this periodic bookie check now, if we
+                // went ahead, we'll report under replication and the user
+                // wanted to avoid that(with lostBookieRecoveryDelay option)
+                LOG.info("Audit already scheduled; skipping periodic bookie check");
             }
-        };
+        }
+    };
 
     int getLostBookieRecoveryDelayBeforeChange() {
         return lostBookieRecoveryDelayBeforeChange;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedGenericCallback.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/OrderedGenericCallback.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.bookkeeper.common.util.MdcUtils;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,9 +60,9 @@ public abstract class OrderedGenericCallback<T> implements GenericCallback<T> {
                 safeOperationComplete(rc, result);
             } else {
                 try {
-                    executor.executeOrdered(orderingKey, new SafeRunnable() {
+                    executor.executeOrdered(orderingKey, new Runnable() {
                         @Override
-                        public void safeRun() {
+                        public void run() {
                             safeOperationComplete(rc, result);
                         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeper.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.OpenBuilderBase;
 import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,12 +105,7 @@ public class MockBookKeeper extends BookKeeper {
                     log.info("Creating ledger {}", id);
                     MockLedgerHandle lh = new MockLedgerHandle(MockBookKeeper.this, id, digestType, passwd);
                     ledgers.put(id, lh);
-                    lh.executeOrdered(new SafeRunnable() {
-                        @Override
-                        public void safeRun() {
-                            cb.createComplete(0, lh, ctx);
-                        }
-                    });
+                    lh.executeOrdered(() -> cb.createComplete(0, lh, ctx));
                 } catch (Throwable t) {
                     log.error("Error", t);
                 }
@@ -168,12 +162,7 @@ public class MockBookKeeper extends BookKeeper {
         } else if (!Arrays.equals(lh.passwd, passwd)) {
             cb.openComplete(BKException.Code.UnauthorizedAccessException, null, ctx);
         } else {
-            lh.executeOrdered(new SafeRunnable() {
-                                  @Override
-                                  public void safeRun() {
-                                      cb.openComplete(0, lh, ctx);
-                                  }
-                              });
+            lh.executeOrdered(() -> cb.openComplete(0, lh, ctx));
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -90,7 +90,7 @@ public class MockLedgerHandle extends LedgerHandle {
     }
 
     @Override
-    void executeOrdered(org.apache.bookkeeper.common.util.SafeRunnable runnable) throws RejectedExecutionException {
+    void executeOrdered(Runnable runnable) throws RejectedExecutionException {
         bk.executor.execute(runnable);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
@@ -21,7 +21,6 @@
 package org.apache.bookkeeper.proto;
 
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
-import static org.apache.bookkeeper.util.SafeRunnable.safeRun;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -137,20 +136,14 @@ public class MockBookieClient implements BookieClient {
     public void forceLedger(BookieId addr, long ledgerId,
                             ForceLedgerCallback cb, Object ctx) {
         executor.executeOrdered(ledgerId,
-                safeRun(() -> {
-                    cb.forceLedgerComplete(BKException.Code.IllegalOpException,
-                            ledgerId, addr, ctx);
-                }));
+                () -> cb.forceLedgerComplete(BKException.Code.IllegalOpException, ledgerId, addr, ctx));
     }
 
     @Override
     public void writeLac(BookieId addr, long ledgerId, byte[] masterKey,
                          long lac, ByteBufList toSend, WriteLacCallback cb, Object ctx) {
         executor.executeOrdered(ledgerId,
-                safeRun(() -> {
-                    cb.writeLacComplete(BKException.Code.IllegalOpException,
-                            ledgerId, addr, ctx);
-                }));
+                () -> cb.writeLacComplete(BKException.Code.IllegalOpException, ledgerId, addr, ctx));
     }
 
     @Override
@@ -195,10 +188,7 @@ public class MockBookieClient implements BookieClient {
     @Override
     public void readLac(BookieId addr, long ledgerId, ReadLacCallback cb, Object ctx) {
         executor.executeOrdered(ledgerId,
-                safeRun(() -> {
-                    cb.readLacComplete(BKException.Code.IllegalOpException,
-                            ledgerId, null, null, ctx);
-                }));
+                () -> cb.readLacComplete(BKException.Code.IllegalOpException, ledgerId, null, null, ctx));
     }
 
     @Override
@@ -242,30 +232,24 @@ public class MockBookieClient implements BookieClient {
                                           ReadEntryCallback cb,
                                           Object ctx) {
         executor.executeOrdered(ledgerId,
-                safeRun(() -> {
-                    cb.readEntryComplete(BKException.Code.IllegalOpException,
-                            ledgerId, entryId, null, ctx);
-                }));
+                () -> cb.readEntryComplete(BKException.Code.IllegalOpException, ledgerId, entryId, null, ctx));
     }
 
     @Override
     public void getBookieInfo(BookieId addr, long requested,
                               GetBookieInfoCallback cb, Object ctx) {
         executor.executeOrdered(addr,
-                safeRun(() -> {
-                    cb.getBookieInfoComplete(BKException.Code.IllegalOpException,
-                            null, ctx);
-                }));
+                () -> cb.getBookieInfoComplete(BKException.Code.IllegalOpException, null, ctx));
     }
 
     @Override
     public CompletableFuture<AvailabilityOfEntriesOfLedger> getListOfEntriesOfLedger(BookieId address,
                                                                                      long ledgerId) {
         FutureGetListOfEntriesOfLedger futureResult = new FutureGetListOfEntriesOfLedger(ledgerId);
-        executor.executeOrdered(address, safeRun(() -> {
-            futureResult
-                    .completeExceptionally(BKException.create(BKException.Code.IllegalOpException).fillInStackTrace());
-        }));
+        executor.executeOrdered(address, () ->
+                futureResult.completeExceptionally(
+                        BKException.create(BKException.Code.IllegalOpException).fillInStackTrace())
+        );
         return futureResult;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestPerChannelBookieClient.java
@@ -52,7 +52,6 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback
 import org.apache.bookkeeper.proto.PerChannelBookieClient.ConnectionState;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -277,12 +276,7 @@ public class TestPerChannelBookieClient extends BookKeeperClusterTestCase {
             @Override
             public void operationComplete(final int rc, PerChannelBookieClient pcbc) {
                 if (rc != BKException.Code.OK) {
-                    executor.executeOrdered(1, new SafeRunnable() {
-                        @Override
-                        public void safeRun() {
-                            cb.readEntryComplete(rc, 1, 1, null, null);
-                        }
-                    });
+                    executor.executeOrdered(1, () -> cb.readEntryComplete(rc, 1, 1, null, null));
                     return;
                 }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKAsyncLogReader.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -68,7 +67,7 @@ import org.slf4j.LoggerFactory;
  * <li> `async_reader`/idle_reader_error: counter. the number idle reader errors.
  * </ul>
  */
-class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotification {
+class BKAsyncLogReader implements AsyncLogReader, Runnable, AsyncNotification {
     static final Logger LOG = LoggerFactory.getLogger(BKAsyncLogReader.class);
 
     private static final Function<List<LogRecordWithDLSN>, LogRecordWithDLSN> READ_NEXT_MAP_FUNCTION =
@@ -105,7 +104,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
 
     private final boolean returnEndOfStreamRecord;
 
-    private final SafeRunnable BACKGROUND_READ_SCHEDULER = () -> {
+    private final Runnable BACKGROUND_READ_SCHEDULER = () -> {
         synchronized (scheduleLock) {
             backgroundScheduleTask = null;
         }
@@ -258,40 +257,37 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
             // Except when idle reader threshold is less than a second (tests?)
             period = Math.min(period, idleErrorThresholdMillis / 5);
 
-            return scheduler.scheduleAtFixedRateOrdered(streamName, new SafeRunnable() {
-                @Override
-                public void safeRun() {
-                    PendingReadRequest nextRequest = pendingRequests.peek();
+            return scheduler.scheduleAtFixedRateOrdered(streamName, () -> {
+                PendingReadRequest nextRequest = pendingRequests.peek();
 
-                    idleReaderCheckCount.inc();
-                    if (null == nextRequest) {
+                idleReaderCheckCount.inc();
+                if (null == nextRequest) {
+                    return;
+                }
+
+                idleReaderCheckIdleReadRequestCount.inc();
+                if (nextRequest.elapsedSinceEnqueue(TimeUnit.MILLISECONDS) < idleErrorThresholdMillis) {
+                    return;
+                }
+
+                ReadAheadEntryReader readAheadReader = getReadAheadReader();
+
+                // read request has been idle
+                //   - cache has records but read request are idle,
+                //     that means notification was missed between readahead and reader.
+                //   - cache is empty and readahead is idle (no records added for a long time)
+                idleReaderCheckIdleReadAheadCount.inc();
+                try {
+                    if (null == readAheadReader || (!hasMoreRecords()
+                            && readAheadReader.isReaderIdle(idleErrorThresholdMillis, TimeUnit.MILLISECONDS))) {
+                        markReaderAsIdle();
                         return;
+                    } else if (lastProcessTime.elapsed(TimeUnit.MILLISECONDS) > idleErrorThresholdMillis) {
+                        markReaderAsIdle();
                     }
-
-                    idleReaderCheckIdleReadRequestCount.inc();
-                    if (nextRequest.elapsedSinceEnqueue(TimeUnit.MILLISECONDS) < idleErrorThresholdMillis) {
-                        return;
-                    }
-
-                    ReadAheadEntryReader readAheadReader = getReadAheadReader();
-
-                    // read request has been idle
-                    //   - cache has records but read request are idle,
-                    //     that means notification was missed between readahead and reader.
-                    //   - cache is empty and readahead is idle (no records added for a long time)
-                    idleReaderCheckIdleReadAheadCount.inc();
-                    try {
-                        if (null == readAheadReader || (!hasMoreRecords()
-                                && readAheadReader.isReaderIdle(idleErrorThresholdMillis, TimeUnit.MILLISECONDS))) {
-                            markReaderAsIdle();
-                            return;
-                        } else if (lastProcessTime.elapsed(TimeUnit.MILLISECONDS) > idleErrorThresholdMillis) {
-                            markReaderAsIdle();
-                        }
-                    } catch (IOException e) {
-                        setLastException(e);
-                        return;
-                    }
+                } catch (IOException e) {
+                    setLastException(e);
+                    return;
                 }
             }, period, period, TimeUnit.MILLISECONDS);
         }
@@ -571,7 +567,7 @@ class BKAsyncLogReader implements AsyncLogReader, SafeRunnable, AsyncNotificatio
     }
 
     @Override
-    public void safeRun() {
+    public void run() {
         synchronized (scheduleLock) {
             if (scheduleDelayStopwatch.isRunning()) {
                 scheduleLatency.registerSuccessfulEvent(

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
@@ -397,7 +397,7 @@ class ReadAheadEntryReader implements
         return isInitialized;
     }
 
-    private void orderedSubmit(SafeRunnable runnable) {
+    private void orderedSubmit(Runnable runnable) {
         synchronized (this) {
             if (null != closePromise) {
                 return;

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogSegmentMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogSegmentMetadataStore.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
@@ -74,7 +73,7 @@ public class ZKLogSegmentMetadataStore implements LogSegmentMetadataStore, Watch
 
     private static final List<String> EMPTY_LIST = ImmutableList.of();
 
-    private static class ReadLogSegmentsTask implements SafeRunnable, FutureEventListener<Versioned<List<String>>> {
+    private static class ReadLogSegmentsTask implements Runnable, FutureEventListener<Versioned<List<String>>> {
 
         private final String logSegmentsPath;
         private final ZKLogSegmentMetadataStore store;
@@ -113,7 +112,7 @@ public class ZKLogSegmentMetadataStore implements LogSegmentMetadataStore, Watch
         }
 
         @Override
-        public void safeRun() {
+        public void run() {
             if (null != store.listeners.get(logSegmentsPath)) {
                 store.zkGetLogSegmentNames(logSegmentsPath, store).whenComplete(this);
             } else {
@@ -194,7 +193,7 @@ public class ZKLogSegmentMetadataStore implements LogSegmentMetadataStore, Watch
         this.skipMinVersionCheck = conf.getDLLedgerMetadataSkipMinVersionCheck();
     }
 
-    protected void scheduleTask(Object key, SafeRunnable r, long delayMs) {
+    protected void scheduleTask(Object key, Runnable r, long delayMs) {
         closeLock.readLock().lock();
         try {
             if (closed) {
@@ -206,7 +205,7 @@ public class ZKLogSegmentMetadataStore implements LogSegmentMetadataStore, Watch
         }
     }
 
-    protected void submitTask(Object key, SafeRunnable r) {
+    protected void submitTask(Object key, Runnable r) {
         closeLock.readLock().lock();
         try {
             if (closed) {

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
@@ -41,7 +41,6 @@ import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.distributedlog.DistributedLogConfiguration;
@@ -60,11 +59,11 @@ import org.slf4j.LoggerFactory;
 /**
  * BookKeeper ledger based log segment entry reader.
  */
-public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryReader, AsyncCallback.OpenCallback {
+public class BKLogSegmentEntryReader implements Runnable, LogSegmentEntryReader, AsyncCallback.OpenCallback {
 
     private static final Logger logger = LoggerFactory.getLogger(BKLogSegmentEntryReader.class);
 
-    private class CacheEntry implements SafeRunnable, AsyncCallback.ReadCallback,
+    private class CacheEntry implements Runnable, AsyncCallback.ReadCallback,
             AsyncCallback.ReadLastConfirmedAndEntryCallback {
 
         protected final long entryId;
@@ -240,7 +239,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
         }
 
         @Override
-        public void safeRun() {
+        public void run() {
             issueRead(this);
         }
     }
@@ -700,7 +699,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
      * The core function to propagate fetched entries to read requests.
      */
     @Override
-    public void safeRun() {
+    public void run() {
         long scheduleCountLocal = scheduleCountUpdater.get(this);
         while (true) {
             PendingReadRequest nextRequest = null;


### PR DESCRIPTION
### Motivation

`OrderedExecutor` is taking `SafeRunnable` tasks instead of the standard `Runnable`. 

The reason was the Java `ThreadPoolExecutor` are failing when an exception is thrown by one of the tasks and there is no log printed of the exception. 

Right now, this is not needed anymore, because the `SingleThreadExecutor` is already doing try/catch/log: https://github.com/apache/bookkeeper/blob/8ac28db16118e5415c041f8da8cca73777971ce6/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java#L135 

For OrderedScheduler, we can instead wrap the tasks when they are submitted, instead of relying on caller to wrap them.

There are a few reasons not to use `SafeRunnable`: 
 1. It requires 1 extra allocation for each task
 2. It makes the API non-standard, pushing the need to always manually wrap the regular `Runnable`
 3. Even when using it in lambda-form, it still requires extra levels of indentation that make the code more difficult to read.