### PR TITLE
Expose registrationClient in DefaultBookieAddressResolver.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -37,6 +37,10 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
         this.registrationClient = registrationClient;
     }
 
+    public RegistrationClient getRegistrationClient() {
+        return registrationClient;
+    }
+
     @Override
     public BookieSocketAddress resolve(BookieId bookieId) {
         try {


### PR DESCRIPTION
Descriptions of the changes in this PR:
In some cases, we need  RegistrationClient to do some work, so expose the registration client.
See comment https://github.com/apache/pulsar/pull/18672#discussion_r1059624499.