### PR TITLE
[refactor][bookkeeper] Refactor ByteBuf release method in bookkeeper-server

### DIFF
--- a/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
+++ b/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
@@ -29,6 +29,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.common.allocator.ByteBufAllocatorBuilder;
@@ -229,17 +230,17 @@ public class ByteBufAllocatorBuilderTest {
         ByteBuf buf1 = alloc.buffer();
         assertEquals(pooledAlloc, buf1.alloc());
         assertFalse(buf1.hasArray());
-        buf1.release();
+        ReferenceCountUtil.safeRelease(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertEquals(pooledAlloc, buf2.alloc());
         assertFalse(buf2.hasArray());
-        buf2.release();
+        ReferenceCountUtil.safeRelease(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertEquals(pooledAlloc, buf3.alloc());
         assertTrue(buf3.hasArray());
-        buf3.release();
+        ReferenceCountUtil.safeRelease(buf3);
     }
 
     @Test
@@ -255,14 +256,14 @@ public class ByteBufAllocatorBuilderTest {
         assertEquals(PooledByteBufAllocator.class, buf1.alloc().getClass());
         assertEquals(3, ((PooledByteBufAllocator) buf1.alloc()).metric().numDirectArenas());
         assertFalse(buf1.hasArray());
-        buf1.release();
+        ReferenceCountUtil.safeRelease(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertFalse(buf2.hasArray());
-        buf2.release();
+        ReferenceCountUtil.safeRelease(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertTrue(buf3.hasArray());
-        buf3.release();
+        ReferenceCountUtil.safeRelease(buf3);
     }
 }

--- a/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
+++ b/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
@@ -29,7 +29,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.common.allocator.ByteBufAllocatorBuilder;
@@ -230,17 +229,17 @@ public class ByteBufAllocatorBuilderTest {
         ByteBuf buf1 = alloc.buffer();
         assertEquals(pooledAlloc, buf1.alloc());
         assertFalse(buf1.hasArray());
-        ReferenceCountUtil.safeRelease(buf1);
+        buf1.release();
 
         ByteBuf buf2 = alloc.directBuffer();
         assertEquals(pooledAlloc, buf2.alloc());
         assertFalse(buf2.hasArray());
-        ReferenceCountUtil.safeRelease(buf2);
+        buf2.release();
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertEquals(pooledAlloc, buf3.alloc());
         assertTrue(buf3.hasArray());
-        ReferenceCountUtil.safeRelease(buf3);
+        buf3.release();
     }
 
     @Test
@@ -256,14 +255,14 @@ public class ByteBufAllocatorBuilderTest {
         assertEquals(PooledByteBufAllocator.class, buf1.alloc().getClass());
         assertEquals(3, ((PooledByteBufAllocator) buf1.alloc()).metric().numDirectArenas());
         assertFalse(buf1.hasArray());
-        ReferenceCountUtil.safeRelease(buf1);
+        buf1.release();
 
         ByteBuf buf2 = alloc.directBuffer();
         assertFalse(buf2.hasArray());
-        ReferenceCountUtil.safeRelease(buf2);
+        buf2.release();
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertTrue(buf3.hasArray());
-        ReferenceCountUtil.safeRelease(buf3);
+        buf3.release();
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -31,6 +31,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.IOException;
@@ -657,7 +658,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     currentEntryLocation += 4 + entry.readableBytes();
                     currentEntryLogId = currentEntryLocation >> 32;
                 } finally {
-                    entry.release();
+                    ReferenceCountUtil.safeRelease(entry);
                 }
             }
         } catch (Exception e) {
@@ -940,7 +941,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 lac = bb.readLong();
                 lac = getOrAddLedgerInfo(ledgerId).setLastAddConfirmed(lac);
             } finally {
-                bb.release();
+                ReferenceCountUtil.safeRelease(bb);
             }
         }
         return lac;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -31,6 +31,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.util.EnumSet;
@@ -269,7 +270,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                 pcbc.writeLac(ledgerId, masterKey, lac, toSend, cb, ctx);
             }
 
-            toSend.release();
+            ReferenceCountUtil.safeRelease(toSend);
         }, ledgerId, useV3Enforced);
     }
 
@@ -410,7 +411,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                               toSend, cb, ctx, options, allowFastFail, writeFlags);
             }
 
-            toSend.release();
+            ReferenceCountUtil.safeRelease(toSend);
             recycle();
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -333,7 +333,7 @@ public interface BookieProtocol {
         }
 
         void release() {
-            data.release();
+            ReferenceCountUtil.safeRelease(data);
         }
 
         private final Handle<ParsedAddRequest> recyclerHandle;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -61,6 +61,7 @@ import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringSocketChannel;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.IOException;
@@ -838,7 +839,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             // usually checked in writeAndFlush, but we have extra check
             // because we need to release toSend.
             errorOut(completionKey);
-            toSend.release();
+            ReferenceCountUtil.safeRelease(toSend);
             return;
         } else {
             // addEntry times out on backpressure
@@ -1943,7 +1944,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             handleReadResponse(readResponse.getLedgerId(),
                                readResponse.getEntryId(),
                                status, buffer, maxLAC, lacUpdateTimestamp);
-            buffer.release(); // meaningless using unpooled, but client may expect to hold the last reference
+            ReferenceCountUtil.safeRelease(
+                    buffer); // meaningless using unpooled, but client may expect to hold the last reference
         }
 
         private void handleReadResponse(long ledgerId,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.util.Recycler;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.BookieException;
@@ -101,7 +102,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             // some bad request which cause unexpected exception
             rc = BookieProtocol.EBADREQ;
         } finally {
-            addData.release();
+            ReferenceCountUtil.safeRelease(addData);
         }
 
         if (rc != BookieProtocol.EOK) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -115,7 +115,7 @@ public abstract class DigestManager {
         final ByteBuf unwrapped = data.unwrap() != null && data.unwrap() instanceof CompositeByteBuf
                 ? data.unwrap() : data;
         ReferenceCountUtil.retain(unwrapped);
-        ReferenceCountUtil.release(data);
+        ReferenceCountUtil.safeRelease(data);
 
         if (unwrapped instanceof CompositeByteBuf) {
             ((CompositeByteBuf) unwrapped).forEach(this::update);
@@ -182,7 +182,7 @@ public abstract class DigestManager {
                 throw new BKDigestMatchException();
             }
         } finally {
-            digest.release();
+            ReferenceCountUtil.safeRelease(digest);
         }
 
         long actualLedgerId = dataReceived.readLong();
@@ -222,7 +222,7 @@ public abstract class DigestManager {
                 throw new BKDigestMatchException();
             }
         } finally {
-            digest.release();
+            ReferenceCountUtil.safeRelease(digest);
         }
 
         long actualLedgerId = dataReceived.readLong();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -357,7 +358,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
 
         storage.flush();
 
@@ -370,7 +371,7 @@ public class DbLedgerStorageTest {
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
 
         ByteBuf entry1 = Unpooled.buffer(1024);
         entry1.writeLong(1); // ledger id
@@ -381,21 +382,21 @@ public class DbLedgerStorageTest {
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
 
         storage.flush();
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        res.release();
+        ReferenceCountUtil.safeRelease(res);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCacheTest.java
@@ -30,6 +30,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.nio.charset.Charset;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
@@ -78,7 +79,7 @@ public class WriteCacheTest {
         assertEquals(0, cache.count());
         assertEquals(0, cache.size());
 
-        entry1.release();
+        ReferenceCountUtil.safeRelease(entry1);
         cache.close();
     }
 
@@ -119,7 +120,7 @@ public class WriteCacheTest {
 
         assertEquals(0, findCount.get());
 
-        entry.release();
+        ReferenceCountUtil.safeRelease(entry);
         cache.close();
     }
 


### PR DESCRIPTION
### Motivation
It may throw an exception when release  a `ByteBuf` object.  So the exception in `ByteBuf.release` should be checked.

### Changes
Use `ReferenceCountUtil.safeRelease()` instead of `ByteBuf.release()`.

Master Issue: [#4](https://github.com/HQebupt/bookkeeper/pull/4)
