### PR TITLE
Upgrade docker image version to fix CVEs

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.3-eclipse-temurin-11
+FROM maven:3.8.6-eclipse-temurin-11
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.6-jdk-11
+FROM maven:3.8.3-eclipse-temurin-11
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.3-eclipse-temurin-8
+FROM maven:3.8.6-eclipse-temurin-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake gnupg2 vim subversion

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.6-jdk-8
+FROM maven:3.8.3-eclipse-temurin-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake gnupg2 vim subversion


### PR DESCRIPTION
### Motivation
There are a lot of critical CVEs in the `maven:3.8.6-jdk-11` docker image
https://snyk.io/test/docker/maven%3A3.8.6-jdk-11

### Changes
Use `maven:3.8.3-eclipse-temurin-11` instead of `maven:3.8.6-jdk-11` to fix it.
