### PR TITLE
 update doc about flushInterval config

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -470,7 +470,8 @@ ledgerDirectories=/tmp/bk-data
 # on too frequent flushing. You can consider increment flush interval
 # to get better performance, but you need to pay more time on bookie
 # server restart after failure.
-# This config is used only when entryLogPerLedgerEnabled is enabled.
+# This config is used only when entryLogPerLedgerEnabled=true
+# or ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage.
 # flushInterval=10000
 
 # Allow the expansion of bookie storage capacity. Newly added ledger

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -470,7 +470,7 @@ ledgerDirectories=/tmp/bk-data
 # on too frequent flushing. You can consider increment flush interval
 # to get better performance, but you need to pay more time on bookie
 # server restart after failure.
-# This config is used only when entryLogPerLedgerEnabled=true
+# This config is used when entryLogPerLedgerEnabled=true
 # or ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage.
 # flushInterval=10000
 


### PR DESCRIPTION
### Motivation
Updated description about flushInterval configuration：
`This config is used when entryLogPerLedgerEnabled=true or ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage.
`
https://github.com/apache/bookkeeper/blob/5724bc8434a4d6903487221d39713f39a4bcb6b4/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java#L459-L477