### PR TITLE
[improve] replace bookie from different rack of other quorum when do recovery

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -471,9 +471,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                 LOG.debug("Try to choose a new bookie to replace {} from ensemble {}, excluding {}.",
                     bookieToReplace, ensembleNodes, excludeNodes);
             }
-            // pick a candidate from same rack to replace
+            // pick a candidate from different rack of excludeNodes to replace
             BookieNode candidate = selectFromNetworkLocation(
-                    bn.getNetworkLocation(),
                     networkLocationsToBeExcluded,
                     excludeNodes,
                     TruePredicate.INSTANCE,


### PR DESCRIPTION
### Motivation

If we need to do recovery when one bookie down, in the current RackAwarePolicy, it would try picking a candidate from same rack to replace the down bookie firstly. There is a risk that if many bookie in the same rack shutdown, it would result in replacing bookie to the several bookie remain in this rack, making these bookies become hot spot.  

### Changes

choose the replaced bookie from different rack of other quorum when do recovery or do ensemble change.


