### PR TITLE
Issue 3549: migrate apply-config-from-env.py from python2 to python3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,9 +43,9 @@ RUN set -x \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
     && apt-get -y --purge autoremove \
-     && apt-get autoclean \
-     && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
+    && apt-get autoclean \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -pv /opt \
     && cd /opt \
     && wget -q "${DISTRO_URL}" \

--- a/docker/scripts/apply-config-from-env.py
+++ b/docker/scripts/apply-config-from-env.py
@@ -29,7 +29,7 @@
 import os, sys
 
 if len(sys.argv) != 2:
-    print 'Usage: %s ' + 'config_dir' % (sys.argv[0])
+    print('Usage: %s ' + 'config_dir' % (sys.argv[0]))
     sys.exit(1)
 
 def mylistdir(dir):
@@ -38,8 +38,8 @@ def mylistdir(dir):
 # Always apply env config to all the files under conf
 conf_dir = sys.argv[1]
 conf_files = mylistdir(conf_dir)
-print 'conf files: '
-print conf_files
+print('conf files: ')
+print(conf_files)
 
 bk_env_prefix = 'BK_'
 zk_env_prefix = 'ZK_'
@@ -75,13 +75,13 @@ for conf_filename in conf_files:
         if k.startswith(bk_env_prefix):
             search_key = k[len(bk_env_prefix):]
             if search_key in keys:
-                print '[%s] Applying config %s = %s' % (conf_filename, search_key, v)
+                print('[%s] Applying config %s = %s' % (conf_filename, search_key, v))
                 idx = keys[search_key]
                 lines[idx] = '%s=%s\n' % (search_key, v)
         if k.startswith(zk_env_prefix):
             search_key = k[len(zk_env_prefix):]
             if search_key in keys:
-                print '[%s] Applying config %s = %s' % (conf_filename, search_key, v)
+                print('[%s] Applying config %s = %s' % (conf_filename, search_key, v))
                 idx = keys[search_key]
                 lines[idx] = '%s=%s\n' % (search_key, v)
 


### PR DESCRIPTION
Fix #3549

Descriptions of the changes in this PR:
migrate apply-config-from-env.py from python2 to python3
fix docker/Dockerfile

### Motivation

Issue 3549: migrate apply-config-from-env.py from python2 to python3

### Changes

add newline character, and reformat for docker/Dockerfile
change print to print()

Master Issue: 3549

