### PR TITLE
Add an argument to decide expose the default JVM metrics

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -877,6 +877,10 @@ zkEnableSecurity=false
 # latency stats rollover interval, in seconds
 # prometheusStatsLatencyRolloverSeconds=60
 
+# Expose the default JVM Metrics or not. If you are using the BookKeeper as an embedded service and you want to 
+# expose metrics in your application, you might need to disable this to avoid the JVM metrics register duplicated.
+# exposeDefaultJVMMetrics=true
+
 #############################################################################
 ## Codahale Metrics Provider
 #############################################################################


### PR DESCRIPTION
---

###Motivation

Expose the default JVM Metrics or not. If you are using the BookKeeper as an embedded service and you want to expose metrics in your application, you might need to disable this to avoid the JVM metrics register duplicated.

### Modification

- Add a configuration variable to decide whether or not to expose the JVM metrics

