### PR TITLE
Run CI when a pull request contains doc changes

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -1,0 +1,16 @@
+# contains pattern definitions used in workflows "changes" step
+# pattern syntax: https://github.com/micromatch/picomatch
+all:
+  - '**'
+docs:
+  - 'site3/**'
+  - '.asf.yaml'
+  - '*.md'
+  - '**/*.md'
+  - '.github/changes-filter.yaml'
+  - '.github/ISSUE_TEMPLATE/**'
+need_owasp:
+  - 'pom.xml'
+  - '**/pom.xml'
+  - 'src/owasp-dependency-check-false-positives.xml'
+  - 'src/owasp-dependency-check-suppressions.xml'

--- a/.github/workflows/backward-compat-tests.yml
+++ b/.github/workflows/backward-compat-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,20 +66,20 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 1.8
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - name: Install Module
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu clean install -DskipTests
       - name: Test current server with old clients
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -DintegrationTests -pl :backward-compat-current-server-old-clients test
       - name: Test progressive upgrade
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -DintegrationTests -pl :upgrade test
       - name: Other tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: |
           mvn -B -nsu -DintegrationTests -pl :bc-non-fips,:hierarchical-ledger-manager,:hostname-bookieid,:old-cookie-new-cluster,:recovery-no-password,:upgrade-direct,:yahoo-custom-version test

--- a/.github/workflows/bookie-tests.yml
+++ b/.github/workflows/bookie-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,22 +66,22 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Maven build bookkeeper-server
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -am -pl bookkeeper-server clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Run bookie tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -pl bookkeeper-server test -Dtest="org.apache.bookkeeper.bookie.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Run shell tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -pl tests/scripts install -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,13 +66,13 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Run client tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -am -nsu -pl bookkeeper-server clean install test -Dtest="org.apache.bookkeeper.client.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/compatibility-check-java11.yml
+++ b/.github/workflows/compatibility-check-java11.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,13 +66,13 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Build with Maven
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn clean package -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/compatibility-check-java17.yml
+++ b/.github/workflows/compatibility-check-java17.yml
@@ -45,12 +45,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -61,13 +65,13 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 17
       - name: Build with Maven
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn clean package -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/.github/workflows/compatibility-check-java8.yml
+++ b/.github/workflows/compatibility-check-java8.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,12 +66,12 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 1.8
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - name: Build with Maven
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn clean package spotbugs:check -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,22 +66,22 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Build with Maven
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu clean install -Pdocker -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Run metadata driver tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -f metadata-drivers/pom.xml test -DintegrationTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Run all integration tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -f tests/pom.xml test -DintegrationTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -42,12 +42,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -58,12 +62,12 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: mvn package
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu clean package -DskipTests

--- a/.github/workflows/owasp-dep-check.yml
+++ b/.github/workflows/owasp-dep-check.yml
@@ -44,17 +44,15 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
-      - name: Detect changed pom files
+      - name: Detect changed files
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            poms:
-              - 'pom.xml'
-              - '**/pom.xml'
+          filters: .github/changes-filter.yaml
+          list-files: csv
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.poms == 'true' }}
+        if: ${{ steps.changes.outputs.need_owasp == 'true' }}
         id: cache
         uses: actions/cache@v2
         with:
@@ -66,12 +64,12 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.poms == 'true' }}
+        if: ${{ steps.changes.outputs.need_owasp == 'true' }}
         with:
           java-version: 1.8
 
       - name: run "clean install verify" to trigger dependency check
-        if: ${{ steps.changes.outputs.poms == 'true' }}
+        if: ${{ steps.changes.outputs.need_owasp == 'true' }}
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyways
         run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,19 +66,19 @@ jobs:
           key: ${{ runner.os }}-bookkeeper-all-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Validate pull request
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn clean -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         
       - name: Check license files
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: dev/check-all-licenses
 
       - name: Generate Javadoc
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn clean -B -nsu -am -pl bookkeeper-common,bookkeeper-server,:bookkeeper-stats-api,:bookkeeper-stats-providers,:codahale-metrics-provider,:prometheus-metrics-provider install javadoc:aggregate -DskipTests -Pdelombok

--- a/.github/workflows/remaining-tests.yml
+++ b/.github/workflows/remaining-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -64,13 +68,13 @@ jobs:
 
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Run remaining tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -am -pl bookkeeper-server clean install test -Dtest="!org.apache.bookkeeper.client.**,!org.apache.bookkeeper.bookie.**,!org.apache.bookkeeper.replication.**,!org.apache.bookkeeper.tls.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/replication-tests.yml
+++ b/.github/workflows/replication-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -63,13 +67,13 @@ jobs:
 
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Run replication tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -am -pl bookkeeper-server clean install test -Dtest="org.apache.bookkeeper.replication.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/stream-tests.yml
+++ b/.github/workflows/stream-tests.yml
@@ -45,12 +45,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -62,16 +66,16 @@ jobs:
 
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Build with Maven
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
       - name: Run StreamStorage tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu -f stream/pom.xml verify -DstreamTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/tls-tests.yml
+++ b/.github/workflows/tls-tests.yml
@@ -46,12 +46,16 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -63,13 +67,13 @@ jobs:
 
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Run tls tests
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -am -nsu -pl bookkeeper-server clean install test -Dtest="org.apache.bookkeeper.tls.**" -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -42,16 +42,20 @@ jobs:
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          filters: |
-            site3:
-              - 'site3/**'
+          filters: .github/changes-filter.yaml
+          list-files: csv
+
+      - name: Check changed files
+        id: check_changes
+        run: |
+          echo "docs_only=${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}" >> $GITHUB_OUTPUT
 
       - name: Install mingw
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: choco install mingw
 
       - name: Cache local Maven repository
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         id: cache
         uses: actions/cache@v2
         with:
@@ -63,12 +67,12 @@ jobs:
 
 
       - name: Set up JDK 11
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: mvn package
-        if: steps.changes.outputs.site3 != 'true'
+        if: steps.check_changes.outputs.docs_only != 'true'
         run: mvn -B -nsu clean package -DskipTests

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java
@@ -22,7 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -32,9 +33,6 @@ import org.apache.bookkeeper.http.service.HttpServiceResponse;
 import org.apache.bookkeeper.tools.cli.commands.bookie.SanityTestCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * HttpEndpointService that exposes the bookie sanity state.


### PR DESCRIPTION
### Motivation

Master build fails due to checsktyle

```
Error:  /home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java:26:1: Extra separation in import group before 'org.apache.bookkeeper.common.util.JsonUtil' [ImportOrder]
Error:  /home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java:36:1: Extra separation in import group before 'lombok.Data' [ImportOrder]
Error:  /home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java:36:1: Import lombok.Data appears after other imports that it should precede [ImportOrder]
```

The problem is that if a pull contains doc changes, all CI checks are skipped

### Changes

* Improve checks changes detection to skip code tests only if the changes are ONLY about docs
* Same as above for owasp check
