### PR TITLE
Upgrade maven version in release docker image

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.6.1-jdk-11
+FROM maven:3.8.6-jdk-11
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.6.1-jdk-8
+FROM maven:3.8.6-jdk-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake gnupg2 vim subversion


### PR DESCRIPTION
---

*Motivation*

When using the lower maven version to build bookkeeper, we will meet the license problem in the binary package.

```
ch.qos.logback-logback-classic-1.2.10.jar unaccounted for in LICENSE
ch.qos.logback-logback-core-1.2.10.jar unaccounted for in LICENSE
io.netty-netty-tcnative-2.0.48.Final.jar unaccounted for in LICENSE
io.netty-netty-transport-native-epoll-4.1.75.Final.jar unaccounted for in LICENSE
```

