### PR TITLE
Fix the duplicated JournalQueueStats

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1128,10 +1128,6 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                             qe = localQueueEntries.removeFirst();
                             dequeueStartTime = MathUtils.nowInNano();
                             busyStartTime = dequeueStartTime;
-                            journalStats.getJournalQueueSize().dec();
-                            journalStats.getJournalQueueStats()
-                                    .registerSuccessfulEvent(MathUtils.elapsedNanos(qe.enqueueTime),
-                                            TimeUnit.NANOSECONDS);
                         } else {
                             long pollWaitTimeNanos = maxGroupWaitInNanos
                                     - MathUtils.elapsedNanos(toFlush.get(0).enqueueTime);


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

It seems that  L1131-1132 is duplicated of L1146-1147, so we need remove the first one.

https://github.com/apache/bookkeeper/blob/7b5b6b240ca7551da266903078f2dd2ba2906b96/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java#L1126-L1148

### Changes

Remove the duplicated JournalQueueStats

