### PR TITLE
Fix Flaky Tests

### DIFF
--- a/bookkeeper-slogger/api/src/test/java/org/apache/bookkeeper/slogger/SloggerTest.java
+++ b/bookkeeper-slogger/api/src/test/java/org/apache/bookkeeper/slogger/SloggerTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.junit.Test;
 
@@ -80,7 +81,7 @@ public class SloggerTest {
     @Test
     public void testMap() throws Exception {
         MockSlogger root = new MockSlogger();
-        HashMap<Integer, Integer> map = new HashMap<>();
+        HashMap<Integer, Integer> map = new LinkedHashMap<>();
         map.put(1, 3);
         map.put(2, 4);
         root.kv("map", map).info(Events.FOOBAR);


### PR DESCRIPTION
Descriptions of the changes in this PR:

The test in org.apache.bookkeeper.slogger.SloggerTest#testMap express non-deterministic behaviour and change the order of the attributes. The fix is changing HashMap to LinkedHashMap to ensure determinism.

### Motivation

Fixing non-deterministic flaky tests.

### Changes

Changed the HashMap to LinkedHashMap in test code.

Master Issue: #3701 

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [x] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [x] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
