### PR TITLE
Pin order executor in LedgerHandle

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -101,7 +101,7 @@ public class LedgerHandle implements WriteHandle {
     final byte[] ledgerKey;
     private Versioned<LedgerMetadata> versionedMetadata;
     final long ledgerId;
-    final ExecutorService orderExecutor;
+    final ExecutorService executor;
     long lastAddPushed;
 
     private enum HandleState {
@@ -196,7 +196,7 @@ public class LedgerHandle implements WriteHandle {
         this.pendingAddsSequenceHead = lastAddConfirmed;
 
         this.ledgerId = ledgerId;
-        this.orderExecutor = clientCtx.getMainWorkerPool().chooseThread(ledgerId);
+        this.executor = clientCtx.getMainWorkerPool().chooseThread(ledgerId);
 
         if (clientCtx.getConf().enableStickyReads
                 && getLedgerMetadata().getEnsembleSize() == getLedgerMetadata().getWriteQuorumSize()) {
@@ -2088,7 +2088,7 @@ public class LedgerHandle implements WriteHandle {
      * @throws RejectedExecutionException
      */
     void executeOrdered(Runnable runnable) throws RejectedExecutionException {
-        orderExecutor.execute(runnable);
+        executor.execute(runnable);
     }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -46,6 +46,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +101,7 @@ public class LedgerHandle implements WriteHandle {
     final byte[] ledgerKey;
     private Versioned<LedgerMetadata> versionedMetadata;
     final long ledgerId;
+    final ExecutorService orderExecutor;
     long lastAddPushed;
 
     private enum HandleState {
@@ -194,6 +196,7 @@ public class LedgerHandle implements WriteHandle {
         this.pendingAddsSequenceHead = lastAddConfirmed;
 
         this.ledgerId = ledgerId;
+        this.orderExecutor = clientCtx.getMainWorkerPool().chooseThread(ledgerId);
 
         if (clientCtx.getConf().enableStickyReads
                 && getLedgerMetadata().getEnsembleSize() == getLedgerMetadata().getWriteQuorumSize()) {
@@ -2085,7 +2088,7 @@ public class LedgerHandle implements WriteHandle {
      * @throws RejectedExecutionException
      */
     void executeOrdered(Runnable runnable) throws RejectedExecutionException {
-        clientCtx.getMainWorkerPool().executeOrdered(ledgerId, runnable);
+        orderExecutor.execute(runnable);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -82,16 +82,11 @@ public class MockLedgerHandle extends LedgerHandle {
 
         fenced = true;
         try {
-            bk.executor.execute(() -> cb.closeComplete(0, this, ctx));
+            executeOrdered(() -> cb.closeComplete(0, this, ctx));
         } catch (RejectedExecutionException e) {
             cb.closeComplete(0, this, ctx);
         }
 
-    }
-
-    @Override
-    void executeOrdered(Runnable runnable) throws RejectedExecutionException {
-        bk.executor.execute(runnable);
     }
 
     @Override
@@ -101,7 +96,7 @@ public class MockLedgerHandle extends LedgerHandle {
             return;
         }
 
-        bk.executor.execute(new Runnable() {
+        executeOrdered(new Runnable() {
             public void run() {
                 if (bk.getProgrammedFailStatus()) {
                     cb.readComplete(bk.failReturnCode, MockLedgerHandle.this, null, ctx);
@@ -188,7 +183,7 @@ public class MockLedgerHandle extends LedgerHandle {
         }
 
         data.retain();
-        bk.executor.execute(new Runnable() {
+        executeOrdered(new Runnable() {
             public void run() {
                 if (bk.getProgrammedFailStatus()) {
                     fenced = true;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
@@ -56,7 +56,7 @@ class MockReadHandle implements ReadHandle {
             return promise;
         }
 
-        bk.executor.execute(() -> {
+        bk.orderedExecutor.chooseThread().execute(() -> {
                 if (bk.getProgrammedFailStatus()) {
                     promise.completeExceptionally(BKException.create(bk.failReturnCode));
                     return;


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Pin the order executor in `LedgerHandle`  to save the choose thread overhead. For details reason:

We could call `executeOrdered()` frequently, e.g., when in `asyncReadEntries`. And we would compute the thread index from ledgerId every time when call `executeOrdered()`. So pin the order executor will save the thread index compution time.

### Changes

- Choose the order executor in `LedgerHandle`  constructor method and save it as a final field
- Override `getMainWorkerPool()` in `MockBookKeeper` to fix UT NPE exception when call `this.executor = clientCtx.getMainWorkerPool().chooseThread(ledgerId);` 

