### PR TITLE
[fix][server]fix memory leak when closeRecovered,failed on clearing newEnsemblesFromRecovery

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -331,8 +331,7 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
                 newEnsemblesFromRecovery.clear();
             }
             if (exception != null) {
-                LOG.error("When closeRecovered,failed on clearing newEnsemblesFromRecovery: {}",
-                        BKException.getExceptionCode(exception));
+                LOG.error("When closeRecovered,failed on clearing newEnsemblesFromRecovery.", exception);
             }
         });
         return f;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOnlyLedgerHandle.java
@@ -326,11 +326,15 @@ class ReadOnlyLedgerHandle extends LedgerHandle implements LedgerMetadataListene
                     return builder.withClosedState().withLastEntryId(lac).withLength(len).build();
                 },
                 this::setLedgerMetadata).run();
-        f.thenRun(() -> {
-                synchronized (metadataLock) {
-                    newEnsemblesFromRecovery.clear();
-                }
-            });
+        f.whenComplete((result, exception) -> {
+            synchronized (metadataLock) {
+                newEnsemblesFromRecovery.clear();
+            }
+            if (exception != null) {
+                LOG.error("When closeRecovered,failed on clearing newEnsemblesFromRecovery: {}",
+                        BKException.getExceptionCode(exception));
+            }
+        });
         return f;
     }
 


### PR DESCRIPTION
### Motivation

change Future.thenRun to Future.whenComplete in the bookie project there are places that must be released.
1) the first place is updated in  #3662 
2) the second place is this pr: #3672 

the condition that the bug triggers:
1) when future handle exception, thenRun will be ignored to run

### Changes
1) handle exception and clean up when promise complete exceptionally.
2) org.apache.bookkeeper.client.LedgerRecovery2Test#testFirstWriterCannotCommitWriteAfter2ndWriterCloses has cover this pr, so no need to add a new testcase
