### PR TITLE
Make RocksDB delete entries batch size configurable

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -337,6 +337,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Used for location index, lots of writes and much bigger dataset
     protected static final String LEDGER_METADATA_ROCKSDB_CONF = "ledgerMetadataRocksdbConf";
 
+    protected static final String ROCKSDB_DELETE_ENTRIES_BATCH_SIZE = "rocksDBDeleteEntriesBatchSize";
+
     /**
      * Construct a default configuration object.
      */
@@ -4044,6 +4046,26 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setLedgerMetadataRocksdbConf(String ledgerMetadataRocksdbConf) {
         this.setProperty(LEDGER_METADATA_ROCKSDB_CONF, ledgerMetadataRocksdbConf);
+        return this;
+    }
+
+    /**
+     * Get entry log location index delete entries batch size from RocksDB.
+     *
+     * @return Int rocksDB delete entries batch size configured in Service configuration.
+     */
+    public int getRocksDBDeleteEntriesBatchSize() {
+        return getInt(ROCKSDB_DELETE_ENTRIES_BATCH_SIZE, 100000);
+    }
+
+    /**
+     * Set entry log location index delete entries batch size from RocksDB.
+     *
+     * @param rocksDBDeleteEntriesBatchSize
+     * @return
+     */
+    public ServerConfiguration setRocksDBDeleteEntriesBatchSize(int rocksDBDeleteEntriesBatchSize) {
+        this.setProperty(ROCKSDB_DELETE_ENTRIES_BATCH_SIZE, rocksDBDeleteEntriesBatchSize);
         return this;
     }
 }

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -756,6 +756,10 @@ gcEntryLogMetadataCacheEnabled=false
 # Default is to use 10% / numberOfLedgers of the direct memory size
 # dbStorage_rocksDB_blockCacheSize=
 
+# entry log location index delete entries batch size from RocksDB.
+# Default is 100000
+# rocksDBDeleteEntriesBatchSize=100000
+
 # Other RocksDB specific tunables
 # dbStorage_rocksDB_writeBufferSizeMB=64
 # dbStorage_rocksDB_sstSizeInMB=64


### PR DESCRIPTION
### Motivation
When there are a lot of ledgers to be deleted, the EntyLocationIndex in RocksDB will delete a large number of entries at one time. 
```
Nov 11, 2022 @ 05:49:39.336     05:49:39.336 [db-storage-cleanup-10-1] INFO  org.apache.bookkeeper.bookie.storage.ldb.EntryLocationIndex - Deleted indexes for 0 entries from 16074 ledgers in 625.242 seconds
Nov 11, 2022 @ 10:18:08.281     10:18:08.281 [db-storage-cleanup-10-1] INFO  org.apache.bookkeeper.bookie.storage.ldb.EntryLocationIndex - Deleted indexes for 0 entries from 13376 ledgers in 248.66 seconds
Nov 11, 2022 @ 14:27:06.949     14:27:06.949 [db-storage-cleanup-10-1] INFO  org.apache.bookkeeper.bookie.storage.ldb.EntryLocationIndex - Deleted indexes for 0 entries from 11798 ledgers in 265.118 seconds
Nov 11, 2022 @ 19:45:40.593     19:45:40.593 [db-storage-cleanup-10-1] INFO  org.apache.bookkeeper.bookie.storage.ldb.EntryLocationIndex - Deleted indexes for 0 entries from 15546 ledgers in 1133.236 seconds
```
The RocksDB location index deletes operation will cause RocksDB busy, and impact the read latency to a few seconds.

Currently, we delete RocksDB entries in batch, and the batch size is hard-coded. We can not change it.

### Changes
Make the RocksDB delete entries in batch configurable.