### PR TITLE
Add parameters check on ledger creation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -859,9 +859,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     public void asyncCreateLedger(final int ensSize, final int writeQuorumSize, final int ackQuorumSize,
                                   final DigestType digestType, final byte[] passwd,
                                   final CreateCallback cb, final Object ctx, final Map<String, byte[]> customMetadata) {
-        if (writeQuorumSize < ackQuorumSize) {
-            throw new IllegalArgumentException("Write quorum must be larger than ack quorum");
-        }
+        checkLedgerCreationParameters(ensSize, writeQuorumSize, ackQuorumSize);
         closeLock.readLock().lock();
         try {
             if (closed) {
@@ -1058,9 +1056,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
     public void asyncCreateLedgerAdv(final int ensSize, final int writeQuorumSize, final int ackQuorumSize,
             final DigestType digestType, final byte[] passwd, final CreateCallback cb, final Object ctx,
             final Map<String, byte[]> customMetadata) {
-        if (writeQuorumSize < ackQuorumSize) {
-            throw new IllegalArgumentException("Write quorum must be larger than ack quorum");
-        }
+        checkLedgerCreationParameters(ensSize, writeQuorumSize, ackQuorumSize);
         closeLock.readLock().lock();
         try {
             if (closed) {
@@ -1165,9 +1161,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
                                      final CreateCallback cb,
                                      final Object ctx,
                                      final Map<String, byte[]> customMetadata) {
-        if (writeQuorumSize < ackQuorumSize) {
-            throw new IllegalArgumentException("Write quorum must be larger than ack quorum");
-        }
+        checkLedgerCreationParameters(ensSize, writeQuorumSize, ackQuorumSize);
         closeLock.readLock().lock();
         try {
             if (closed) {
@@ -1662,5 +1656,18 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
     public ClientContext getClientCtx() {
         return clientCtx;
+    }
+
+    private void checkLedgerCreationParameters(int ensSize, int writeQuorumSize, int ackQuorumSize) {
+        if (ensSize <= 0
+            || writeQuorumSize <= 0
+            || ackQuorumSize <= 0
+            || writeQuorumSize > ensSize
+            || ackQuorumSize > writeQuorumSize) {
+            LOG.error("Illegal parameter: ensembleSize: {}, writeQuorumSize: {}, ackQuorumSize: {}",
+                ensSize, writeQuorumSize, ackQuorumSize);
+            throw new IllegalArgumentException(String.format("Illegal arguments, ensembleSize: %s, "
+                + "writeQuorumSize: %s, ackQuorumSize: %s", ensSize, writeQuorumSize, ackQuorumSize));
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -1127,4 +1127,165 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @Test
+    public void testCreateLedgerWithIllegalArguments() throws Exception {
+        final byte[] PASSWD = "testpasswd".getBytes();
+        final byte[] data = "data".getBytes();
+        int ensSize = 0;
+        int writeQuorumSize = 0;
+        int ackQuorumSize = 0;
+
+        try {
+            LedgerHandle lh = bkc.createLedger(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 3;
+            writeQuorumSize = 3;
+            ackQuorumSize = -1;
+            LedgerHandle lh = bkc.createLedger(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 2;
+            writeQuorumSize = 3;
+            ackQuorumSize = 1;
+            LedgerHandle lh = bkc.createLedger(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 2;
+            writeQuorumSize = 2;
+            ackQuorumSize = 3;
+            LedgerHandle lh = bkc.createLedger(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 3;
+            writeQuorumSize = 3;
+            ackQuorumSize = 2;
+            LedgerHandle lh = bkc.createLedger(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        try {
+            ensSize = 0;
+            writeQuorumSize = 0;
+            ackQuorumSize = 0;
+            LedgerHandle lh = bkc.createLedgerAdv(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 3;
+            writeQuorumSize = 3;
+            ackQuorumSize = -1;
+            LedgerHandle lh = bkc.createLedgerAdv(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 2;
+            writeQuorumSize = 3;
+            ackQuorumSize = 1;
+            LedgerHandle lh = bkc.createLedgerAdv(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 2;
+            writeQuorumSize = 2;
+            ackQuorumSize = 3;
+            LedgerHandle lh = bkc.createLedgerAdv(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(data);
+            }
+            lh.close();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(String.format("Illegal arguments, ensembleSize: %s, writeQuorumSize: %s, ackQuorumSize: %s",
+                ensSize, writeQuorumSize, ackQuorumSize), e.getMessage());
+        }
+
+        try {
+            ensSize = 3;
+            writeQuorumSize = 3;
+            ackQuorumSize = 2;
+            LedgerHandle lh = bkc.createLedgerAdv(ensSize, writeQuorumSize, ackQuorumSize,
+                BookKeeper.DigestType.CRC32, PASSWD);
+            for (int i = 0; i < 10; ++i) {
+                lh.addEntry(i, data);
+            }
+            lh.close();
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
When the BookKeeper client creates a ledger with illegal parameters, such as `EnsembleSize = 0`, `WriteQuorumSize = 0`, and `AckQuorumSize = 0`, the ledger can be created successfully. However, when we use the ledgerHandle to write entries into this ledger, the write operation will be blocked without any logs or exceptions. It will be hard to debug.

### Modification
Add parameters check on ledger creation.