### PR TITLE
Allow to use IO uring instead of epoll

### DIFF
--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -60,6 +60,18 @@
       <artifactId>jctools-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+      <version>${netty-iouring.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+      <version>${netty-iouring.version}</version>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>

--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -62,13 +62,11 @@
     <dependency>
       <groupId>io.netty.incubator</groupId>
       <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-      <version>${netty-iouring.version}</version>
       <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>io.netty.incubator</groupId>
       <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-      <version>${netty-iouring.version}</version>
       <classifier>linux-aarch_64</classifier>
     </dependency>
     <dependency>

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -238,6 +238,8 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -240,7 +240,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -240,6 +240,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -238,7 +238,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -238,6 +238,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -236,6 +236,8 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -238,6 +238,8 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -240,7 +240,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -240,6 +240,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar [11]
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -44,6 +44,8 @@ LongAdder), which was released with the following comments:
 - lib/io.netty-netty-transport-4.1.81.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar
 
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -24,6 +24,8 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-transport-4.1.81.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar
 
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -26,6 +26,8 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-transport-4.1.81.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.81.Final.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar
 
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -28,6 +28,7 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar
 
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -28,7 +28,6 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-transport-native-epoll-4.1.81.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final-linux-aarch_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.15.Final.jar
 - lib/io.netty-netty-transport-native-unix-common-4.1.81.Final.jar
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -52,7 +52,6 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.incubator.channel.uring.IOUring;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -52,6 +52,9 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.incubator.channel.uring.IOUring;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -316,7 +319,9 @@ class BookieNettyServer {
             bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(
                     conf.getServerWriteBufferLowWaterMark(), conf.getServerWriteBufferHighWaterMark()));
 
-            if (eventLoopGroup instanceof EpollEventLoopGroup) {
+            if (eventLoopGroup instanceof IOUringEventLoopGroup){
+                bootstrap.channel(IOUringServerSocketChannel.class);
+            } else if (eventLoopGroup instanceof EpollEventLoopGroup) {
                 bootstrap.channel(EpollServerSocketChannel.class);
             } else {
                 bootstrap.channel(NioServerSocketChannel.class);
@@ -386,6 +391,8 @@ class BookieNettyServer {
 
             if (jvmEventLoopGroup instanceof DefaultEventLoopGroup) {
                 jvmBootstrap.channel(LocalServerChannel.class);
+            } else if (jvmEventLoopGroup instanceof IOUringEventLoopGroup) {
+                jvmBootstrap.channel(IOUringServerSocketChannel.class);
             } else if (jvmEventLoopGroup instanceof EpollEventLoopGroup) {
                 jvmBootstrap.channel(EpollServerSocketChannel.class);
             } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -57,6 +57,9 @@ import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.incubator.channel.uring.IOUringChannelOption;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import io.netty.incubator.channel.uring.IOUringSocketChannel;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.netty.util.concurrent.Future;
@@ -543,7 +546,14 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         // Set up the ClientBootStrap so we can create a new Channel connection to the bookie.
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(eventLoopGroup);
-        if (eventLoopGroup instanceof EpollEventLoopGroup) {
+        if (eventLoopGroup instanceof IOUringEventLoopGroup) {
+            bootstrap.channel(IOUringSocketChannel.class);
+            try {
+                bootstrap.option(IOUringChannelOption.TCP_USER_TIMEOUT, conf.getTcpUserTimeoutMillis());
+            } catch (NoSuchElementException e) {
+                // Property not set, so keeping default value.
+            }
+        } else if (eventLoopGroup instanceof EpollEventLoopGroup) {
             bootstrap.channel(EpollSocketChannel.class);
             try {
                 // For Epoll channels, configure the TCP user timeout.

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
     <mockito.version>3.12.4</mockito.version>
     <netty.version>4.1.81.Final</netty.version>
     <netty-boringssl.version>2.0.54.Final</netty-boringssl.version>
+    <netty-iouring.version>0.0.15.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>
     <prometheus.version>0.15.0</prometheus.version>
@@ -466,6 +467,11 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${netty-boringssl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+        <version>${netty-iouring.version}</version>
       </dependency>
 
       <!-- grpc dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,18 @@
         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
         <version>${netty-iouring.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+        <version>${netty-iouring.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+        <version>${netty-iouring.version}</version>
+        <classifier>linux-aarch_64</classifier>
+      </dependency>
 
       <!-- grpc dependencies -->
       <dependency>


### PR DESCRIPTION
### Motivation

Allow users to enable IO_uring for BK network transport.

Since the Netty implementation is still considered experimental, it will not be enabled by default, rather only when the `-Denable.io_uring=true` is passed.

