### PR TITLE
Bump hadoop-common from 3.2.4 to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <grpc.version>1.47.0</grpc.version>
     <guava.version>31.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
-    <hadoop.version>3.2.4</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.13.4.20221013</jackson.version>


### PR DESCRIPTION
### Motivation
Bump hadoop-common from 3.2.4 to 3.3.4 to avoid indirect dependent security vulnerabilities, such as **commons-text**

### Changes

Bump hadoop-common from 3.2.4 to 3.3.4
