### PR TITLE
Dont validate CompactionInterval when compaction is disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -3164,10 +3164,10 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             throw new ConfigurationException("For persisiting explicitLac, journalFormatVersionToWrite should be >= 6"
                     + "and FileInfoFormatVersionToWrite should be >= 1");
         }
-        if (getMinorCompactionInterval() * SECOND < getGcWaitTime()) {
+        if (getMinorCompactionInterval() > 0 && getMinorCompactionInterval() * SECOND < getGcWaitTime()) {
             throw new ConfigurationException("minorCompactionInterval should be >= gcWaitTime.");
         }
-        if (getMajorCompactionInterval() * SECOND < getGcWaitTime()) {
+        if (getMajorCompactionInterval() > 0 && getMajorCompactionInterval() * SECOND < getGcWaitTime()) {
             throw new ConfigurationException("majorCompactionInterval should be >= gcWaitTime.");
         }
     }


### PR DESCRIPTION
### Motivation
Currently, We cannot disable minorCompaction and majorCompaction by setting interval to -1, with `gcWaitTime` is  enabled.

### Changes
Don't validate CompactionInterval if compaction is disabled
