### PR TITLE
Include bkperf into bk all package

### DIFF
--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -104,6 +104,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-perf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
        <!-- needed by ZooKeeper server -->
        <groupId>org.xerial.snappy</groupId>
        <artifactId>snappy-java</artifactId>

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -320,6 +320,7 @@ Apache Software License, Version 2.
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
+- lib/org.hdrhistogram-HdrHistogram-2.1.10.jar [52]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.11.0
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.11.3
@@ -369,6 +370,7 @@ Apache Software License, Version 2.
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
 [50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
+[52] Source available at https://github.com/HdrHistogram/HdrHistogram/tree/HdrHistogram-2.1.10
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.81.Final.jar bundles some 3rd party dependencies


### PR DESCRIPTION
### Motivation
The `bkperf` dependency doesn't include in the bookkeeper-all package, and when we run `bin/bkperf` command, it will throw the following exceptions.
```
$ bin/bkperf journal append -j data -n 100000000 --sync true
Couldn't find module '(org.apache.bookkeeper-)?bookkeeper-perf' jar.
Do you want me to run `mvn package -DskipTests` for you ? (y|n)
```

### Changes
Include the `bookkeeper-perf` dependency into `bookkeeper-all` package.