### PR TITLE
[website] Fix releases page header and move latest release to 4.15.3

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -7,7 +7,7 @@ const baseUrl = process.env.BASE_URL || "/"
 const deployUrl = process.env.DEPLOY_URL || "https://bookkeeper.apache.org";
 const variables = {
   /** They are used in .md files*/
-  latest_release: "4.15.0",
+  latest_release: "4.15.3",
   stable_release: "4.14.5",
   github_repo: "https://github.com/apache/bookkeeper",
   github_master: "https://github.com/apache/bookkeeper/tree/master",

--- a/site3/website/src/pages/release-notes.md
+++ b/site3/website/src/pages/release-notes.md
@@ -533,7 +533,7 @@ below.
 
 - [https://github.com/apache/bookkeeper/pull/2415] Spammy log when one bookie of ensemble is down
 
-### Compatiblity
+### Compatibility
 
 This is a point release and it does not bring API changes.
 

--- a/site3/website/src/pages/releases.md
+++ b/site3/website/src/pages/releases.md
@@ -1,9 +1,5 @@
 <!-- markdown-link-check-disable -->
-
----
-id: releases
-title: Apache BookKeeper Releases
----
+# Releases
 
 Version **{{ site.latest_release }}** is the latest release of BookKeeper. The current stable version is **{{ site.stable_release }}**.
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Releases page is malformed
![Screen Shot 2022-11-15 at 9 35 22 AM](https://user-images.githubusercontent.com/23314389/201870107-4bd2806b-eecc-46a9-9c18-8bdff01dcb41.png)

Also update latest version to 4.15.3 since the doc is already online

