### PR TITLE
[refactor] [server] Refactor ByteBuf release method in module distributedlog-core/distributedlog-protocol

### DIFF
--- a/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
+++ b/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 
@@ -70,9 +71,9 @@ public class TestCompressionCodec {
         decompressedBuf.readBytes(decompressedData);
         assertArrayEquals("The decompressed bytes should be same as the original bytes",
                 data, decompressedData);
-        buf.release();
-        compressedBuf.release();
-        decompressedBuf.release();
+        ReferenceCountUtil.safeRelease(buf);
+        ReferenceCountUtil.safeRelease(compressedBuf);
+        ReferenceCountUtil.safeRelease(decompressedBuf);
     }
 
     private void testCompressionCodec2(CompressionCodec codec) throws Exception {
@@ -93,9 +94,9 @@ public class TestCompressionCodec {
         byte[] decompressedData = new byte[decompressedBuf.readableBytes()];
         decompressedBuf.slice().readBytes(decompressedData);
 
-        buffer.release();
-        compressedBuf.release();
-        decompressedBuf.release();
+        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.safeRelease(compressedBuf);
+        ReferenceCountUtil.safeRelease(decompressedBuf);
     }
 
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
@@ -157,14 +157,14 @@ class EnvelopedRecordSetWriter implements LogRecordSet.Writer {
     @Override
     public synchronized void completeTransmit(long lssn, long entryId, long startSlotId) {
         satisfyPromises(lssn, entryId, startSlotId);
-        buffer.release();
-        ReferenceCountUtil.release(recordSetBuffer);
+        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.safeRelease(recordSetBuffer);
     }
 
     @Override
     public synchronized void abortTransmit(Throwable reason) {
         cancelPromises(reason);
-        buffer.release();
-        ReferenceCountUtil.release(recordSetBuffer);
+        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.safeRelease(recordSetBuffer);
     }
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -225,7 +226,7 @@ public class LogRecord {
 
     void setPayloadBuf(ByteBuf payload, boolean copyData) {
         if (null != this.payload) {
-            this.payload.release();
+            ReferenceCountUtil.safeRelease(this.payload);
         }
         if (copyData) {
             this.payload = Unpooled.copiedBuffer(payload);


### PR DESCRIPTION
### Motivation

It may throw an exception when release a ByteBuf object. so the exception in ByteBuf.release should be checked.

### Changes
1) Use ReferenceCountUtil.safeRelease() instead of ByteBuf.release() in module distributedlog-core/distributedlog-protocol
