### PR TITLE
Added new way to self-invite to BK Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For filing bugs, suggesting improvements, or requesting new features, help us ou
 
 [Subscribe](mailto:dev-subscribe@bookkeeper.apache.org) or [mail](mailto:dev@bookkeeper.apache.org) the [dev@bookkeeper.apache.org](mailto:dev@bookkeeper.apache.org) list - Join development discussions, propose new ideas and connect with contributors.
 
-[Join us on Slack](https://apachebookkeeper.herokuapp.com/) - This is the most immediate way to connect with Apache BookKeeper committers and contributors.
+[Join us on Slack](https://communityinviter.com/apps/apachebookkeeper/apache-bookkeeper) - This is the most immediate way to connect with Apache BookKeeper committers and contributors.
 
 ## Contributing
 

--- a/site3/website/src/pages/community/slack.md
+++ b/site3/website/src/pages/community/slack.md
@@ -4,4 +4,4 @@ There is an [Apache BookKeeper](http://apachebookkeeper.slack.com/) channel that
 
 The Slack channel is at [http://apachebookkeeper.slack.com/](http://apachebookkeeper.slack.com/).
 
-You can self-register at [https://apachebookkeeper.herokuapp.com/](https://apachebookkeeper.herokuapp.com/).
+You can self-register at [https://communityinviter.com/apps/apachebookkeeper/apache-bookkeeper](https://communityinviter.com/apps/apachebookkeeper/apache-bookkeeper).


### PR DESCRIPTION
### Motivation

The Slack auto-invite app on Heroku has stopped working. Adding a different Slack app to allow users to auto-invite.