### PR TITLE
[refactor] [server] Refactor ByteBuf release method in InterleavedLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -36,6 +36,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -374,7 +375,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
                     lac = bb.readLong();
                     lac = ledgerCache.updateLastAddConfirmed(ledgerId, lac);
                 } finally {
-                    bb.release();
+                    ReferenceCountUtil.safeRelease(bb);
                 }
             }
         }


### PR DESCRIPTION
### Motivation

It may throw an exception when release a ByteBuf object. so the exception in ByteBuf.release should be checked.

### Changes
1) Use ReferenceCountUtil.safeRelease() instead of ByteBuf.release() in InterleavedLedgerStorage 
