### PR TITLE
Fix the concurrency problem of the compaction process and the regular…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
@@ -119,6 +119,11 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
     }
 
     @Override
+    synchronized void createNewLog(long ledgerId, String reason) throws IOException {
+        super.createNewLog(ledgerId, reason);
+    }
+
+    @Override
     public synchronized void setCurrentLogForLedgerAndAddToRotate(long ledgerId, BufferedLogChannel logChannel) {
         BufferedLogChannel hasToRotateLogChannel = activeLogChannel;
         activeLogChannel = logChannel;


### PR DESCRIPTION
… write process

Descriptions of the changes in this PR:
add a synchronized createNewLog method in EntryLogManagerForSingleEntryLog.


### Motivation

we use SortedLedgerStorage+EntryLogManagerForSingleEntryLog. 
When the entrylog file managed by EntryLogManagerForSingleEntryLog reaches the upper limit, the createNewLog method is executed. This operation is not locked, which will conflict with the addEntry executed in the compaction process, resulting in disordered entryLog file data.
![14e56f8a3e057508f446abb1ccd7b687](https://user-images.githubusercontent.com/35036009/199918343-ce3f5648-6851-4d82-b093-e0605ea9a02a.png)
![ae141da9c0fa6d51373775c19e0860ad](https://user-images.githubusercontent.com/35036009/199918357-d0124ed3-d7d7-4563-bef1-64ab62d553dc.png)
There is a concurrency problem with the two operations shown above.
In our case we found this code execution order:
1.logChannel.flush();
2.logChannel.write(sizeBuffer);
3.logChannel.appendLedgersMap();
4.logChannel.write(entry);

The correct entryLog file format should be like this：
header
entrySize1+entryData1
entrySize2+entryData2
...
entrySizen+entryDatan
ledgersMap

The wrong entrylog is as follows:
header
entrySize1+entryData1
entrySize2+entryData2
...
entrySizen
ledgersMap
entryDatan

### Changes

add a synchronized createNewLog method in EntryLogManagerForSingleEntryLog.

Master Issue: #3604
