### PR TITLE
Fix potential direct memory leak of add request

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -113,6 +113,10 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
                 if (response instanceof BookieProtocol.Response) {
                     ((BookieProtocol.Response) response).release();
                 }
+                if (request instanceof BookieProtocol.ParsedAddRequest) {
+                    ((BookieProtocol.ParsedAddRequest) request).release();
+                    request.recycle();
+                }
                 return;
             } else {
                 requestProcessor.invalidateBlacklist(channel);
@@ -129,6 +133,10 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
         } else {
             if (response instanceof BookieProtocol.Response) {
                 ((BookieProtocol.Response) response).release();
+            }
+            if (request instanceof BookieProtocol.ParsedAddRequest) {
+                ((BookieProtocol.ParsedAddRequest) request).release();
+                request.recycle();
             }
             logger.debug("Netty channel {} is inactive, "
                     + "hence bypassing netty channel writeAndFlush during sendResponse", channel);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -111,6 +111,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             sendWriteReqResponse(rc,
                          ResponseBuilder.buildErrorResponse(rc, request),
                          requestProcessor.getRequestStats().getAddRequestStats());
+            request.release();
             request.recycle();
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -111,7 +111,6 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             sendWriteReqResponse(rc,
                          ResponseBuilder.buildErrorResponse(rc, request),
                          requestProcessor.getRequestStats().getAddRequestStats());
-            request.release();
             request.recycle();
         }
     }


### PR DESCRIPTION
### Motivation
Fixes #3737

### Changes
release the ParsedAddRequest if the connection is disconnected. 

I tested in my test env, the first bookie fixed this issue, the second not.
![image](https://user-images.githubusercontent.com/9278488/212660198-40f7974d-ea65-4085-bca9-054da11855c9.png)
