### PR TITLE
[branch-4.15] Fix the problem that the abnormal file causes the bookie GC fail

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1021,6 +1021,11 @@ public class EntryLogger {
                 long offset = pos;
                 pos += 4;
                 int entrySize = headerBuffer.readInt();
+                if (entrySize <= 0) {
+                    LOG.warn("bad read for ledger entry from entryLog {}@{} (entry size {})",
+                            entryLogId, pos, entrySize);
+                    return;
+                }
                 long ledgerId = headerBuffer.readLong();
                 headerBuffer.clear();
 
@@ -1031,11 +1036,6 @@ public class EntryLogger {
                 }
                 // read the entry
                 data.clear();
-                if (entrySize <= 0) {
-                    LOG.warn("bad read for ledger entry from entryLog {}@{} (entry size {})",
-                            entryLogId, pos, entrySize);
-                    return;
-                }
                 data.capacity(entrySize);
                 int rc = readFromLogChannel(entryLogId, bc, data, pos);
                 if (rc != entrySize) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -1021,10 +1021,10 @@ public class EntryLogger {
                 long offset = pos;
                 pos += 4;
                 int entrySize = headerBuffer.readInt();
-                if (entrySize <= 0) {
-                    LOG.warn("bad read for ledger entry from entryLog {}@{} (entry size {})",
-                            entryLogId, pos, entrySize);
-                    return;
+                if (entrySize <= 0) { // hitting padding
+                    pos++;
+                    headerBuffer.clear();
+                    continue;
                 }
                 long ledgerId = headerBuffer.readLong();
                 headerBuffer.clear();


### PR DESCRIPTION
Descriptions of the changes in this PR:

Motivation
When bookie GC encounters an entryLog file with disordered data, a IllegalArgumentException are not caught, resulting in the death of the GC thread and the end of the GC process.
This problem is encountered again in the next GC, resulting in the subsequent entrylog being unable to GC.
The problem described in this issue(https://github.com/apache/bookkeeper/issues/3604) will cause the entryLog file to be disordered, and will cause the IllegalArgumentException when parsing the entrylog file.

Master Issue:
https://github.com/apache/bookkeeper/issues/3607 : Describes the problem to be solved by this pr.
https://github.com/apache/bookkeeper/issues/3604 : Describes the phenomenon and causes of disordered entrylog files.