### PR TITLE
[refactor][bookkeeper] Refactor ByteBuf release method in  tools

### DIFF
--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
@@ -26,6 +26,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -389,7 +390,7 @@ public class JournalWriter implements Runnable {
                     buf,
                     false,
                     (rc, ledgerId, entryId, addr, ctx) -> {
-                        buf.release();
+                        ReferenceCountUtil.safeRelease(buf);
                         if (0 == rc) {
                             if (null != semaphore) {
                                 semaphore.release(len);

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.tools.perf.table;
 import com.google.common.util.concurrent.RateLimiter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -89,7 +90,7 @@ abstract class IncrementTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                keyBuf.release();
+                ReferenceCountUtil.safeRelease(keyBuf);
             });
     }
 

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -95,8 +96,8 @@ abstract class WriteTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                keyBuf.release();
-                valBuf.release();
+                ReferenceCountUtil.safeRelease(keyBuf);
+                ReferenceCountUtil.safeRelease(valBuf);
             });
     }
 


### PR DESCRIPTION
### Motivation
It may throw an exception when release  a `ByteBuf` object.  So the exception in `ByteBuf.release` should be checked.

### Changes
Use `ReferenceCountUtil.safeRelease()` instead of `ByteBuf.release()`.

Master Issue: [#3](https://github.com/HQebupt/bookkeeper/pull/3)
