### PR TITLE
Make `jvm_memory_direct_bytes_used` metrics compatible with jdk8.

### DIFF
--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -51,7 +51,11 @@
        <groupId>io.netty</groupId>
        <artifactId>netty-common</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -221,7 +221,6 @@ public class PrometheusMetricsProvider implements StatsProvider {
      */
     private static AtomicLong directMemoryUsage;
     private static Optional<BufferPoolMXBean> poolMxBeanOp;
-    
     private static Supplier<Long> getDirectMemoryUsage;
 
     static {

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -43,7 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.stats.ThreadRegistry;
@@ -233,7 +232,7 @@ public class PrometheusMetricsProvider implements StatsProvider {
             log.warn("Failed to access netty DIRECT_MEMORY_COUNTER field {}", t.getMessage());
         }
         directMemoryUsage = tmpDirectMemoryUsage;
-    
+
         List<BufferPoolMXBean> platformMXBeans = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
         poolMxBeanOp = platformMXBeans.stream()
                 .filter(bufferPoolMXBean -> bufferPoolMXBean.getName().equals("direct")).findAny();

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -21,13 +21,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import lombok.Cleanup;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -22,10 +22,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.io.StringWriter;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import lombok.Cleanup;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -131,7 +133,7 @@ public class TestPrometheusMetricsProvider {
         config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, true);
         config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_PORT, 0);
         config.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ADDRESS, "127.0.0.1");
-        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(25);
+        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.directBuffer(25);
         PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
         try {
             provider.start(config);
@@ -154,7 +156,7 @@ public class TestPrometheusMetricsProvider {
             Assert.assertNotEquals("Nan", directBytesUsed);
             Assert.assertTrue(Double.parseDouble(directBytesUsed) > 25);
             // ensure byteBuffer doesn't gc
-            byteBuffer.clear();
+            byteBuf.release();
         } finally {
             provider.stop();
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:
In #3252, it only uses poolMxBeanOp to get direct memory usage. It only works in jdk11.
But if the user still uses the old version, netty still uses `NoCleanerConstructor` ByteBuffer to allocate direct memory, the poolMxBeanOp didn't cover it.
We should check the netty `PlatformDependent.useDirectBufferNoCleaner()`, then choose the corresponding way to get direct memory usage.
