### PR TITLE
Execute clean indexes in finally

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -800,21 +800,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             ledgerIndex.flush();
             recordSuccessfulEvent(dbLedgerStorageStats.getFlushLedgerIndexStats(), ledgerIndexStartTime);
 
-            cleanupExecutor.execute(() -> {
-                // There can only be one single cleanup task running because the cleanupExecutor
-                // is single-threaded
-                try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Removing deleted ledgers from db indexes");
-                    }
-
-                    entryLocationIndex.removeOffsetFromDeletedLedgers();
-                    ledgerIndex.removeDeletedLedgers();
-                } catch (Throwable t) {
-                    log.warn("Failed to cleanup db indexes", t);
-                }
-            });
-
             lastCheckpoint = thisCheckpoint;
 
             // Discard all the entry from the write cache, since they're now persisted
@@ -838,6 +823,20 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             // Wrap unchecked exceptions
             throw new IOException(e);
         } finally {
+            cleanupExecutor.execute(() -> {
+                // There can only be one single cleanup task running because the cleanupExecutor
+                // is single-threaded
+                try {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removing deleted ledgers from db indexes");
+                    }
+
+                    entryLocationIndex.removeOffsetFromDeletedLedgers();
+                    ledgerIndex.removeDeletedLedgers();
+                } catch (Throwable t) {
+                    log.warn("Failed to cleanup db indexes", t);
+                }
+            });
             try {
                 isFlushOngoing.set(false);
             } finally {


### PR DESCRIPTION
### Motivation
Fixes  #3771

### Changes
Move cleanupExecutor to finally block to make sure it can be executed every checkpoint process.

