### PR TITLE
Upgrade dependency-check-maven plugin to fix broken OWASP check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
+    <dependency-check-maven.version>8.0.2</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>7.1.2</dependency-check-maven.version>
+    <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -228,10 +228,12 @@
 
   <suppress>
     <notes><![CDATA[
-       file name: snakeyaml-1.32.jar
-       ]]></notes>
-    <sha1>e80612549feb5c9191c498de628c1aa80693cf0b</sha1>
-    <cve>CVE-2022-1471</cve>
+    snakeyaml is not "fixing" CVE-2022-1471.
+    see: https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE%20&%20NIST.md
+         https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+    <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
   </suppress>
 
   <suppress>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -217,6 +217,11 @@
     </suppress>
 
   <suppress>
+    <notes>fredsmith utils library is not used at all. CVE-2021-4277 is a false positive.</notes>
+    <cve>CVE-2021-4277</cve>
+  </suppress>
+
+  <suppress>
     <notes>yaml_project is not used at all. Any CVEs reported for yaml_project are false positives.</notes>
     <cpe>cpe:/a:yaml_project:yaml</cpe>
   </suppress>
@@ -228,5 +233,12 @@
     <sha1>e80612549feb5c9191c498de628c1aa80693cf0b</sha1>
     <cve>CVE-2022-1471</cve>
   </suppress>
-</suppressions>
 
+  <suppress>
+    <notes><![CDATA[
+   file name: testng-7.5.jar
+   ]]></notes>
+    <sha1>1416a607fae667c14e390b484e8d02b5824c0674</sha1>
+    <vulnerabilityName>CVE-2022-4065</vulnerabilityName>
+  </suppress>
+</suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -215,5 +215,18 @@
         <sha1>68d4180c51468ae8f45869f8f9c569092262fcca</sha1>
         <cve>CVE-2021-26291</cve>
     </suppress>
+
+  <suppress>
+    <notes>yaml_project is not used at all. Any CVEs reported for yaml_project are false positives.</notes>
+    <cpe>cpe:/a:yaml_project:yaml</cpe>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+       file name: snakeyaml-1.32.jar
+       ]]></notes>
+    <sha1>e80612549feb5c9191c498de628c1aa80693cf0b</sha1>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
 </suppressions>
 


### PR DESCRIPTION
### Motivation

- 7.4.4 includes fix for issue https://github.com/jeremylong/DependencyCheck/issues/5220

    Error:  org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569'
    org.owasp.dependencycheck.data.update.exception.UpdateException: org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569'
    ...
    Caused by: org.h2.jdbc.JdbcBatchUpdateException: Value too long for column "VERSIONENDEXCLUDING CHARACTER VARYING(60)": "'0.0.0-20160722212129-ac0cc4484ad4_before_v0.0.0-20200131131040-063a3fb69896' (75)"; SQL statement:

### Changes

Upgrade dependency-check maven plugin to 8.0.2 version.