### PR TITLE
Check client if closed when complete callback.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -206,7 +206,7 @@ class LedgerOpenOp {
                             }
                             if (rc == BKException.Code.UnauthorizedAccessException
                                     || rc == BKException.Code.TimeoutException) {
-                                openComplete(rc, null);
+                                openComplete(bk.getReturnRc(rc), null);
                             } else {
                                 openComplete(bk.getReturnRc(BKException.Code.LedgerRecoveryException), null);
                             }


### PR DESCRIPTION
### Motivation

Follow the same rules to complete the callback to avoid Bookkeeper client operations being allowed even after its closure.

### Changes

- Use `bk.getReturnRc(rc)` check the client state.