### PR TITLE
Fix docker compose deployment

### DIFF
--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -2,23 +2,22 @@
 
 ## Requirements
 
-* Docker >= 16.10
-* Docker Compose >= 1.6.0
+* Docker >= 20.10
+* Docker Compose >= 2.12.0
 
 ## Quick start
 
 ```bash
 $ git clone https://github.com/apache/bookkeeper.git
 $ cd bookkeeper/deploy/docker-compose
-$ docker-compose pull # Get the latest Docker images
-$ docker-compose up -d
+$ docker compose pull # Get the latest Docker images
+$ docker compose up -d
 $ cd ../../
 $ bin/bkctl bookies list
 $ bin/bkctl ledger simpletest
 ```
 
 ## Access Apache BookKeeper cluster
-
 
 ### Ledger Service
 
@@ -41,13 +40,9 @@ $ bin/dlog tool create -u 'distributedlog://localhost:2181/distributedlog' --pre
 
 ### Install Helm
 
-[Helm](https://helm.sh) is used as a template render engine
+[Helm](https://helm.sh) is used as a template render engine.
 
-```
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-```
-
-Or if you use Mac, you can use homebrew to install Helm by `brew install kubernetes-helm`
+See how to [install Helm](https://helm.sh/docs/intro/install/).
 
 ### Bring up Apache BookKeeper cluster
 
@@ -56,6 +51,6 @@ $ git clone https://github.com/apache/bookkeeper.git
 $ cd bookkeeper/deploy/docker-compose
 $ vi compose/values.yaml # custom cluster size, docker image, port mapping etc
 $ helm template compose > generated-docker-compose.yaml
-$ docker-compose -f generated-docker-compose.yaml pull # Get the latest Docker images
-$ docker-compose -f generated-docker-compose.yaml up -d
+$ docker compose -f generated-docker-compose.yaml pull # Get the latest Docker images
+$ docker compose -f generated-docker-compose.yaml up -d
 ```

--- a/deploy/docker-compose/compose/Chart.yaml
+++ b/deploy/docker-compose/compose/Chart.yaml
@@ -19,10 +19,10 @@
 apiVersion: v1
 description: apache-bookkeeper-docker-compose
 name: apache-bookkeeper-docker-compose
-version: 4.8.0
+version: 4.15.3
 home: https://github.com/apache/bookkeeper
 sources:
-  - https://github.com/apache/bookkeeper/deploy/docker-compose
+  - https://github.com/apache/bookkeeper/tree/master/deploy/docker-compose
 keywords:
   - log storage
   - stream storage

--- a/deploy/docker-compose/compose/templates/docker-compose.yml
+++ b/deploy/docker-compose/compose/templates/docker-compose.yml
@@ -29,40 +29,38 @@
 {{- $bookieHttpPort := .Values.bookkeeper.bookieHttpPort | int }}
 
 {{- define "zookeeper_servers" }}
-  {{- range until (.Values.zookeeper.size | int) }}
-    {{- if . -}}
-      ,
-    {{- end -}}
-    zookeeper-{{ . }}:2181
-  {{- end -}}
+{{- range until (.Values.zookeeper.size | int) }}
+{{- if . -}}
+,
+{{- end -}}
+zookeeper-{{ add 1 . }}:2181
+{{- end -}}
 {{- end -}}
 
 {{- define "metadata_service_uri" }}
-  {{- range until (.Values.zookeeper.size | int) }}
-    {{- if . -}}
-      ;
-    {{- end -}}
-    zookeeper-{{ . }}:2181
-  {{- end -}}
+{{- range until (.Values.zookeeper.size | int) }}
+{{- if . -}}
+;
+{{- end -}}
+zookeeper-{{ add 1 . }}:2181
+{{- end -}}
 {{- end -}}
 
 
-{{- define "zookeeper_server_list" }} 
-  {{- $zk := dict "servers" (list) -}}
-  {{- range until (.Values.zookeeper.size | int) }}
-    {{- $noop := printf "server.%d=zookeeper-%d:%d:%d:participant;0.0.0.0:%d" . . ($.Values.zookeeper.peerPort | int) ($.Values.zookeeper.leaderPort | int) ($.Values.zookeeper.clientPort | int) | append $zk.servers | set $zk "servers" -}} 
-  {{- end -}}
-  {{- join " " $zk.servers -}}
+{{- define "zookeeper_server_list" }}
+{{- $zk := dict "servers" (list) -}}
+{{- range until (.Values.zookeeper.size | int) }}
+{{- $noop := printf "server.%d=zookeeper-%d:%d:%d;%d" (add 1 .) (add 1 .) ($.Values.zookeeper.peerPort | int) ($.Values.zookeeper.leaderPort | int) ($.Values.zookeeper.clientPort | int) | append $zk.servers | set $zk "servers" -}}
+{{- end -}}
+{{- join " " $zk.servers -}}
 {{- end -}}
 
 version: '3'
 
 services:
   {{- range until $zkSize }}
-  zookeeper-{{ . }}:
+  zookeeper-{{ add 1 . }}:
     image: {{ $.Values.zookeeper.image }}
-    hostname: zookeeper-{{ . }}
-    command: ["zookeeper"]
     {{- if eq $.Values.networkMode "host" }}
     network_mode: host
     {{- else }}
@@ -70,16 +68,15 @@ services:
       - "{{ add $zkAdminPort . 1000 }}:{{ $zkAdminPort }}"
       - "{{ add $zkClientPort . }}:{{ $zkClientPort }}"
     {{- end }}
+    {{- if $.Values.dataDir }}
     volumes:
-      - {{ $.Values.dataDir }}/zookeeper-{{ . }}/data:/data/zookeeper/data
-      - {{ $.Values.dataDir }}/zookeeper-{{ . }}/txlog:/data/zookeeper/txlog
+      - {{ $.Values.dataDir }}/zookeeper-{{ add 1 . }}/data:/data
+      - {{ $.Values.dataDir }}/zookeeper-{{ add 1 . }}/txlog:/datalog
+    {{- end }}
     environment:
-      - ZK_dataDir=/data/zookeeper/data
-      - ZK_dataLogDir=/data/zookeeper/txlog
-      - ZK_clientPort={{ $zkClientPort }}
-      - ZK_ID={{ . }}
-      - ZK_SERVERS={{- template "zookeeper_server_list" $ }}
-      - ZK_standaloneEnabled=false
+      - ZOO_MY_ID={{ add 1 . }}
+      - ZOO_SERVERS={{- template "zookeeper_server_list" $ }}
+      - ZOO_STANDALONE_ENABLED=false
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:{{ $zkAdminPort }}/commands/stat"]
       interval: 60s
@@ -89,9 +86,8 @@ services:
   {{ end }}
 
   {{- range until $bkSize }}
-  bookie-{{ . }}:
+  bookie-{{ add 1 . }}:
     image: {{ $.Values.bookkeeper.image }}
-    hostname: bookie-{{ . }}
     {{- if eq $.Values.networkMode "host" }}
     network_mode: host
     {{- else }}
@@ -104,13 +100,14 @@ services:
       - "{{ add $bookieHttpPort . }}:{{ $bookieHttpPort }}"
       - "{{ add $bookieGrpcPort . }}:{{ $bookieGrpcPort }}"
     {{- end }}
+    {{- if $.Values.dataDir }}
     volumes:
-      - {{ $.Values.dataDir }}/bookie-{{ . }}/journal:/data/bookkeeper/journal
-      - {{ $.Values.dataDir }}/bookie-{{ . }}/ledgers:/data/bookkeeper/ledgers
+      - {{ $.Values.dataDir }}/bookie-{{ add 1 . }}/journal:/data/bookkeeper/journal
+      - {{ $.Values.dataDir }}/bookie-{{ add 1 . }}/ledgers:/data/bookkeeper/ledgers
+    {{- end }}
     environment:
       - BK_zkServers={{- template "zookeeper_servers" $ }}
-      - BK_zkLedgersRootPath=/ledgers
-      - BK_metadataServiceUri=zk://{{- template "metadata_service_uri" $ }}/ledgers
+      - BK_metadataServiceUri=zk+hierarchical://{{- template "metadata_service_uri" $ }}/ledgers
       - BK_DATA_DIR=/data/bookkeeper
       {{- if eq $.Values.networkMode "host" }}
       - BK_bookiePort={{ $bookiePort }}
@@ -121,7 +118,7 @@ services:
       - BK_httpServerEnabled=true
     depends_on:
       {{- range until $zkSize }}
-      - "zookeeper-{{.}}"
+      - "zookeeper-{{add 1 .}}"
       {{- end }}
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:{{ $bookieHttpPort }}/heartbeat"]

--- a/deploy/docker-compose/compose/values.yaml
+++ b/deploy/docker-compose/compose/values.yaml
@@ -16,8 +16,9 @@
 # * limitations under the License.
 # */
 
-# data directories
-dataDir: ./data
+# data directories, set .e.g `./data` if you want to have
+# Zookeeper (data and datalog) and BookKeeper (journal and ledgers) volumes mounted to your host
+dataDir:
 
 # advertised address that bookies used for advertising themselves.
 # host network mode is useless on Mac, so in order to let clients
@@ -31,7 +32,7 @@ networkMode: bridge
 
 zookeeper:
   size: 3
-  image: apachebookkeeper/bookkeeper-current:latest
+  image: zookeeper:3.8.0
   adminPort: 8080
   clientPort: 2181
   peerPort: 2888
@@ -39,7 +40,7 @@ zookeeper:
 
 bookkeeper:
   size: 3
-  image: apachebookkeeper/bookkeeper-current:latest
+  image: apache/bookkeeper:4.15.3
   bookiePort: 3181
   bookieGrpcPort: 4181
   bookieHttpPort: 8080

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -22,47 +22,15 @@
 version: '3'
 
 services:
-  zookeeper-0:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: zookeeper-0
-    command: ["zookeeper"]
+  zookeeper-1:
+    image: zookeeper:3.8.0
     ports:
       - "9080:8080"
       - "2181:2181"
-    volumes:
-      - ./data/zookeeper-0/data:/data/zookeeper/data
-      - ./data/zookeeper-0/txlog:/data/zookeeper/txlog
     environment:
-      - ZK_dataDir=/data/zookeeper/data
-      - ZK_dataLogDir=/data/zookeeper/txlog
-      - ZK_clientPort=2181
-      - ZK_ID=0
-      - ZK_SERVERS=server.0=zookeeper-0:2888:3888:participant;0.0.0.0:2181 server.1=zookeeper-1:2888:3888:participant;0.0.0.0:2181 server.2=zookeeper-2:2888:3888:participant;0.0.0.0:2181
-      - ZK_standaloneEnabled=false
-    healthcheck:
-      test: ["CMD", "curl", "-s", "http://localhost:8080/commands/stat"]
-      interval: 60s
-      timeout: 3s
-      retries: 60
-    restart: on-failure
-  
-  zookeeper-1:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: zookeeper-1
-    command: ["zookeeper"]
-    ports:
-      - "9081:8080"
-      - "2182:2181"
-    volumes:
-      - ./data/zookeeper-1/data:/data/zookeeper/data
-      - ./data/zookeeper-1/txlog:/data/zookeeper/txlog
-    environment:
-      - ZK_dataDir=/data/zookeeper/data
-      - ZK_dataLogDir=/data/zookeeper/txlog
-      - ZK_clientPort=2181
-      - ZK_ID=1
-      - ZK_SERVERS=server.0=zookeeper-0:2888:3888:participant;0.0.0.0:2181 server.1=zookeeper-1:2888:3888:participant;0.0.0.0:2181 server.2=zookeeper-2:2888:3888:participant;0.0.0.0:2181
-      - ZK_standaloneEnabled=false
+      - ZOO_MY_ID=1
+      - ZOO_SERVERS=server.1=zookeeper-1:2888:3888;2181 server.2=zookeeper-2:2888:3888;2181 server.3=zookeeper-3:2888:3888;2181
+      - ZOO_STANDALONE_ENABLED=false
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:8080/commands/stat"]
       interval: 60s
@@ -71,22 +39,14 @@ services:
     restart: on-failure
   
   zookeeper-2:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: zookeeper-2
-    command: ["zookeeper"]
+    image: zookeeper:3.8.0
     ports:
-      - "9082:8080"
-      - "2183:2181"
-    volumes:
-      - ./data/zookeeper-2/data:/data/zookeeper/data
-      - ./data/zookeeper-2/txlog:/data/zookeeper/txlog
+      - "9081:8080"
+      - "2182:2181"
     environment:
-      - ZK_dataDir=/data/zookeeper/data
-      - ZK_dataLogDir=/data/zookeeper/txlog
-      - ZK_clientPort=2181
-      - ZK_ID=2
-      - ZK_SERVERS=server.0=zookeeper-0:2888:3888:participant;0.0.0.0:2181 server.1=zookeeper-1:2888:3888:participant;0.0.0.0:2181 server.2=zookeeper-2:2888:3888:participant;0.0.0.0:2181
-      - ZK_standaloneEnabled=false
+      - ZOO_MY_ID=2
+      - ZOO_SERVERS=server.1=zookeeper-1:2888:3888;2181 server.2=zookeeper-2:2888:3888;2181 server.3=zookeeper-3:2888:3888;2181
+      - ZOO_STANDALONE_ENABLED=false
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:8080/commands/stat"]
       interval: 60s
@@ -94,57 +54,39 @@ services:
       retries: 60
     restart: on-failure
   
-  bookie-0:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: bookie-0
+  zookeeper-3:
+    image: zookeeper:3.8.0
     ports:
-      - "3181:3181"
-      - "8080:8080"
-      - "4181:4181"
-    volumes:
-      - ./data/bookie-0/journal:/data/bookkeeper/journal
-      - ./data/bookie-0/ledgers:/data/bookkeeper/ledgers
+      - "9082:8080"
+      - "2183:2181"
     environment:
-      - BK_zkServers=zookeeper-0:2181,zookeeper-1:2181,zookeeper-2:2181
-      - BK_zkLedgersRootPath=/ledgers
-      - BK_metadataServiceUri=zk://zookeeper-0:2181;zookeeper-1:2181;zookeeper-2:2181/ledgers
-      - BK_DATA_DIR=/data/bookkeeper
-      - BK_advertisedAddress=127.0.0.1
-      - BK_bookiePort=3181
-      - BK_httpServerEnabled=true
-    depends_on:
-      - "zookeeper-0"
-      - "zookeeper-1"
-      - "zookeeper-2"
+      - ZOO_MY_ID=3
+      - ZOO_SERVERS=server.1=zookeeper-1:2888:3888;2181 server.2=zookeeper-2:2888:3888;2181 server.3=zookeeper-3:2888:3888;2181
+      - ZOO_STANDALONE_ENABLED=false
     healthcheck:
-      test: ["CMD", "curl", "-s", "http://localhost:8080/heartbeat"]
+      test: ["CMD", "curl", "-s", "http://localhost:8080/commands/stat"]
       interval: 60s
       timeout: 3s
       retries: 60
     restart: on-failure
   
   bookie-1:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: bookie-1
+    image: apache/bookkeeper:4.15.3
     ports:
-      - "3182:3182"
-      - "8081:8080"
-      - "4182:4181"
-    volumes:
-      - ./data/bookie-1/journal:/data/bookkeeper/journal
-      - ./data/bookie-1/ledgers:/data/bookkeeper/ledgers
+      - "3181:3181"
+      - "8080:8080"
+      - "4181:4181"
     environment:
-      - BK_zkServers=zookeeper-0:2181,zookeeper-1:2181,zookeeper-2:2181
-      - BK_zkLedgersRootPath=/ledgers
-      - BK_metadataServiceUri=zk://zookeeper-0:2181;zookeeper-1:2181;zookeeper-2:2181/ledgers
+      - BK_zkServers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      - BK_metadataServiceUri=zk+hierarchical://zookeeper-1:2181;zookeeper-2:2181;zookeeper-3:2181/ledgers
       - BK_DATA_DIR=/data/bookkeeper
       - BK_advertisedAddress=127.0.0.1
-      - BK_bookiePort=3182
+      - BK_bookiePort=3181
       - BK_httpServerEnabled=true
     depends_on:
-      - "zookeeper-0"
       - "zookeeper-1"
       - "zookeeper-2"
+      - "zookeeper-3"
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:8080/heartbeat"]
       interval: 60s
@@ -153,27 +95,22 @@ services:
     restart: on-failure
   
   bookie-2:
-    image: apachebookkeeper/bookkeeper-current:latest
-    hostname: bookie-2
+    image: apache/bookkeeper:4.15.3
     ports:
-      - "3183:3183"
-      - "8082:8080"
-      - "4183:4181"
-    volumes:
-      - ./data/bookie-2/journal:/data/bookkeeper/journal
-      - ./data/bookie-2/ledgers:/data/bookkeeper/ledgers
+      - "3182:3182"
+      - "8081:8080"
+      - "4182:4181"
     environment:
-      - BK_zkServers=zookeeper-0:2181,zookeeper-1:2181,zookeeper-2:2181
-      - BK_zkLedgersRootPath=/ledgers
-      - BK_metadataServiceUri=zk://zookeeper-0:2181;zookeeper-1:2181;zookeeper-2:2181/ledgers
+      - BK_zkServers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      - BK_metadataServiceUri=zk+hierarchical://zookeeper-1:2181;zookeeper-2:2181;zookeeper-3:2181/ledgers
       - BK_DATA_DIR=/data/bookkeeper
       - BK_advertisedAddress=127.0.0.1
-      - BK_bookiePort=3183
+      - BK_bookiePort=3182
       - BK_httpServerEnabled=true
     depends_on:
-      - "zookeeper-0"
       - "zookeeper-1"
       - "zookeeper-2"
+      - "zookeeper-3"
     healthcheck:
       test: ["CMD", "curl", "-s", "http://localhost:8080/heartbeat"]
       interval: 60s
@@ -181,4 +118,26 @@ services:
       retries: 60
     restart: on-failure
   
-
+  bookie-3:
+    image: apache/bookkeeper:4.15.3
+    ports:
+      - "3183:3183"
+      - "8082:8080"
+      - "4183:4181"
+    environment:
+      - BK_zkServers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+      - BK_metadataServiceUri=zk+hierarchical://zookeeper-1:2181;zookeeper-2:2181;zookeeper-3:2181/ledgers
+      - BK_DATA_DIR=/data/bookkeeper
+      - BK_advertisedAddress=127.0.0.1
+      - BK_bookiePort=3183
+      - BK_httpServerEnabled=true
+    depends_on:
+      - "zookeeper-1"
+      - "zookeeper-2"
+      - "zookeeper-3"
+    healthcheck:
+      test: ["CMD", "curl", "-s", "http://localhost:8080/heartbeat"]
+      interval: 60s
+      timeout: 3s
+      retries: 60
+    restart: on-failure


### PR DESCRIPTION
### Motivation

I tried to run the Apache BookKeeper server locally for learning and development purposes. I found out that the [deploy/docker-compose](https://github.com/apache/bookkeeper/tree/master/deploy/docker-compose) is using some old docker images and is not working with the latest version of BookKeeper and Zookeeper.
I updated it to work with current versions and also fixed #3657 .

### Changes
- updated images (BookKeeper and Zookeeper) to the latest official versions
- updated Helm template 
   - configuration adjusted to the latest versions
   - numeration of services starts from `1` instead of `0`
   - by default do not mount data to the host drive (empty `dataDir` value)
- updated `docker-compose.yml` according to the Helm template changes
- updated `README.md`

Master Issue: #3657

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
