### PR TITLE
Remove unnecessary hasExplicitLac check

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -988,13 +988,11 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             }
             return null;
         }
-        if (ledgerData.hasExplicitLac()) {
-            if (log.isDebugEnabled()) {
-                log.debug("getExplicitLac ledger {} returned from LedgerData", ledgerId);
-            }
-            ByteString persistedLac = ledgerData.getExplicitLac();
-            ledgerInfo.setExplicitLac(Unpooled.wrappedBuffer(persistedLac.toByteArray()));
+        if (log.isDebugEnabled()) {
+            log.debug("getExplicitLac ledger {} returned from LedgerData", ledgerId);
         }
+        ByteString persistedLac = ledgerData.getExplicitLac();
+        ledgerInfo.setExplicitLac(Unpooled.wrappedBuffer(persistedLac.toByteArray()));
         return ledgerInfo.getExplicitLac();
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Remove the unnecessary `ledgerData.hasExplicitLac()` check,  because we have check it at Line985

### Changes

Remove the unnecessary `ledgerData.hasExplicitLac()` check

