### PR TITLE
[improvement ]Avoid leaks  when use computeIfAbsent in ConcurrentLongHashMap and ConcurrentOpenHashMap

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -382,6 +382,9 @@ public class ConcurrentLongHashMap<V> {
         }
 
         V put(long key, V value, int keyHash, boolean onlyIfAbsent, LongFunction<V> valueProvider) {
+            if (value == null) {
+                checkNotNull(valueProvider.apply(key));
+            }
             int bucket = keyHash;
 
             long stamp = writeLock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -357,6 +357,9 @@ public class ConcurrentOpenHashMap<K, V> {
         }
 
         V put(K key, V value, int keyHash, boolean onlyIfAbsent, Function<K, V> valueProvider) {
+            if (value == null) {
+                checkNotNull(valueProvider.apply(key));
+            }
             long stamp = writeLock();
             int bucket = signSafeMod(keyHash, capacity);
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMapTest.java
@@ -606,6 +606,28 @@ public class ConcurrentLongHashMapTest {
         assertEquals(map.get(2).intValue(), 2);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testPutWhenNull() {
+        ConcurrentLongHashMap<Integer> map = ConcurrentLongHashMap.<Integer>newBuilder()
+                .expectedItems(5)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+        map.put(0, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testComputeIfAbsentWhenNull() {
+        ConcurrentLongHashMap<Integer> map = ConcurrentLongHashMap.<Integer>newBuilder()
+                .expectedItems(5)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+
+        LongFunction<Integer> nullProvider = key -> null;
+        map.computeIfAbsent(0, nullProvider);
+    }
+
     static final int Iterations = 1;
     static final int ReadIterations = 100;
     static final int N = 1_000_000;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.LongFunction;
 import org.junit.Test;
 
 /**
@@ -458,6 +459,27 @@ public class ConcurrentOpenHashMapTest {
 
         assertEquals(map.computeIfAbsent(2, provider).intValue(), 2);
         assertEquals(map.get(2).intValue(), 2);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPutWhenNull() {
+        ConcurrentOpenHashMap<Integer, Integer> map = ConcurrentOpenHashMap.<Integer, Integer>newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .build();
+        map.put(0, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testComputeIfAbsentWhenNull() {
+        ConcurrentOpenHashMap<Integer, Integer> map = ConcurrentOpenHashMap.<Integer, Integer>newBuilder()
+                .expectedItems(16)
+                .concurrencyLevel(1)
+                .autoShrink(true)
+                .build();
+
+        Function<Integer, Integer>  nullProvider = key -> null;
+        map.computeIfAbsent(0, nullProvider);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMapTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.LongFunction;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
 Fix  #3705
# Motivation
When use computeIfAbsent  in ConcurrentLongHashMap and ConcurrentOpenHashMap:
![image](https://user-images.githubusercontent.com/39521534/208232691-ca21ea1f-f4a3-4da5-8e7a-b081f8756791.png)
There are following problems:
1. According to the logic of the get function, it is equivalent to not inserting the key-value pair(Key Not found), and it is meaningless for valueProvider.apply(key) to return null, but we have not prevented such things from happening
2. When valueProvider.apply(key) returns null, unnecessary expansion will be performed at this time, and it cannot be recycled. It can only wait for reuse, which will cause leakage
