### PR TITLE
Journal queue size dropped down to negative

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -51,7 +51,8 @@ public class TestStatsProvider implements StatsProvider {
 
         @Override
         public void inc() {
-            updateMax(val.incrementAndGet());
+            val.incrementAndGet();
+            updateMax(1);
         }
 
         @Override
@@ -61,13 +62,13 @@ public class TestStatsProvider implements StatsProvider {
 
         @Override
         public void addCount(long delta) {
-            updateMax(val.addAndGet(delta));
+            updateMax(delta);
         }
 
         @Override
         public void addLatency(long eventLatency, TimeUnit unit) {
             long valueMillis = unit.toMillis(eventLatency);
-            updateMax(val.addAndGet(valueMillis));
+            updateMax(valueMillis);
         }
 
         @Override
@@ -76,15 +77,7 @@ public class TestStatsProvider implements StatsProvider {
         }
 
         private void updateMax(long newVal) {
-            while (true) {
-                long curMax = max.get();
-                if (curMax > newVal) {
-                    break;
-                }
-                if (max.compareAndSet(curMax, newVal)) {
-                    break;
-                }
-            }
+            max.addAndGet(newVal);
         }
 
         public Long getMax() {

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/test/TestStatsProvider.java
@@ -62,12 +62,14 @@ public class TestStatsProvider implements StatsProvider {
 
         @Override
         public void addCount(long delta) {
+            val.addAndGet(delta);
             updateMax(delta);
         }
 
         @Override
         public void addLatency(long eventLatency, TimeUnit unit) {
             long valueMillis = unit.toMillis(eventLatency);
+            val.addAndGet(valueMillis);
             updateMax(valueMillis);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1128,9 +1128,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                             qe = localQueueEntries.removeFirst();
                             dequeueStartTime = MathUtils.nowInNano();
                             busyStartTime = dequeueStartTime;
-                            journalStats.getJournalQueueStats()
-                                    .registerSuccessfulEvent(MathUtils.elapsedNanos(qe.enqueueTime),
-                                            TimeUnit.NANOSECONDS);
                         } else {
                             long pollWaitTimeNanos = maxGroupWaitInNanos
                                     - MathUtils.elapsedNanos(toFlush.get(0).enqueueTime);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1128,7 +1128,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                             qe = localQueueEntries.removeFirst();
                             dequeueStartTime = MathUtils.nowInNano();
                             busyStartTime = dequeueStartTime;
-                            journalStats.getJournalQueueSize().dec();
                             journalStats.getJournalQueueStats()
                                     .registerSuccessfulEvent(MathUtils.elapsedNanos(qe.enqueueTime),
                                             TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
@@ -92,7 +92,7 @@ public class OpStatTest extends BookKeeperClusterTestCase {
     @Test
     public void testTopLevelBookieWriteCounters() throws Exception {
         long startNanos = MathUtils.nowInNano();
-        for (int i=0; i<5; i++) {
+        for (int i = 0; i < 5; i++) {
             lh.addEntry("test".getBytes());
         }
         long elapsed = MathUtils.elapsedNanos(startNanos);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
@@ -92,7 +92,9 @@ public class OpStatTest extends BookKeeperClusterTestCase {
     @Test
     public void testTopLevelBookieWriteCounters() throws Exception {
         long startNanos = MathUtils.nowInNano();
-        lh.addEntry("test".getBytes());
+        for (int i=0;i<5;i++) {
+            lh.addEntry("test".getBytes());
+        }
         long elapsed = MathUtils.elapsedNanos(startNanos);
         TestStatsProvider stats = getStatsProvider(0);
         validateOpStat(stats, new String[]{
@@ -102,23 +104,29 @@ public class OpStatTest extends BookKeeperClusterTestCase {
                 SERVER_SCOPE + ".BookieWriteThreadPool.task_execution",
                 SERVER_SCOPE + ".CHANNEL_WRITE"
         }, (count, average) -> {
-            assertTrue(count == 1);
+            assertTrue(count == 5);
             assertTrue(average > 0);
             assertTrue(average <= elapsed);
         });
         validateOpStat(stats, new String[]{
                 SERVER_SCOPE + ".CHANNEL_WRITE"
         }, (count, average) -> {
-            assertTrue(count > 0);
+            assertTrue(count == 5);
             assertTrue(average > 0);
             assertTrue(average <= elapsed);
         });
         validateNonMonotonicCounterGauges(stats, new String[]{
                 BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_CB_QUEUE_SIZE,
-                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_FORCE_WRITE_QUEUE_SIZE,
                 BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_QUEUE_SIZE
         }, (value, max) -> {
-            assertTrue(max > 0);
+            assertTrue(value ==  0);
+            assertTrue(max == 6);
+        });
+        validateNonMonotonicCounterGauges(stats, new String[]{
+                BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_FORCE_WRITE_QUEUE_SIZE,
+        }, (value, max) -> {
+            assertTrue(value ==  0);
+            assertTrue(max == 10);
         });
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/OpStatTest.java
@@ -92,7 +92,7 @@ public class OpStatTest extends BookKeeperClusterTestCase {
     @Test
     public void testTopLevelBookieWriteCounters() throws Exception {
         long startNanos = MathUtils.nowInNano();
-        for (int i=0;i<5;i++) {
+        for (int i=0; i<5; i++) {
             lh.addEntry("test".getBytes());
         }
         long elapsed = MathUtils.elapsedNanos(startNanos);
@@ -119,13 +119,13 @@ public class OpStatTest extends BookKeeperClusterTestCase {
                 BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_CB_QUEUE_SIZE,
                 BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_QUEUE_SIZE
         }, (value, max) -> {
-            assertTrue(value ==  0);
+            assertTrue(value == 0);
             assertTrue(max == 6);
         });
         validateNonMonotonicCounterGauges(stats, new String[]{
                 BOOKIE_SCOPE + "." + JOURNAL_SCOPE + ".journalIndex_0." + JOURNAL_FORCE_WRITE_QUEUE_SIZE,
         }, (value, max) -> {
-            assertTrue(value ==  0);
+            assertTrue(value == 0);
             assertTrue(max == 10);
         });
     }


### PR DESCRIPTION
Journal queue size dropped down to negative, This issue is introduced by #3544. 

This change can be covered by `org.apache.bookkeeper.test.OpStatTest#testTopLevelBookieWriteCounters`. 
5 entries were added, the count of `JOURNAL_CB_QUEUE_SIZE` and `JOURNAL_QUEUE_SIZE` is 6 because the master key is added extra. The count of `JOURNAL_FORCE_WRITE_QUEUE_SIZE` is 10, because of the journal marker.

I also change the behavior of `org.apache.bookkeeper.test.TestStatsProvider.TestCounter`, Because previous logic cannot record the max value correctly. 
