### PR TITLE
Bring back deleteRange for RocksDB to improve location delete performance

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -337,8 +337,6 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     // Used for location index, lots of writes and much bigger dataset
     protected static final String LEDGER_METADATA_ROCKSDB_CONF = "ledgerMetadataRocksdbConf";
 
-    protected static final String ROCKSDB_DELETE_ENTRIES_BATCH_SIZE = "rocksDBDeleteEntriesBatchSize";
-
     /**
      * Construct a default configuration object.
      */
@@ -4046,26 +4044,6 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public ServerConfiguration setLedgerMetadataRocksdbConf(String ledgerMetadataRocksdbConf) {
         this.setProperty(LEDGER_METADATA_ROCKSDB_CONF, ledgerMetadataRocksdbConf);
-        return this;
-    }
-
-    /**
-     * Get entry log location index delete entries batch size from RocksDB.
-     *
-     * @return Int rocksDB delete entries batch size configured in Service configuration.
-     */
-    public int getRocksDBDeleteEntriesBatchSize() {
-        return getInt(ROCKSDB_DELETE_ENTRIES_BATCH_SIZE, 100000);
-    }
-
-    /**
-     * Set entry log location index delete entries batch size from RocksDB.
-     *
-     * @param rocksDBDeleteEntriesBatchSize
-     * @return
-     */
-    public ServerConfiguration setRocksDBDeleteEntriesBatchSize(int rocksDBDeleteEntriesBatchSize) {
-        this.setProperty(ROCKSDB_DELETE_ENTRIES_BATCH_SIZE, rocksDBDeleteEntriesBatchSize);
         return this;
     }
 }

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -756,10 +756,6 @@ gcEntryLogMetadataCacheEnabled=false
 # Default is to use 10% / numberOfLedgers of the direct memory size
 # dbStorage_rocksDB_blockCacheSize=
 
-# entry log location index delete entries batch size from RocksDB.
-# Default is 100000
-# rocksDBDeleteEntriesBatchSize=100000
-
 # Other RocksDB specific tunables
 # dbStorage_rocksDB_writeBufferSizeMB=64
 # dbStorage_rocksDB_sstSizeInMB=64


### PR DESCRIPTION
### Motivation
The entry log location index deletion is deleted in batches one by one currently, and it will have low performance. Refer to: https://github.com/apache/bookkeeper/pull/3646

Matteo has introduced deleteRange API a few years ago, but rollback due to RocksDB delete ranges bug. https://github.com/apache/bookkeeper/pull/1620.  The RocksDB bug has been addressed since 5.18.0 https://github.com/facebook/rocksdb/blob/main/HISTORY.md#5180-2018-11-30. We can bring the `deleteRange` API back to improve the entry log location deletion performance.

### Changes
Bring `deleteRange` API back for entry log location deletion.