### PR TITLE
Fix ReadEntryProcessor v2 SchedulingDelayStats

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -166,10 +166,11 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
 
     @Override
     public void run() {
-        if (this instanceof ReadEntryProcessor) {
+        if (request instanceof BookieProtocol.ReadRequest) {
             requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats()
                     .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
-        } else {
+        }
+        if (request instanceof BookieProtocol.ParsedAddRequest) {
             requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
                     .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -166,8 +166,14 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
 
     @Override
     public void run() {
-        requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
-                .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        if (this instanceof ReadEntryProcessor) {
+            requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats().registerSuccessfulEvent(
+                    MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        } else {
+            requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
+                    .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        }
+
         if (!isVersionCompatible()) {
             sendResponse(BookieProtocol.EBADVERSION,
                          ResponseBuilder.buildErrorResponse(BookieProtocol.EBADVERSION, request),

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -167,8 +167,8 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
     @Override
     public void run() {
         if (this instanceof ReadEntryProcessor) {
-            requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats().registerSuccessfulEvent(
-                    MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+            requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats()
+                    .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         } else {
             requestProcessor.getRequestStats().getWriteThreadQueuedLatency()
                     .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

We registered `ReadEntrySchedulingDelayStats` of `ReadEntryProcessor` as `WriteThreadQueuedLatency` mistakenly, so we need fix it.

### Changes

Register `ReadEntrySchedulingDelayStats`  if `ReadEntryProcessor`

