### PR TITLE
Fix the problem that the abnormal file causes the bookie GC to fail

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1012,6 +1012,12 @@ public class EntryLogger {
             while (true) {
                 // Check if we've finished reading the entry log file.
                 if (pos >= bc.size()) {
+                    LOG.warn("read position illegal, ledgersMap maybe error. position {} entrylog size {} entrylog {}",
+                            pos, bc.size(), entryLogId);
+                    break;
+                }
+                if (pos < 0) {
+                    LOG.warn("read position illegal, position is negative. position {} entrylog {}", pos, entryLogId);
                     break;
                 }
                 if (readFromLogChannel(entryLogId, bc, headerBuffer, pos) != headerBuffer.capacity()) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
When bookie GC encounters an entryLog file with disordered data, all exceptions are not caught, resulting in the death of the GC thread and the end of the GC process.
This problem is encountered again in the next GC, resulting in the subsequent entrylog being unable to GC.

![image](https://user-images.githubusercontent.com/35036009/199929909-91f5d847-aa11-4aae-a046-30d40087fb4d.png)
In our case, due to the disorder of the entrylog file, the exception in the above figure appeared. This exception is not a subclass of IOException and cannot be caught.

This issue (#3604) describes a scenario that causes the entry log file to be disordered.


Master Issue: #3607

@hangc0276 