### PR TITLE
Add push trigger condition for CI

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -24,6 +24,10 @@ on:
     branches:
       - master
       - branch-*
+  push:
+    branches:
+      - master
+      - branch-*
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### Motivation

1. Make code coverage have a base branch to diff.
2. Every PR may not sync and merge the latest master code, so we need to run CI for the target branch after a PR merged.
