### PR TITLE
Fix ForceWriteRequest recycle problem

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -443,6 +443,11 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
         private void recycle() {
             logFile = null;
+            shouldClose = false;
+            isMarker = false;
+            enqueueTime = -1;
+            logId = -1;
+            lastFlushedPosition = -1;
             if (forceWriteWaiters != null) {
                 forceWriteWaiters.recycle();
                 forceWriteWaiters = null;


### PR DESCRIPTION
The ForceWriteRequest is recycled without resetting properties.

![image](https://user-images.githubusercontent.com/9278488/213381537-7b2e6c9d-a7a6-4905-b343-58983ac168e8.png)
