### PR TITLE
Add logs for ensemble select failed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -675,6 +675,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             }
             return bn;
         }
+        LOG.warn("Failed to select bookie node from path: {}, leaves: {}, exclude Bookies: {}, ensemble: {}",
+            netPath, leaves, excludeBookies, ensemble);
         throw new BKNotEnoughBookiesException();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -519,7 +519,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                         networkLoc, excludeBookies);
                 throw e;
             }
-            LOG.warn("Failed to choose a bookie from {} : leaves {}, excluded {}, "
+            LOG.warn("Failed to choose a bookie from {} : leaves {}, excluded bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
                      networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             // randomly choose one from whole cluster, ignore the provided predicate.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -519,7 +519,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                         networkLoc, excludeBookies);
                 throw e;
             }
-            LOG.warn("Failed to choose a bookie from {} : leaves {}, excluded bookies {}, "
+            LOG.warn("Failed to choose a bookie from network location {}, "
+                    + "the bookies in the network location are {}, excluded bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
                      networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             // randomly choose one from whole cluster, ignore the provided predicate.
@@ -544,7 +545,8 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
              * the whole cluster and exclude the racks specified at
              * <tt>excludeRacks</tt>.
              */
-            LOG.warn("Failed to choose a bookie node from {} : leaves {}, exclude Bookies {}, "
+            LOG.warn("Failed to choose a bookie node from network location {}, "
+                    + "the bookies in the network location are {}, excluded bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
                 networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             return selectFromNetworkLocation(excludeRacks, excludeBookies, predicate, ensemble, fallbackToRandom);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -519,9 +519,9 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
                         networkLoc, excludeBookies);
                 throw e;
             }
-            LOG.warn("Failed to choose a bookie from {} : "
-                     + "excluded {}, fallback to choose bookie randomly from the cluster.",
-                     networkLoc, excludeBookies);
+            LOG.warn("Failed to choose a bookie from {} : leaves {}, excluded {}, "
+                    + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
+                     networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             // randomly choose one from whole cluster, ignore the provided predicate.
             return selectRandom(1, excludeBookies, predicate, ensemble).get(0);
         }
@@ -544,6 +544,9 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
              * the whole cluster and exclude the racks specified at
              * <tt>excludeRacks</tt>.
              */
+            LOG.info("Failed to choose a bookie node from {} : leaves {}, exclude Bookies {}, "
+                    + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
+                networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             return selectFromNetworkLocation(excludeRacks, excludeBookies, predicate, ensemble, fallbackToRandom);
         }
     }
@@ -675,8 +678,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             }
             return bn;
         }
-        LOG.warn("Failed to select bookie node from path: {}, leaves: {}, exclude Bookies: {}, ensemble: {}",
-            netPath, leaves, excludeBookies, ensemble);
         throw new BKNotEnoughBookiesException();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -544,7 +544,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
              * the whole cluster and exclude the racks specified at
              * <tt>excludeRacks</tt>.
              */
-            LOG.info("Failed to choose a bookie node from {} : leaves {}, exclude Bookies {}, "
+            LOG.warn("Failed to choose a bookie node from {} : leaves {}, exclude Bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
                 networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
             return selectFromNetworkLocation(excludeRacks, excludeBookies, predicate, ensemble, fallbackToRandom);


### PR DESCRIPTION
### Motivation
We have 3 bookies in the same rack, and configured `E = 2, W = 2, A = 2`. When one bookie restarted, we found the ledger select bookie from the same rack failed in the ensemble change replacing the failed bookie step.

Due to there being no log information in `selectRandomFromRack`, it's hard to debug the root cause.
https://github.com/apache/bookkeeper/blob/02e64a4b97e03afc9993ab227f82a5956965c03f/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L630-L679

### Modification
Add one warn log in `selectRandomFromRack` when selecting a new bookie node failed.