### PR TITLE
Fix flushEntrylogBytes invalidation problem.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -134,6 +134,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
             if (doRegularFlushes) {
                 unpersistedBytes.addAndGet(copied);
                 if (unpersistedBytes.get() >= unpersistedBytesBound) {
+                    flush();
                     forceWrite(false);
                     shouldForceWrite = true;
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -134,7 +134,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
             if (doRegularFlushes) {
                 unpersistedBytes.addAndGet(copied);
                 if (unpersistedBytes.get() >= unpersistedBytesBound) {
-                    flush();
+                    forceWrite(false);
                     shouldForceWrite = true;
                 }
             }


### PR DESCRIPTION
### Motivation
The write cache configuration is as follows:
`dbStorage_writeCacheMaxSizeMb=8192`
There are 2 disks, so a write cache block size is 8G/2/2=2G.
Through the iostat command, I saw that one write to disk data reached 1.9G, resulting in disk util reaching 81%:
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/19296967/200221262-ed64203b-2920-420e-a463-8caa363c3bbf.png">
I hope to reduce disk util by adjusting flushEntrylogBytes=32M.

When flushEntrylogBytes is configured to 32M, the data from a flush page cache to disk may still exceed 32M, because when unpersistedBytes.get() >= unpersistedBytesBound, flush() is called instead of forceWrite method:
https://github.com/apache/bookkeeper/blob/860d40d58ca0eea1eaca2ddb81b43cb80447ae73/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java#L135-L145

When unpersistedBytes.get() >= unpersistedBytesBound, forceWrite should be called ：
```

if (unpersistedBytes.get() >= unpersistedBytesBound) {
                    flush();
                    forceWrite(false);
                    shouldForceWrite = true;
                }

```
