### PR TITLE
Add small files check in garbage collection

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -589,7 +589,7 @@ public class GarbageCollectorThread implements Runnable {
 
         final int maxBucket = calculateUsageIndex(numBuckets, threshold);
         stopCompaction:
-        for (int currBucket = 0; currBucket < maxBucket; currBucket++) {
+        for (int currBucket = 0; currBucket <= maxBucket; currBucket++) {
             LinkedList<Long> entryLogIds = compactableBuckets.get(currBucket);
             while (!entryLogIds.isEmpty()) {
                 if (timeDiff.getValue() < maxTimeMillis) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -546,14 +546,24 @@ public class GarbageCollectorThread implements Runnable {
     @VisibleForTesting
     void doCompactEntryLogs(double threshold, long maxTimeMillis) throws EntryLogMetadataMapException {
         LOG.info("Do compaction to compact those files lower than {}", threshold);
+        double tmpGcEntryLogSizeRatio = conf.getGcEntryLogSizeRatio() <= 0 ? 0 : conf.getGcEntryLogSizeRatio();
+        final double gcEntryLogSizeRatio = tmpGcEntryLogSizeRatio > 1 ? 1.0 : tmpGcEntryLogSizeRatio;
+        if (gcEntryLogSizeRatio > 0.5) {
+            LOG.warn("Configured gcEntryLogSizeRatio: {}, updated gcEntryLogSizeRatio: {} gratter than 0.5, "
+                + "which means any entryLog file size less than {} will be compacted and it will bring heavy pressure "
+                + "on garbage collection.", conf.getGcEntryLogSizeRatio(), gcEntryLogSizeRatio,
+                gcEntryLogSizeRatio * conf.getEntryLogSizeLimit());
+        }
 
         final int numBuckets = 10;
         int[] entryLogUsageBuckets = new int[numBuckets];
         int[] compactedBuckets = new int[numBuckets];
 
         ArrayList<LinkedList<Long>> compactableBuckets = new ArrayList<>(numBuckets);
+        ArrayList<LinkedList<Long>> smallFilesCompactableBuckets = new ArrayList<>(numBuckets);
         for (int i = 0; i < numBuckets; i++) {
             compactableBuckets.add(new LinkedList<>());
+            smallFilesCompactableBuckets.add(new LinkedList<>());
         }
 
         long start = System.currentTimeMillis();
@@ -568,14 +578,20 @@ public class GarbageCollectorThread implements Runnable {
                 end.setValue(System.currentTimeMillis());
                 timeDiff.setValue(end.getValue() - start);
             }
-            if (meta.getUsage() >= threshold || (maxTimeMillis > 0 && timeDiff.getValue() >= maxTimeMillis)
-                    || !running) {
+            if ((meta.getUsage() >= threshold
+                && meta.getTotalSize() >= conf.getEntryLogSizeLimit() * gcEntryLogSizeRatio)
+                || (maxTimeMillis > 0 && timeDiff.getValue() >= maxTimeMillis)
+                || !running) {
                 // We allow the usage limit calculation to continue so that we get an accurate
                 // report of where the usage was prior to running compaction.
                 return;
             }
 
-            compactableBuckets.get(bucketIndex).add(meta.getEntryLogId());
+            if (meta.getTotalSize() < conf.getEntryLogSizeLimit() * gcEntryLogSizeRatio) {
+                smallFilesCompactableBuckets.get(bucketIndex).add(meta.getEntryLogId());
+            } else {
+                compactableBuckets.get(bucketIndex).add(meta.getEntryLogId());
+            }
         });
 
         LOG.info(
@@ -584,8 +600,11 @@ public class GarbageCollectorThread implements Runnable {
 
         final int maxBucket = calculateUsageIndex(numBuckets, threshold);
         stopCompaction:
-        for (int currBucket = 0; currBucket <= maxBucket; currBucket++) {
-            LinkedList<Long> entryLogIds = compactableBuckets.get(currBucket);
+        for (int currBucket = 0; currBucket < numBuckets; currBucket++) {
+            LinkedList<Long> entryLogIds = smallFilesCompactableBuckets.get(currBucket);
+            if (currBucket <= maxBucket) {
+                entryLogIds.addAll(compactableBuckets.get(currBucket));
+            }
             while (!entryLogIds.isEmpty()) {
                 if (timeDiff.getValue() < maxTimeMillis) {
                     end.setValue(System.currentTimeMillis());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -116,7 +116,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     protected static final String GC_ENTRYLOGMETADATA_CACHE_ENABLED = "gcEntryLogMetadataCacheEnabled";
     protected static final String GC_ENTRYLOG_METADATA_CACHE_PATH = "gcEntryLogMetadataCachePath";
-    protected static final String GC_ENTRYLOG_SIZE_RATIO = "gcEntryLogSizeRatio";
+    protected static final String USE_TARGET_ENTRYLOG_SIZE_FOR_GC = "useTargetEntryLogSizeForGc";
     // Scrub Parameters
     protected static final String LOCAL_SCRUB_PERIOD = "localScrubInterval";
     protected static final String LOCAL_SCRUB_RATE_LIMIT = "localScrubRateLimit";
@@ -555,36 +555,12 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
         return this;
     }
 
-    /**
-     * Get the gc entry log size ratio.
-     * When the current entry log total size less than GC_ENTRYLOG_SIZE_RATIO * ENTRY_LOG_SIZE_LIMIT,
-     * this entry log file will be compacted. This configuration is aiming to reduce small entry log files
-     * when using TransactionalEntryLogCompactor.
-     *
-     * For example,
-     *   - the current entry log file total size is 1MB
-     *   - the current entry log file usage is 0.9
-     *   - the garbage collection threshold is 0.5
-     *   - ENTRY_LOG_SIZE_LIMIT = 1GB
-     *
-     *   The entry log file usage is greater than garbage collection threshold,
-     *   it will skip to compact this entry log file if we don't have entry log file size check.
-     *   If we set add the entry log file size check, it will have the following cases.
-     *   case 1: GC_ENTRYLOG_SIZE_RATIO = 0.0, 1MB > 0.0 * 1GB, we will skip the entry log file garbage collection
-     *   case 2: GC_ENTRYLOG_SIZE_RATIO = 0.5, 1MB < 1.0 * 1GB, we will compact the entry log file
-     *   case 3: GC_ENTRYLOG_SIZE_RATIO = 1.0, 1MB < 1.0 * 1GB, we will compact the entry log file
-     *
-     *   If GC_ENTRYLOG_SIZE_RATIO <= 0.0, it means disable the entry log file size check.
-     *   By default, the GC_ENTRYLOG_SIZE_RATIO = 0.0.
-     *
-     * @return the gcEntryLogSizeRatio, default is 1.0.
-     */
-    public double getGcEntryLogSizeRatio() {
-        return getDouble(GC_ENTRYLOG_SIZE_RATIO, 0.0);
+    public boolean isUseTargetEntryLogSizeForGc() {
+        return getBoolean(USE_TARGET_ENTRYLOG_SIZE_FOR_GC, false);
     }
 
-    public ServerConfiguration setGcEntryLogSizeRatio(double gcEntryLogSizeRatio) {
-        this.setProperty(GC_ENTRYLOG_SIZE_RATIO, gcEntryLogSizeRatio);
+    public ServerConfiguration setUseTargetEntryLogSizeForGc(boolean useTargetEntryLogSizeForGc) {
+        this.setProperty(USE_TARGET_ENTRYLOG_SIZE_FOR_GC, useTargetEntryLogSizeForGc);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -116,6 +116,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     protected static final String GC_ENTRYLOGMETADATA_CACHE_ENABLED = "gcEntryLogMetadataCacheEnabled";
     protected static final String GC_ENTRYLOG_METADATA_CACHE_PATH = "gcEntryLogMetadataCachePath";
+    protected static final String GC_ENTRYLOG_SIZE_RATIO = "gcEntryLogSizeRatio";
     // Scrub Parameters
     protected static final String LOCAL_SCRUB_PERIOD = "localScrubInterval";
     protected static final String LOCAL_SCRUB_RATE_LIMIT = "localScrubRateLimit";
@@ -551,6 +552,39 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setGcEntryLogMetadataCachePath(String gcEntrylogMetadataCachePath) {
         this.setProperty(GC_ENTRYLOG_METADATA_CACHE_PATH, gcEntrylogMetadataCachePath);
+        return this;
+    }
+
+    /**
+     * Get the gc entry log size ratio.
+     * When the current entry log total size less than GC_ENTRYLOG_SIZE_RATIO * ENTRY_LOG_SIZE_LIMIT,
+     * and the remaining usage less than the threshold, this entry log file will be compacted.
+     * This configuration is aiming to reduce small entry log files when using TransactionalEntryLogCompactor.
+     *
+     * For example,
+     *   - the current entry log file total size is 1MB
+     *   - the current entry log file usage is 0.9
+     *   - the garbage collection threshold is 0.5
+     *   - ENTRY_LOG_SIZE_LIMIT = 1GB
+     *
+     *   The entry log file usage is greater than garbage collection threshold,
+     *   it will skip to compact this entry log file if we don't have entry log file size check.
+     *   If we set add the entry log file size check, it will have the following cases.
+     *   case 1: GC_ENTRYLOG_SIZE_RATIO = 0.0, 1MB > 0.0 * 1GB, we will skip the entry log file garbage collection
+     *   case 2: GC_ENTRYLOG_SIZE_RATIO = 0.5, 1MB < 1.0 * 1GB, we will compact the entry log file
+     *   case 3: GC_ENTRYLOG_SIZE_RATIO = 1.0, 1MB < 1.0 * 1GB, we will compact the entry log file
+     *
+     *   If GC_ENTRYLOG_SIZE_RATIO <= 0.0, it means disable the entry log file size check.
+     *   By default, the GC_ENTRYLOG_SIZE_RATIO = 0.0.
+     *
+     * @return the gcEntryLogSizeRatio, default is 1.0.
+     */
+    public double getGcEntryLogSizeRatio() {
+        return getDouble(GC_ENTRYLOG_SIZE_RATIO, 0.0);
+    }
+
+    public ServerConfiguration setGcEntryLogSizeRatio(double gcEntryLogSizeRatio) {
+        this.setProperty(GC_ENTRYLOG_SIZE_RATIO, gcEntryLogSizeRatio);
         return this;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -558,8 +558,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     /**
      * Get the gc entry log size ratio.
      * When the current entry log total size less than GC_ENTRYLOG_SIZE_RATIO * ENTRY_LOG_SIZE_LIMIT,
-     * and the remaining usage less than the threshold, this entry log file will be compacted.
-     * This configuration is aiming to reduce small entry log files when using TransactionalEntryLogCompactor.
+     * this entry log file will be compacted. This configuration is aiming to reduce small entry log files
+     * when using TransactionalEntryLogCompactor.
      *
      * For example,
      *   - the current entry log file total size is 1MB

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -308,7 +308,6 @@ class BookieNettyServer {
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.option(ChannelOption.ALLOCATOR, allocator);
             bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
-            bootstrap.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 100);
             bootstrap.group(acceptorGroup, eventLoopGroup);
             bootstrap.childOption(ChannelOption.TCP_NODELAY, conf.getServerTcpNoDelay());
             bootstrap.childOption(ChannelOption.SO_LINGER, conf.getServerSockLinger());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -308,6 +308,7 @@ class BookieNettyServer {
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.option(ChannelOption.ALLOCATOR, allocator);
             bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
+            bootstrap.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 100);
             bootstrap.group(acceptorGroup, eventLoopGroup);
             bootstrap.childOption(ChannelOption.TCP_NODELAY, conf.getServerTcpNoDelay());
             bootstrap.childOption(ChannelOption.SO_LINGER, conf.getServerSockLinger());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -238,4 +239,143 @@ public class GarbageCollectorThreadTest {
         assertTrue(entryLogMetaMap.isEmpty());
         assertFalse(entryLogger.logExists(logId3));
     }
+
+    @Test
+    public void testCompactionWithFileSizeCheck() throws Exception {
+        File ledgerDir = tmpDirs.createNew("testFileSize", "ledgers");
+        EntryLogger entryLogger = newLegacyEntryLogger(20000, ledgerDir);
+
+        MockLedgerStorage storage = new MockLedgerStorage();
+        MockLedgerManager lm = new MockLedgerManager();
+
+        GarbageCollectorThread gcThread = new GarbageCollectorThread(
+            TestBKConfiguration.newServerConfiguration().setGcEntryLogSizeRatio(0.5), lm,
+            newDirsManager(ledgerDir),
+            storage, entryLogger, NullStatsLogger.INSTANCE);
+
+        // Add entries.
+        // Ledger 1 is on first entry log
+        // Ledger 2 spans first, second and third entry log
+        // Ledger 3 is on the third entry log (which is still active when extract meta)
+        long loc1 = entryLogger.addEntry(1L, makeEntry(1L, 1L, 5000));
+        long loc2 = entryLogger.addEntry(2L, makeEntry(2L, 1L, 5000));
+        assertThat(logIdFromLocation(loc2), equalTo(logIdFromLocation(loc1)));
+        long loc3 = entryLogger.addEntry(2L, makeEntry(2L, 2L, 15000));
+        assertThat(logIdFromLocation(loc3), greaterThan(logIdFromLocation(loc2)));
+        long loc4 = entryLogger.addEntry(2L, makeEntry(2L, 3L, 15000));
+        assertThat(logIdFromLocation(loc4), greaterThan(logIdFromLocation(loc3)));
+        long loc5 = entryLogger.addEntry(3L, makeEntry(3L, 1L, 1000));
+        assertThat(logIdFromLocation(loc5), equalTo(logIdFromLocation(loc4)));
+
+        long logId1 = logIdFromLocation(loc2);
+        long logId2 = logIdFromLocation(loc3);
+        long logId3 = logIdFromLocation(loc5);
+        entryLogger.flush();
+
+        storage.setMasterKey(1L, new byte[0]);
+        storage.setMasterKey(2L, new byte[0]);
+        storage.setMasterKey(3L, new byte[0]);
+
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertTrue(entryLogger.logExists(logId1));
+        assertTrue(entryLogger.logExists(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+
+        // all ledgers exist, nothing should disappear
+        final EntryLogMetadataMap entryLogMetaMap = gcThread.getEntryLogMetaMap();
+        gcThread.extractMetaFromEntryLogs();
+
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertTrue(entryLogMetaMap.containsKey(logId1));
+        assertTrue(entryLogMetaMap.containsKey(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+
+        gcThread.runWithFlags(true, true, false);
+
+        // logId1 and logId2 should be compacted
+        assertFalse(entryLogger.logExists(logId1));
+        assertFalse(entryLogger.logExists(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+        assertFalse(entryLogMetaMap.containsKey(logId1));
+        assertFalse(entryLogMetaMap.containsKey(logId2));
+
+        assertEquals(3, storage.getUpdatedLocations().size());
+
+        EntryLocation location1 = storage.getUpdatedLocations().get(0);
+        assertEquals(1, location1.getLedger());
+        assertEquals(1, location1.getEntry());
+        assertThat(logIdFromLocation(location1.getLocation()), greaterThan((int) logId3));
+
+        EntryLocation location2 = storage.getUpdatedLocations().get(1);
+        assertEquals(2, location2.getLedger());
+        assertEquals(1, location2.getEntry());
+        assertEquals(logIdFromLocation(location2.getLocation()), logIdFromLocation(location1.getLocation()));
+
+        EntryLocation location3 = storage.getUpdatedLocations().get(2);
+        assertEquals(2, location3.getLedger());
+        assertEquals(2, location3.getEntry());
+        assertThat(logIdFromLocation(loc4), greaterThan(logIdFromLocation(loc3)));
+    }
+
+    @Test
+    public void testCompactionWithoutFileSizeCheck() throws Exception {
+        File ledgerDir = tmpDirs.createNew("testFileSize", "ledgers");
+        EntryLogger entryLogger = newLegacyEntryLogger(20000, ledgerDir);
+
+        MockLedgerStorage storage = new MockLedgerStorage();
+        MockLedgerManager lm = new MockLedgerManager();
+
+        GarbageCollectorThread gcThread = new GarbageCollectorThread(
+            TestBKConfiguration.newServerConfiguration(), lm,
+            newDirsManager(ledgerDir),
+            storage, entryLogger, NullStatsLogger.INSTANCE);
+
+        // Add entries.
+        // Ledger 1 is on first entry log
+        // Ledger 2 spans first, second and third entry log
+        // Ledger 3 is on the third entry log (which is still active when extract meta)
+        long loc1 = entryLogger.addEntry(1L, makeEntry(1L, 1L, 5000));
+        long loc2 = entryLogger.addEntry(2L, makeEntry(2L, 1L, 5000));
+        assertThat(logIdFromLocation(loc2), equalTo(logIdFromLocation(loc1)));
+        long loc3 = entryLogger.addEntry(2L, makeEntry(2L, 2L, 15000));
+        assertThat(logIdFromLocation(loc3), greaterThan(logIdFromLocation(loc2)));
+        long loc4 = entryLogger.addEntry(2L, makeEntry(2L, 3L, 15000));
+        assertThat(logIdFromLocation(loc4), greaterThan(logIdFromLocation(loc3)));
+        long loc5 = entryLogger.addEntry(3L, makeEntry(3L, 1L, 1000));
+        assertThat(logIdFromLocation(loc5), equalTo(logIdFromLocation(loc4)));
+
+        long logId1 = logIdFromLocation(loc2);
+        long logId2 = logIdFromLocation(loc3);
+        long logId3 = logIdFromLocation(loc5);
+        entryLogger.flush();
+
+        storage.setMasterKey(1L, new byte[0]);
+        storage.setMasterKey(2L, new byte[0]);
+        storage.setMasterKey(3L, new byte[0]);
+
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertTrue(entryLogger.logExists(logId1));
+        assertTrue(entryLogger.logExists(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+
+        // all ledgers exist, nothing should disappear
+        final EntryLogMetadataMap entryLogMetaMap = gcThread.getEntryLogMetaMap();
+        gcThread.extractMetaFromEntryLogs();
+
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertTrue(entryLogMetaMap.containsKey(logId1));
+        assertTrue(entryLogMetaMap.containsKey(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+
+        gcThread.runWithFlags(true, true, false);
+
+        assertTrue(entryLogger.logExists(logId1));
+        assertTrue(entryLogger.logExists(logId2));
+        assertTrue(entryLogger.logExists(logId3));
+        assertTrue(entryLogMetaMap.containsKey(logId1));
+        assertTrue(entryLogMetaMap.containsKey(logId2));
+
+        assertEquals(0, storage.getUpdatedLocations().size());
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -266,26 +266,29 @@ public class GarbageCollectorThreadTest {
         assertThat(logIdFromLocation(loc4), greaterThan(logIdFromLocation(loc3)));
         long loc5 = entryLogger.addEntry(3L, makeEntry(3L, 1L, 1000));
         assertThat(logIdFromLocation(loc5), equalTo(logIdFromLocation(loc4)));
+        long loc6 = entryLogger.addEntry(3L, makeEntry(3L, 2L, 5000));
 
         long logId1 = logIdFromLocation(loc2);
         long logId2 = logIdFromLocation(loc3);
         long logId3 = logIdFromLocation(loc5);
+        long logId4 = logIdFromLocation(loc6);
         entryLogger.flush();
 
         storage.setMasterKey(1L, new byte[0]);
         storage.setMasterKey(2L, new byte[0]);
         storage.setMasterKey(3L, new byte[0]);
 
-        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2, logId3));
         assertTrue(entryLogger.logExists(logId1));
         assertTrue(entryLogger.logExists(logId2));
         assertTrue(entryLogger.logExists(logId3));
+        assertTrue(entryLogger.logExists(logId4));
 
         // all ledgers exist, nothing should disappear
         final EntryLogMetadataMap entryLogMetaMap = gcThread.getEntryLogMetaMap();
         gcThread.extractMetaFromEntryLogs();
 
-        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
+        assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2, logId3));
         assertTrue(entryLogMetaMap.containsKey(logId1));
         assertTrue(entryLogMetaMap.containsKey(logId2));
         assertTrue(entryLogger.logExists(logId3));
@@ -306,7 +309,7 @@ public class GarbageCollectorThreadTest {
         EntryLocation location2 = storage.getUpdatedLocations().get(0);
         assertEquals(2, location2.getLedger());
         assertEquals(1, location2.getEntry());
-        assertEquals(logIdFromLocation(location2.getLocation()), logId3 + 1);
+        assertEquals(logIdFromLocation(location2.getLocation()), logId4);
     }
 
     @Test

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -621,6 +621,13 @@ gcEntryLogMetadataCacheEnabled=false
 # name "entrylogIndexCache"]
 # gcEntryLogMetadataCachePath=
 
+# When the current entry log total size less than gcEntryLogSizeRatio * logSizeLimit,
+# and the remaining usage less than the threshold, this entry log file will be compacted.
+# This configuration is aiming to reduce small entry log files when using TransactionalEntryLogCompactor.
+# If gcEntryLogSizeRatio <= 0.0, it means disable the entry log file size check.
+# By default, the entry log file size check is disabled.
+# gcEntryLogSizeRatio = 0.0
+
 #############################################################################
 ## Disk utilization
 #############################################################################

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -621,12 +621,14 @@ gcEntryLogMetadataCacheEnabled=false
 # name "entrylogIndexCache"]
 # gcEntryLogMetadataCachePath=
 
-# When the current entry log total size less than gcEntryLogSizeRatio * logSizeLimit,
-# and the remaining usage less than the threshold, this entry log file will be compacted.
-# This configuration is aiming to reduce small entry log files when using TransactionalEntryLogCompactor.
-# If gcEntryLogSizeRatio <= 0.0, it means disable the entry log file size check.
-# By default, the entry log file size check is disabled.
-# gcEntryLogSizeRatio = 0.0
+# When judging whether an entry log file need to be compacted, we calculate the usage rate of the entry log file based
+# on the actual size of the entry log file. However, if an entry log file is 1MB in size and 0.9MB of data is
+# being used, this entry log file won't be compacted by garbage collector due to the high usage ratio,
+# which will result in many small entry log files.
+# We introduced the parameter `useTargetEntryLogSizeForGc` to determine whether to calculate entry log file usage
+# based on the configured target entry log file size, which is configured by `logSizeLimit`.
+# Default: useTargetEntryLogSizeForGc is false.
+# useTargetEntryLogSizeForGc=false
 
 #############################################################################
 ## Disk utilization


### PR DESCRIPTION
### Motivation
When we use `TransactionalEntryLogCompactor` to compact the entry log files, it will generate a lot of small entry log files, and for those files, the file usage is usually greater than 90%, which can not be compacted unless the file usage decreased.

![image](https://user-images.githubusercontent.com/5436568/201135615-4d6072f5-e353-483d-9afb-48fad8134044.png)


### Changes
We introduce the entry log file size check during compaction, and the checker is controlled by `gcEntryLogSizeRatio`. 
If the total entry log file size is less than `gcEntryLogSizeRatio * logSizeLimit`, the entry log file will be compacted even though the file usage is greater than 90%. This feature is disabled by default and the `gcEntryLogSizeRatio` default value is `0.0`