### PR TITLE
Change directIO configuration names to avoid confusing

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -81,11 +81,11 @@ public class DbLedgerStorage implements LedgerStorage {
     public static final String READ_AHEAD_CACHE_MAX_SIZE_MB = "dbStorage_readAheadCacheMaxSizeMb";
     public static final String DIRECT_IO_ENTRYLOGGER = "dbStorage_directIOEntryLogger";
     public static final String DIRECT_IO_ENTRYLOGGER_TOTAL_WRITEBUFFER_SIZE_MB =
-        "dbStorage_directIOEntryLoggerTotalWriteBufferSizeMb";
+        "dbStorage_directIOEntryLoggerTotalWriteBufferSizeMB";
     public static final String DIRECT_IO_ENTRYLOGGER_TOTAL_READBUFFER_SIZE_MB =
-        "dbStorage_directIOEntryLoggerTotalReadBufferSizeMb";
+        "dbStorage_directIOEntryLoggerTotalReadBufferSizeMB";
     public static final String DIRECT_IO_ENTRYLOGGER_READBUFFER_SIZE_MB =
-        "dbStorage_directIOEntryLoggerReadBufferSizeMb";
+        "dbStorage_directIOEntryLoggerReadBufferSizeMB";
     public static final String DIRECT_IO_ENTRYLOGGER_MAX_FD_CACHE_TIME_SECONDS =
         "dbStorage_directIOEntryLoggerMaxFdCacheTimeSeconds";
 

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -768,6 +768,32 @@ gcEntryLogMetadataCacheEnabled=false
 # dbStorage_rocksDB_logPath=
 # dbStorage_rocksDB_format_version=2
 
+#############################################################################
+## DirectIO entry logger configuration
+#############################################################################
+# DirectIO entry logger only support DbLedgerStorage
+
+# Enable/Disable directIO entry logger.
+# dbStorage_directIOEntryLogger = false
+
+# Total write buffer size in megabytes for all the entry directories.
+# The write buffer size of each entry directory needs to be divided by the number of entry directories.
+# By default it will be allocated to 12.5% of the available direct memory.
+# dbStorage_directIOEntryLoggerTotalWriteBufferSizeMB=
+
+# Total read buffer size in megabytes for all the entry directories.
+# The read buffer size of each entry directory needs to be divided by the number of entry directories.
+# By default it will be allocated to 12.5% of the available direct memory.
+# dbStorage_directIOEntryLoggerTotalReadBufferSizeMB=
+
+# The buffer size, in megabytes, for each direct reader to read data from the entry log file.
+# An entry log file will have only one direct reader.
+# By default it will be set to 8MB
+# dbStorage_directIOEntryLoggerReadBufferSizeMB=8
+
+# Maximum cache time after a direct reader is accessed.
+# dbStorage_directIOEntryLoggerMaxFdCacheTimeSeconds=300
+
 
 ############################################## Metadata Services ##############################################
 


### PR DESCRIPTION
### Motivation
We have the following configurations from the DirectIO entry logger.
```
dbStorage_directIOEntryLoggerTotalWriteBufferSizeMb
dbStorage_directIOEntryLoggerTotalReadBufferSizeMb
dbStorage_directIOEntryLoggerReadBufferSizeMb
```

In fact, the units are bytes instead of bits. But from the first sight of the configuration name, users may be confused by the units, because we use `Mb` instead of `MB`.
I suggest changing the configuration name suffix from `Mb` to `MB` to avoid confusing.

###  Modifications
- Change `dbStorage_directIOEntryLoggerTotalWriteBufferSizeMb` to `dbStorage_directIOEntryLoggerTotalWriteBufferSizeMB`
- Change `dbStorage_directIOEntryLoggerTotalReadBufferSizeMb` to `dbStorage_directIOEntryLoggerTotalReadBufferSizeMB`
- Change `dbStorage_directIOEntryLoggerReadBufferSizeMb` to `dbStorage_directIOEntryLoggerReadBufferSizeMB`
- Add documents in `conf/bk_server.conf`