### PR TITLE
Exit bookkeeper shell correctly even if fails to run for some reason

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -2397,50 +2397,56 @@ public class BookieShell implements Tool {
         }
     }
 
-    public static void main(String[] argv) throws Exception {
-        BookieShell shell = new BookieShell();
+    public static void main(String[] argv) {
+        int res = -1;
+        try {
+            BookieShell shell = new BookieShell();
 
-        // handle some common options for multiple cmds
-        Options opts = new Options();
-        opts.addOption(CONF_OPT, true, "configuration file");
-        opts.addOption(LEDGERID_FORMATTER_OPT, true, "format of ledgerId");
-        opts.addOption(ENTRY_FORMATTER_OPT, true, "format of entries");
-        BasicParser parser = new BasicParser();
-        CommandLine cmdLine = parser.parse(opts, argv, true);
+            // handle some common options for multiple cmds
+            Options opts = new Options();
+            opts.addOption(CONF_OPT, true, "configuration file");
+            opts.addOption(LEDGERID_FORMATTER_OPT, true, "format of ledgerId");
+            opts.addOption(ENTRY_FORMATTER_OPT, true, "format of entries");
+            BasicParser parser = new BasicParser();
+            CommandLine cmdLine = parser.parse(opts, argv, true);
 
-        // load configuration
-        CompositeConfiguration conf = new CompositeConfiguration();
-        if (cmdLine.hasOption(CONF_OPT)) {
-            String val = cmdLine.getOptionValue(CONF_OPT);
-            conf.addConfiguration(new PropertiesConfiguration(
-                    new File(val).toURI().toURL()));
-        }
-        shell.setConf(conf);
+            // load configuration
+            CompositeConfiguration conf = new CompositeConfiguration();
+            if (cmdLine.hasOption(CONF_OPT)) {
+                String val = cmdLine.getOptionValue(CONF_OPT);
+                conf.addConfiguration(new PropertiesConfiguration(
+                        new File(val).toURI().toURL()));
+            }
+            shell.setConf(conf);
 
-        // ledgerid format
-        if (cmdLine.hasOption(LEDGERID_FORMATTER_OPT)) {
-            String val = cmdLine.getOptionValue(LEDGERID_FORMATTER_OPT);
-            shell.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(val, shell.bkConf);
-        } else {
-            shell.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(shell.bkConf);
-        }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Using ledgerIdFormatter {}", shell.ledgerIdFormatter.getClass());
-        }
+            // ledgerid format
+            if (cmdLine.hasOption(LEDGERID_FORMATTER_OPT)) {
+                String val = cmdLine.getOptionValue(LEDGERID_FORMATTER_OPT);
+                shell.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(val, shell.bkConf);
+            } else {
+                shell.ledgerIdFormatter = LedgerIdFormatter.newLedgerIdFormatter(shell.bkConf);
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using ledgerIdFormatter {}", shell.ledgerIdFormatter.getClass());
+            }
 
-        // entry format
-        if (cmdLine.hasOption(ENTRY_FORMATTER_OPT)) {
-            String val = cmdLine.getOptionValue(ENTRY_FORMATTER_OPT);
-            shell.entryFormatter = EntryFormatter.newEntryFormatter(val, shell.bkConf);
-        } else {
-            shell.entryFormatter = EntryFormatter.newEntryFormatter(shell.bkConf);
-        }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Using entry formatter {}", shell.entryFormatter.getClass());
-        }
+            // entry format
+            if (cmdLine.hasOption(ENTRY_FORMATTER_OPT)) {
+                String val = cmdLine.getOptionValue(ENTRY_FORMATTER_OPT);
+                shell.entryFormatter = EntryFormatter.newEntryFormatter(val, shell.bkConf);
+            } else {
+                shell.entryFormatter = EntryFormatter.newEntryFormatter(shell.bkConf);
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using entry formatter {}", shell.entryFormatter.getClass());
+            }
 
-        int res = shell.run(cmdLine.getArgs());
-        System.exit(res);
+            res = shell.run(cmdLine.getArgs());
+        } catch (Throwable e) {
+            LOG.error("Got an exception", e);
+        } finally {
+            System.exit(res);
+        }
     }
 
     private synchronized void initEntryLogger() throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/HierarchicalLedgerManager.java
@@ -122,4 +122,15 @@ class HierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
     protected String getLedgerParentNodeRegex() {
         return StringUtils.HIERARCHICAL_LEDGER_PARENT_NODE_REGEX;
     }
+
+    @Override
+    public void close() {
+        super.close();
+        if (legacyLM != null) {
+            legacyLM.close();
+        }
+        if (longLM != null) {
+            longLM.close();
+        }
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListLedgersCommand.java
@@ -157,7 +157,9 @@ public class ListLedgersCommand extends BookieCommand<ListLedgersFlags> {
                                 }
                                 cb.processResult(BKException.Code.OK, null, null);
                             } else if (BKException.getExceptionCode(exception)
-                                      == BKException.Code.NoSuchLedgerExistsException) {
+                                        == BKException.Code.NoSuchLedgerExistsException
+                                    || BKException.getExceptionCode(exception)
+                                        == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
                                 cb.processResult(BKException.Code.OK, null, null);
                             } else {
                                 LOG.error("Unable to read the ledger: {} information", ledgerId);


### PR DESCRIPTION
### Motivation

When I run `bookkeeper shell listledgers` command and get exception like the below, the shell process doesn't exit forever. I expect shell processes will exit soon.

```
...
06:00:02.801 [main-EventThread] ERROR o.a.b.t.c.c.b.ListLedgersCommand     - Unable to read the ledger: 15256124 information
06:00:02.805 [main-EventThread] ERROR o.a.b.p.BookkeeperInternalCallbacks  - Error in multi callback : -25
06:00:02.807 [main] ERROR o.a.b.t.c.c.b.ListLedgersCommand     - Received error return value while processing ledgers: -1
06:00:02.810 [main] ERROR o.a.b.t.c.c.b.ListLedgersCommand     - Received Exception while processing ledgers
org.apache.bookkeeper.client.BKException$BKReadException: Error while reading ledger
        at org.apache.bookkeeper.client.BKException.create(BKException.java:62)
        at org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand.lambda$handler$3(ListLedgersCommand.java:176)
        at org.apache.bookkeeper.meta.MetadataDrivers.lambda$runFunctionWithLedgerManagerFactory$2(MetadataDrivers.java:389)
        at org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithMetadataBookieDriver(MetadataDrivers.java:347)
        at org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithLedgerManagerFactory(MetadataDrivers.java:387)
        at org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand.handler(ListLedgersCommand.java:127)
        at org.apache.bookkeeper.tools.cli.commands.bookie.ListLedgersCommand.apply(ListLedgersCommand.java:99)
        at org.apache.bookkeeper.bookie.BookieShell$ListLedgersCmd.runCmd(BookieShell.java:704)
        at org.apache.bookkeeper.bookie.BookieShell$MyCommand.runCmd(BookieShell.java:236)
        at org.apache.bookkeeper.bookie.BookieShell.run(BookieShell.java:2235)
        at org.apache.bookkeeper.bookie.BookieShell.main(BookieShell.java:2326)
...
```

I encountered the issue in the v4.12.0 client.

### Changes

* Close legacyLM and longLM if call HierarchicalLedgerManager#close
  - legacyLM and longLM have [inner scheduler](https://github.com/apache/bookkeeper/blob/e4ef0ef7f4f989e46f854c92ac7684325f050a60/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java#L87). In this case, these schedulers are not shut down.
* Exit as ok when calling listledgers command and get NoSuchLedgerExistsOnMetadataServerException
* Call `System.exit` even if get some exception in bookkeeler shell