### PR TITLE
[refactor] [server] Refactor ByteBuf release method in module bookkeeper-server

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -30,6 +30,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -1271,7 +1272,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                      * (METAENTRY_ID_LEDGER_EXPLICITLAC) to Journal.
                      */
                     memoryLimitController.releaseMemory(qe.entry.readableBytes());
-                    qe.entry.release();
+                    ReferenceCountUtil.safeRelease(qe.entry);
                 } else if (qe.entryId != BookieImpl.METAENTRY_ID_FORCE_LEDGER) {
                     int entrySize = qe.entry.readableBytes();
                     journalStats.getJournalWriteBytes().addCount(entrySize);
@@ -1287,7 +1288,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     bc.write(lenBuff);
                     bc.write(qe.entry);
                     memoryLimitController.releaseMemory(qe.entry.readableBytes());
-                    qe.entry.release();
+                    ReferenceCountUtil.safeRelease(qe.entry);
                 }
 
                 toFlush.add(qe);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
@@ -24,6 +24,7 @@ import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -142,7 +143,7 @@ public class EntryCopierImpl implements EntryCopier {
                         } catch (Throwable t) {
                             promise.completeExceptionally(t);
                         } finally {
-                            buffer.release();
+                            ReferenceCountUtil.safeRelease(buffer);
                         }
                     }
                 });

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -30,6 +30,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -455,7 +456,7 @@ public class DirectEntryLogger implements EntryLogger {
             writer.writeAt(0, buf);
             writer.position(buf.capacity());
         } finally {
-            buf.release();
+            ReferenceCountUtil.safeRelease(buf);
         }
         return writer;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
@@ -25,6 +25,7 @@ import static org.apache.bookkeeper.common.util.ExceptionMessageHelper.exMsg;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +91,7 @@ class DirectReader implements LogReader {
         try {
             readIntoBufferAt(buf, offset, size);
         } catch (IOException e) {
-            buf.release();
+            ReferenceCountUtil.safeRelease(buf);
             throw e;
         }
 
@@ -120,7 +121,7 @@ class DirectReader implements LogReader {
                 try {
                     return intBuf.getInt(0);
                 } finally {
-                    intBuf.release();
+                    ReferenceCountUtil.safeRelease(intBuf);
                 }
             }
         }
@@ -137,7 +138,7 @@ class DirectReader implements LogReader {
                 try {
                     return longBuf.getLong(0);
                 } finally {
-                    longBuf.release();
+                    ReferenceCountUtil.safeRelease(longBuf);
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
@@ -24,6 +24,7 @@ import static org.apache.bookkeeper.common.util.ExceptionMessageHelper.exMsg;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
@@ -107,14 +108,14 @@ class LogMetadata {
                 throw e;
             }
         } finally {
-            serializedMap.release();
+            ReferenceCountUtil.safeRelease(serializedMap);
         }
         ByteBuf buf = allocator.buffer(Buffer.ALIGNMENT);
         try {
             Header.writeHeader(buf, ledgerMapOffset, numberOfLedgers);
             writer.writeAt(0, buf);
         } finally {
-            buf.release();
+            ReferenceCountUtil.safeRelease(buf);
         }
         writer.flush();
     }
@@ -177,7 +178,7 @@ class LogMetadata {
                                               .toString());
                     }
                 } finally {
-                    ledgerMapBuffer.release();
+                    ReferenceCountUtil.safeRelease(ledgerMapBuffer);
                 }
             }
             return meta;
@@ -185,7 +186,7 @@ class LogMetadata {
             throw new IOException(exMsg("Error reading index").kv("logId", reader.logId())
                                   .kv("reason", ioe.getMessage()).toString(), ioe);
         } finally {
-            header.release();
+            ReferenceCountUtil.safeRelease(header);
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogReaderScan.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogReaderScan.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.bookie.storage.directentrylogger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import org.apache.bookkeeper.bookie.storage.EntryLogScanner;
 
@@ -55,7 +56,7 @@ class LogReaderScan {
                 offset += entrySize;
             }
         } finally {
-            entry.release();
+            ReferenceCountUtil.safeRelease(entry);
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ReadCache.java
@@ -25,6 +25,7 @@ import static org.apache.bookkeeper.bookie.storage.ldb.WriteCache.align64;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,7 @@ public class ReadCache implements Closeable {
 
     @Override
     public void close() {
-        cacheSegments.forEach(ByteBuf::release);
+        cacheSegments.forEach(ReferenceCountUtil::safeRelease);
     }
 
     public void put(long ledgerId, long entryId, ByteBuf entry) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -173,7 +174,7 @@ public class BookieJournalTest {
 
             fc.write(lenBuff);
             fc.write(packet.nioBuffer());
-            packet.release();
+            ReferenceCountUtil.safeRelease(packet);
         }
     }
 
@@ -217,7 +218,7 @@ public class BookieJournalTest {
 
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            packet.release();
+            ReferenceCountUtil.safeRelease(packet);
         }
         bc.flushAndForceWrite(false);
 
@@ -251,7 +252,7 @@ public class BookieJournalTest {
 
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            packet.release();
+            ReferenceCountUtil.safeRelease(packet);
         }
         bc.flushAndForceWrite(false);
 
@@ -284,7 +285,7 @@ public class BookieJournalTest {
             lenBuff.flip();
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            packet.release();
+            ReferenceCountUtil.safeRelease(packet);
         }
         // write fence key
         ByteBuf packet = generateFenceEntry(1);
@@ -332,7 +333,7 @@ public class BookieJournalTest {
             }
             bc.write(lenBuff);
             bc.write(packet);
-            packet.release();
+            ReferenceCountUtil.safeRelease(packet);
             Journal.writePaddingBytes(jc, paddingBuff, JournalChannel.SECTOR_SIZE);
         }
         // write fence key

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.spy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -183,14 +184,14 @@ public class CheckpointOnNewLedgersTest {
             assertNotNull(entry);
             assertEquals(l2, entry.readLong());
             assertEquals((long) i, entry.readLong());
-            entry.release();
+            ReferenceCountUtil.safeRelease(entry);
         }
 
         ByteBuf entry = newBookie.readEntry(l1, 0L);
         assertNotNull(entry);
         assertEquals(l1, entry.readLong());
         assertEquals(0L, entry.readLong());
-        entry.release();
+        ReferenceCountUtil.safeRelease(entry);
         newBookie.shutdown();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -138,15 +139,15 @@ public class TestDirectEntryLogger {
             ByteBuf e2read = elog.readEntry(ledgerId1, 2L, loc2);
             assertEntryEquals(e1read, e1);
             assertEntryEquals(e2read, e2);
-            e1read.release();
-            e2read.release();
+            ReferenceCountUtil.safeRelease(e1read);
+            ReferenceCountUtil.safeRelease(e2read);
 
             long loc3 = elog.addEntry(ledgerId1, e3.slice());
             elog.flush();
 
             ByteBuf e3read = elog.readEntry(ledgerId1, 3L, loc3);
             assertEntryEquals(e3read, e3);
-            e3read.release();
+            ReferenceCountUtil.safeRelease(e3read);
         }
     }
 
@@ -199,7 +200,7 @@ public class TestDirectEntryLogger {
             }
             elog.flush();
             for (Long loc : locations) {
-                elog.readEntry(loc).release();
+                ReferenceCountUtil.safeRelease(elog.readEntry(loc));
             }
             assertThat(outstandingReaders.get(), equalTo(maxCachedReaders));
         } finally {


### PR DESCRIPTION
### Motivation

It may throw an exception when release a ByteBuf object. so the exception in ByteBuf.release should be checked.

### Changes
1) Use ReferenceCountUtil.safeRelease() instead of ByteBuf.release() in module bookkeeper-server
