### PR TITLE
Fix the problem that the abnormal file causes the bookie GC to fail

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -988,7 +988,7 @@ public class EntryLogger {
      * @param scanner Entry Log Scanner
      * @throws IOException
      */
-    public void scanEntryLog(long entryLogId, EntryLogScanner scanner) throws IOException {
+    public void scanEntryLog(long entryLogId, EntryLogScanner scanner) throws Exception {
         // Buffer where to read the entrySize (4 bytes) and the ledgerId (8 bytes)
         ByteBuf headerBuffer = Unpooled.buffer(4 + 8);
         BufferedReadChannel bc;
@@ -1054,7 +1054,7 @@ public class EntryLogger {
         }
     }
 
-    public EntryLogMetadata getEntryLogMetadata(long entryLogId) throws IOException {
+    public EntryLogMetadata getEntryLogMetadata(long entryLogId) throws Exception {
         // First try to extract the EntryLogMetada from the index, if there's no index then fallback to scanning the
         // entry log
         try {
@@ -1150,7 +1150,7 @@ public class EntryLogger {
         return meta;
     }
 
-    private EntryLogMetadata extractEntryLogMetadataByScanning(long entryLogId) throws IOException {
+    private EntryLogMetadata extractEntryLogMetadataByScanning(long entryLogId) throws Exception {
         final EntryLogMetadata meta = new EntryLogMetadata(entryLogId);
 
         // Read through the entry log file and extract the entry log meta

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -624,7 +624,7 @@ public class GarbageCollectorThread extends SafeRunnable {
                 } else {
                     entryLogMetaMap.put(entryLogId, entryLogMeta);
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 hasExceptionWhenScan = true;
                 LOG.warn("Premature exception when processing " + entryLogId
                          + " recovery will take care of the problem", e);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

When bookie GC encounters an entryLog file with disordered data, all exceptions are not caught, resulting in the death of the GC thread and the end of the GC process.
This problem is encountered again in the next GC, resulting in the subsequent entrylog being unable to GC. Disk is full.

image
In our case, due to the disorder of the entrylog file, the exception in the above figure appeared. This exception is not a subclass of IOException and cannot be caught.

### Changes

In the entryLogger.getEntryLogMetadata(entryLogId) process, modify IOException to Exception
Master Issue: #3607
@hangc0276 