### PR TITLE
Fix release AddsSemaphore if version not compatible

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -175,7 +175,7 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
             if (request instanceof BookieProtocol.ReadRequest) {
                 requestProcessor.onReadRequestFinish();
             }
-            if (request instanceof BookieProtocol.AddRequest) {
+            if (request instanceof BookieProtocol.ParsedAddRequest) {
                 requestProcessor.onAddRequestFinish();
             }
             return;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/WriteEntryProcessorTest.java
@@ -277,7 +277,7 @@ public class WriteEntryProcessorTest {
         assertEquals(1, requestProcessor.getAddsSemaphore().availablePermits());
 
         request = ParsedAddRequest.create(
-                (byte)-1, // 0 is lowest protocol version which will work with the bookie
+                (byte) -1, // 0 is lowest protocol version which will work with the bookie
                 System.currentTimeMillis(),
                 System.currentTimeMillis() + 1,
                 (short) 0,


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix release AddsSemaphore if version not compatible.  We should use `BookieProtocol.ParsedAddRequest` in server instead of `BookieProtocol.AddRequest`

### Changes 

- Change `AddRequest` to `ParsedAddRequest`. 
- Add a test `WriteEntryProcessorTest#testVersionNotCompatible` to verfiy it

