### PR TITLE
[improve] Fix indexDirs upgrade failed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -99,7 +99,12 @@ public class FileSystemUpgrade {
     private static List<File> getAllDirectories(ServerConfiguration conf) {
         List<File> dirs = new ArrayList<>();
         dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
-        Collections.addAll(dirs, conf.getLedgerDirs());
+        final File[] ledgerDirs = conf.getLedgerDirs();
+        final File[] indexDirs = conf.getIndexDirs();
+        if (indexDirs != null && indexDirs != ledgerDirs) {
+            dirs.addAll(Lists.newArrayList(indexDirs));
+        }
+        Collections.addAll(dirs, ledgerDirs);
         return dirs;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -24,6 +24,7 @@ package org.apache.bookkeeper.bookie;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithRegistrationManager;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.File;
@@ -97,13 +98,14 @@ public class FileSystemUpgrade {
             }
         };
 
-    private static List<File> getAllDirectories(ServerConfiguration conf) {
+    @VisibleForTesting
+    public static List<File> getAllDirectories(ServerConfiguration conf) {
         List<File> dirs = new ArrayList<>();
         dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
         final File[] ledgerDirs = conf.getLedgerDirs();
         final File[] indexDirs = conf.getIndexDirs();
-        if (indexDirs != null
-                && !Arrays.asList(indexDirs).equals(Arrays.asList(ledgerDirs))) {
+        if (indexDirs != null && indexDirs.length == ledgerDirs.length
+                && !Arrays.asList(indexDirs).containsAll(Arrays.asList(ledgerDirs))) {
             dirs.addAll(Lists.newArrayList(indexDirs));
         }
         Collections.addAll(dirs, ledgerDirs);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -31,6 +31,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +102,8 @@ public class FileSystemUpgrade {
         dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
         final File[] ledgerDirs = conf.getLedgerDirs();
         final File[] indexDirs = conf.getIndexDirs();
-        if (indexDirs != null && indexDirs != ledgerDirs) {
+        if (indexDirs != null &&
+                !Arrays.asList(indexDirs).equals(Arrays.asList(ledgerDirs))) {
             dirs.addAll(Lists.newArrayList(indexDirs));
         }
         Collections.addAll(dirs, ledgerDirs);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/FileSystemUpgrade.java
@@ -102,8 +102,8 @@ public class FileSystemUpgrade {
         dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
         final File[] ledgerDirs = conf.getLedgerDirs();
         final File[] indexDirs = conf.getIndexDirs();
-        if (indexDirs != null &&
-                !Arrays.asList(indexDirs).equals(Arrays.asList(ledgerDirs))) {
+        if (indexDirs != null
+                && !Arrays.asList(indexDirs).equals(Arrays.asList(ledgerDirs))) {
             dirs.addAll(Lists.newArrayList(indexDirs));
         }
         Collections.addAll(dirs, ledgerDirs);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -183,7 +183,8 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
         return ledgerDir;
     }
 
-    private static void testUpgradeProceedure(String zkServers, String journalDir, String ledgerDir, String indexDir) throws Exception {
+    private static void testUpgradeProceedure(String zkServers, String journalDir, String ledgerDir, String indexDir)
+            throws Exception {
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setMetadataServiceUri("zk://" + zkServers + "/ledgers");
         conf.setJournalDirName(journalDir)
@@ -255,7 +256,8 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
     public void testUpgradeV1toCurrentWithIndexDir() throws Exception {
         File journalDir = initV1JournalDirectory(tmpDirs.createNew("bookie", "journal"));
         File indexDir = tmpDirs.createNew("bookie", "index");
-        File ledgerDir = initV1LedgerDirectoryWithIndexDir(tmpDirs.createNew("bookie", "ledger"), indexDir);
+        File ledgerDir = initV1LedgerDirectoryWithIndexDir(
+                tmpDirs.createNew("bookie", "ledger"), indexDir);
         testUpgradeProceedure(zkUtil.getZooKeeperConnectString(), journalDir.getPath(),
                 ledgerDir.getPath(), indexDir.getPath());
     }
@@ -273,7 +275,8 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
     public void testUpgradeV2toCurrentWithIndexDir() throws Exception {
         File journalDir = initV2JournalDirectory(tmpDirs.createNew("bookie", "journal"));
         File indexDir = tmpDirs.createNew("bookie", "index");
-        File ledgerDir = initV2LedgerDirectoryWithIndexDir(tmpDirs.createNew("bookie", "ledger"), indexDir);
+        File ledgerDir = initV2LedgerDirectoryWithIndexDir(
+                tmpDirs.createNew("bookie", "ledger"), indexDir);
         testUpgradeProceedure(zkUtil.getZooKeeperConnectString(), journalDir.getPath(),
                 ledgerDir.getPath(), indexDir.getPath());
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpgradeTest.java
@@ -21,6 +21,7 @@
 
 package org.apache.bookkeeper.bookie;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -36,6 +37,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+import java.util.List;
 import org.apache.bookkeeper.client.ClientUtil;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -355,5 +357,44 @@ public class UpgradeTest extends BookKeeperClusterTestCase {
             System.setOut(origout);
             System.setErr(origerr);
         }
+    }
+
+    @Test
+    public void testFSUGetAllDirectories() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        final File journalDir = tmpDirs.createNew("bookie", "journal");
+        final File ledgerDir1 = tmpDirs.createNew("bookie", "ledger");
+        final File ledgerDir2 = tmpDirs.createNew("bookie", "ledger");
+
+        // test1
+        conf.setJournalDirName(journalDir.getPath())
+                .setLedgerDirNames(new String[]{ledgerDir1.getPath(), ledgerDir2.getPath()})
+                .setIndexDirName(new String[]{ledgerDir1.getPath(), ledgerDir2.getPath()});
+        List<File> allDirectories = FileSystemUpgrade.getAllDirectories(conf);
+        assertEquals(3, allDirectories.size());
+
+        // test2
+        conf.setJournalDirName(journalDir.getPath())
+                .setLedgerDirNames(new String[]{ledgerDir1.getPath(), ledgerDir2.getPath()})
+                .setIndexDirName(new String[]{ledgerDir2.getPath(), ledgerDir1.getPath()});
+        allDirectories = FileSystemUpgrade.getAllDirectories(conf);
+        assertEquals(3, allDirectories.size());
+
+        final File indexDir1 = tmpDirs.createNew("bookie", "index");
+        final File indexDir2 = tmpDirs.createNew("bookie", "index");
+
+        // test3
+        conf.setJournalDirName(journalDir.getPath())
+                .setLedgerDirNames(new String[]{ledgerDir1.getPath(), ledgerDir2.getPath()})
+                .setIndexDirName(new String[]{indexDir1.getPath(), indexDir2.getPath()});
+        allDirectories = FileSystemUpgrade.getAllDirectories(conf);
+        assertEquals(5, allDirectories.size());
+
+        // test4
+        conf.setJournalDirName(journalDir.getPath())
+                .setLedgerDirNames(new String[]{ledgerDir1.getPath(), ledgerDir2.getPath()})
+                .setIndexDirName(new String[]{indexDir2.getPath(), indexDir1.getPath()});
+        allDirectories = FileSystemUpgrade.getAllDirectories(conf);
+        assertEquals(5, allDirectories.size());
     }
 }


### PR DESCRIPTION
### Motivation

Now we have written indexDir into Cookie in #3372 .

When we configure an independent indexDir, the `FileSystemUpgrade` tool will fail when the cookie is an old version or a new cookie version will be added in the future, because it does not consider indexDirs when upgrading, so we should add indexDirs to the upgrade step.

### Changes
You can use the following two implementations of getAllDirectories in FileSystemUpgrade, and then run some tests added by this PR in UpgradeTest, and you will find that the first implementation will fail the test, while the second implementation will succeed.
1:
```java
    private static List<File> getAllDirectories(ServerConfiguration conf) {
        List<File> dirs = new ArrayList<>();
        dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
        Collections.addAll(dirs, conf.getLedgerDirs());
        return dirs;
    }
```
![image](https://user-images.githubusercontent.com/35599757/216272842-e21cf916-0bf7-4d88-ad24-2864d5b207ec.png)


2:
```java
    private static List<File> getAllDirectories(ServerConfiguration conf) {
        List<File> dirs = new ArrayList<>();
        dirs.addAll(Lists.newArrayList(conf.getJournalDirs()));
        final File[] ledgerDirs = conf.getLedgerDirs();
        final File[] indexDirs = conf.getIndexDirs();
        if (indexDirs != null && indexDirs != ledgerDirs) {
            dirs.addAll(Lists.newArrayList(indexDirs));
        }
        Collections.addAll(dirs, ledgerDirs);
        return dirs;
    }
```
![image](https://user-images.githubusercontent.com/35599757/216273056-608267be-9631-46fc-9046-a5431f764363.png)

