### PR TITLE
[fix][server]fix memory leak when operating ledger metadata

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -34,14 +35,12 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.Processor;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.zookeeper.AsyncCallback;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A ledger manager that cleans up resources upon closing.
  */
+@Slf4j
 public class CleanupLedgerManager implements LedgerManager {
-    private static final Logger LOG = LoggerFactory.getLogger(CleanupLedgerManager.class);
 
     private class CleanupGenericCallback<T> implements GenericCallback<T> {
 
@@ -117,9 +116,14 @@ public class CleanupLedgerManager implements LedgerManager {
         promise.whenComplete((result, exception) -> {
             futures.remove(promise);
             if (exception != null) {
-                LOG.error("Failed on operating ledger metadata: {}", BKException.getExceptionCode(exception));
+                log.error("Failed on operating ledger metadata: {}", BKException.getExceptionCode(exception));
             }
         });
+    }
+
+    @VisibleForTesting
+    int getCurrentFuturePromiseSize() {
+        return futures.size();
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/CleanupLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/CleanupLedgerManagerTest.java
@@ -1,0 +1,56 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.meta;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test of {@link CleanupLedgerManager}.
+ */
+public class CleanupLedgerManagerTest {
+
+    protected LedgerManager ledgerManager = null;
+    protected CleanupLedgerManager cleanupLedgerManager = null;
+
+    @Before
+    public void setup() throws Exception {
+        ledgerManager = mock(LedgerManager.class);
+        CompletableFuture<Versioned<LedgerMetadata>> future = new CompletableFuture<>();
+        future.completeExceptionally(new Exception("LedgerNotExistException"));
+        when(ledgerManager.readLedgerMetadata(anyLong())).thenReturn(future);
+        cleanupLedgerManager = new CleanupLedgerManager(ledgerManager);
+    }
+
+    @Test
+    public void testReadLedgerMetadataException() throws Exception {
+        cleanupLedgerManager.readLedgerMetadata(anyLong());
+        Assert.assertEquals(0, cleanupLedgerManager.getCurrentFuturePromiseSize());
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/CleanupLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/CleanupLedgerManagerTest.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,7 +15,6 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
 package org.apache.bookkeeper.meta;
@@ -24,6 +22,7 @@ package org.apache.bookkeeper.meta;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.versioning.Versioned;


### PR DESCRIPTION
### Motivation
There is a memory leak point in Bookkeeper client, see the following heap report:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/4970972/203212033-09337cf0-afd1-4b0c-9ddf-3ba246e85849.png">

It happens when opening a non-existent or expired ledger data. The following screen shot is memeory leak point by [Eclipse Memory Analyzer](https://www.eclipse.org/mat/).
<img width="799" alt="image" src="https://user-images.githubusercontent.com/4970972/203212114-d75cfcbc-f8d1-4880-977f-aa1847acb837.png">


### Changes
Handle exception and clean up when promise complete exceptionally.

Master Issue: [#1](https://github.com/HQebupt/bookkeeper/pull/1)
