### PR TITLE
BookieImpl remove wait until journal quits

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -810,30 +810,9 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
 
     @Override
     public void run() {
-        // bookie thread wait for journal thread
-        try {
-            // start journals
-            for (Journal journal: journals) {
-                journal.start();
-            }
-
-            // wait until journal quits
-            for (Journal journal: journals) {
-
-                journal.joinThread();
-            }
-            LOG.info("Journal thread(s) quit.");
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            LOG.warn("Interrupted on running journal thread : ", ie);
-        }
-        // if the journal thread quits due to shutting down, it is ok
-        if (!stateManager.isShuttingDown()) {
-            // some error found in journal thread and it quits
-            // following add operations to it would hang unit client timeout
-            // so we should let bookie server exists
-            LOG.error("Journal manager quits unexpectedly.");
-            triggerBookieShutdown(ExitCode.BOOKIE_EXCEPTION);
+        // start journals
+        for (Journal journal: journals) {
+            journal.start();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -238,7 +238,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
         assertEquals("writable dirs should have one dir", 1, ledgerDirsManager
                 .getWritableLedgerDirs().size());
         assertTrue("Bookie should shutdown if readOnlyMode not enabled",
-                bookie.isAlive());
+                bookie.isRunning());
     }
 
     private void startNewBookieWithMultipleLedgerDirs(int numOfLedgerDirs)


### PR DESCRIPTION
### Motivation

PR #2887 introduced the feature of shutdown the bookie service after any Journal thread exits, so we don't need to wait in BookieImpl for all Journal threads to exit before shutdown the Bookie service, because this cannot happen.