### PR TITLE
BP61: revert BP-59 to release ByteBuf using ReferenceCountUtil.release() instead of ReferenceCountUtil.safeRelease()

### DIFF
--- a/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
+++ b/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
@@ -230,17 +230,17 @@ public class ByteBufAllocatorBuilderTest {
         ByteBuf buf1 = alloc.buffer();
         assertEquals(pooledAlloc, buf1.alloc());
         assertFalse(buf1.hasArray());
-        ReferenceCountUtil.safeRelease(buf1);
+        ReferenceCountUtil.release(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertEquals(pooledAlloc, buf2.alloc());
         assertFalse(buf2.hasArray());
-        ReferenceCountUtil.safeRelease(buf2);
+        ReferenceCountUtil.release(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertEquals(pooledAlloc, buf3.alloc());
         assertTrue(buf3.hasArray());
-        ReferenceCountUtil.safeRelease(buf3);
+        ReferenceCountUtil.release(buf3);
     }
 
     @Test
@@ -256,14 +256,14 @@ public class ByteBufAllocatorBuilderTest {
         assertEquals(PooledByteBufAllocator.class, buf1.alloc().getClass());
         assertEquals(3, ((PooledByteBufAllocator) buf1.alloc()).metric().numDirectArenas());
         assertFalse(buf1.hasArray());
-        ReferenceCountUtil.safeRelease(buf1);
+        ReferenceCountUtil.release(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertFalse(buf2.hasArray());
-        ReferenceCountUtil.safeRelease(buf2);
+        ReferenceCountUtil.release(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertTrue(buf3.hasArray());
-        ReferenceCountUtil.safeRelease(buf3);
+        ReferenceCountUtil.release(buf3);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -941,7 +941,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
                     getJournal(ledgerId).logAddEntry(
                             masterKeyEntry, false /* ackBeforeSync */, new NopWriteCallback(), null);
                 } finally {
-                    ReferenceCountUtil.safeRelease(masterKeyEntry);
+                    ReferenceCountUtil.release(masterKeyEntry);
                 }
             }
         }
@@ -988,7 +988,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
                 bookieStats.getAddBytesStats().registerFailedValue(entrySize);
             }
 
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
         }
     }
 
@@ -1019,9 +1019,9 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             stateManager.transitionToReadOnlyMode();
             throw new IOException(e);
         } finally {
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
             if (explicitLACEntry != null) {
-                ReferenceCountUtil.safeRelease(explicitLACEntry);
+                ReferenceCountUtil.release(explicitLACEntry);
             }
         }
     }
@@ -1082,7 +1082,7 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
                 bookieStats.getAddBytesStats().registerFailedValue(entrySize);
             }
 
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -101,7 +101,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         if (closed) {
             return;
         }
-        ReferenceCountUtil.safeRelease(writeBuffer);
+        ReferenceCountUtil.release(writeBuffer);
         fileChannel.close();
         closed = true;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -191,7 +191,7 @@ public class DefaultEntryLogger implements EntryLogger {
                     throw e;
                 }
             } finally {
-                ReferenceCountUtil.safeRelease(serializedMap);
+                ReferenceCountUtil.release(serializedMap);
             }
             // Flush the ledger's map out before we write the header.
             // Otherwise the header might point to something that is not fully
@@ -843,7 +843,7 @@ public class DefaultEntryLogger implements EntryLogger {
         ByteBuf data = allocator.buffer(entrySize, entrySize);
         int rc = readFromLogChannel(entryLogId, fc, data, pos);
         if (rc != entrySize) {
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
             throw new IOException("Bad entry read from log file id: " + entryLogId,
                     new EntryLookupException("Short read for " + ledgerId + "@"
                                               + entryId + " in " + entryLogId + "@"
@@ -877,7 +877,7 @@ public class DefaultEntryLogger implements EntryLogger {
             int ledgersCount = headers.readInt();
             return new Header(headerVersion, ledgersMapOffset, ledgersCount);
         } finally {
-            ReferenceCountUtil.safeRelease(headers);
+            ReferenceCountUtil.release(headers);
         }
     }
 
@@ -1026,7 +1026,7 @@ public class DefaultEntryLogger implements EntryLogger {
                 pos += entrySize;
             }
         } finally {
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
         }
     }
 
@@ -1118,7 +1118,7 @@ public class DefaultEntryLogger implements EntryLogger {
         } catch (IndexOutOfBoundsException e) {
             throw new IOException(e);
         } finally {
-            ReferenceCountUtil.safeRelease(ledgersMap);
+            ReferenceCountUtil.release(ledgersMap);
         }
 
         if (meta.getLedgersMap().size() != header.ledgersCount) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -370,7 +370,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
                     lac = bb.readLong();
                     lac = ledgerCache.updateLastAddConfirmed(ledgerId, lac);
                 } finally {
-                    ReferenceCountUtil.safeRelease(bb);
+                    ReferenceCountUtil.release(bb);
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1165,7 +1165,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                      * (METAENTRY_ID_LEDGER_EXPLICITLAC) to Journal.
                      */
                     memoryLimitController.releaseMemory(qe.entry.readableBytes());
-                    ReferenceCountUtil.safeRelease(qe.entry);
+                    ReferenceCountUtil.release(qe.entry);
                 } else if (qe.entryId != BookieImpl.METAENTRY_ID_FORCE_LEDGER) {
                     int entrySize = qe.entry.readableBytes();
                     journalStats.getJournalWriteBytes().addCount(entrySize);
@@ -1181,7 +1181,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     bc.write(lenBuff);
                     bc.write(qe.entry);
                     memoryLimitController.releaseMemory(qe.entry.readableBytes());
-                    ReferenceCountUtil.safeRelease(qe.entry);
+                    ReferenceCountUtil.release(qe.entry);
                 }
 
                 toFlush.add(qe);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/EntryCopierImpl.java
@@ -143,7 +143,7 @@ public class EntryCopierImpl implements EntryCopier {
                         } catch (Throwable t) {
                             promise.completeExceptionally(t);
                         } finally {
-                            ReferenceCountUtil.safeRelease(buffer);
+                            ReferenceCountUtil.release(buffer);
                         }
                     }
                 });

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/Buffer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/Buffer.java
@@ -243,7 +243,7 @@ class Buffer {
      * Free the memory that backs this buffer.
      */
     void free() {
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         buffer = null;
         byteBuffer = null;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -456,7 +456,7 @@ public class DirectEntryLogger implements EntryLogger {
             writer.writeAt(0, buf);
             writer.position(buf.capacity());
         } finally {
-            ReferenceCountUtil.safeRelease(buf);
+            ReferenceCountUtil.release(buf);
         }
         return writer;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
@@ -91,7 +91,7 @@ class DirectReader implements LogReader {
         try {
             readIntoBufferAt(buf, offset, size);
         } catch (IOException e) {
-            ReferenceCountUtil.safeRelease(buf);
+            ReferenceCountUtil.release(buf);
             throw e;
         }
 
@@ -121,7 +121,7 @@ class DirectReader implements LogReader {
                 try {
                     return intBuf.getInt(0);
                 } finally {
-                    ReferenceCountUtil.safeRelease(intBuf);
+                    ReferenceCountUtil.release(intBuf);
                 }
             }
         }
@@ -138,7 +138,7 @@ class DirectReader implements LogReader {
                 try {
                     return longBuf.getLong(0);
                 } finally {
-                    ReferenceCountUtil.safeRelease(longBuf);
+                    ReferenceCountUtil.release(longBuf);
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogMetadata.java
@@ -108,14 +108,14 @@ class LogMetadata {
                 throw e;
             }
         } finally {
-            ReferenceCountUtil.safeRelease(serializedMap);
+            ReferenceCountUtil.release(serializedMap);
         }
         ByteBuf buf = allocator.buffer(Buffer.ALIGNMENT);
         try {
             Header.writeHeader(buf, ledgerMapOffset, numberOfLedgers);
             writer.writeAt(0, buf);
         } finally {
-            ReferenceCountUtil.safeRelease(buf);
+            ReferenceCountUtil.release(buf);
         }
         writer.flush();
     }
@@ -178,7 +178,7 @@ class LogMetadata {
                                               .toString());
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(ledgerMapBuffer);
+                    ReferenceCountUtil.release(ledgerMapBuffer);
                 }
             }
             return meta;
@@ -186,7 +186,7 @@ class LogMetadata {
             throw new IOException(exMsg("Error reading index").kv("logId", reader.logId())
                                   .kv("reason", ioe.getMessage()).toString(), ioe);
         } finally {
-            ReferenceCountUtil.safeRelease(header);
+            ReferenceCountUtil.release(header);
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogReaderScan.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/LogReaderScan.java
@@ -56,7 +56,7 @@ class LogReaderScan {
                 offset += entrySize;
             }
         } finally {
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -652,7 +652,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                     currentEntryLocation += 4 + entry.readableBytes();
                     currentEntryLogId = currentEntryLocation >> 32;
                 } finally {
-                    ReferenceCountUtil.safeRelease(entry);
+                    ReferenceCountUtil.release(entry);
                 }
             }
         } catch (Exception e) {
@@ -927,7 +927,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 lac = bb.readLong();
                 lac = getOrAddLedgerInfo(ledgerId).setLastAddConfirmed(lac);
             } finally {
-                ReferenceCountUtil.safeRelease(bb);
+                ReferenceCountUtil.release(bb);
             }
         }
         return lac;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -270,7 +270,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                 pcbc.writeLac(ledgerId, masterKey, lac, toSend, cb, ctx);
             }
 
-            ReferenceCountUtil.safeRelease(toSend);
+            ReferenceCountUtil.release(toSend);
         }, ledgerId, useV3Enforced);
     }
 
@@ -398,7 +398,7 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                               toSend, cb, ctx, options, allowFastFail, writeFlags);
             }
 
-            ReferenceCountUtil.safeRelease(toSend);
+            ReferenceCountUtil.release(toSend);
             recycle();
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -298,7 +298,7 @@ public interface BookieProtocol {
             ledgerId = -1;
             entryId = -1;
             masterKey = null;
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
             data = null;
             recyclerHandle.recycle(this);
         }
@@ -333,7 +333,7 @@ public interface BookieProtocol {
         }
 
         void release() {
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
         }
 
         private final Handle<ParsedAddRequest> recyclerHandle;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -837,7 +837,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             // usually checked in writeAndFlush, but we have extra check
             // because we need to release toSend.
             errorOut(completionKey);
-            ReferenceCountUtil.safeRelease(toSend);
+            ReferenceCountUtil.release(toSend);
             return;
         } else {
             // addEntry times out on backpressure
@@ -1942,7 +1942,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             handleReadResponse(readResponse.getLedgerId(),
                                readResponse.getEntryId(),
                                status, buffer, maxLAC, lacUpdateTimestamp);
-            ReferenceCountUtil.safeRelease(
+            ReferenceCountUtil.release(
                     buffer); // meaningless using unpooled, but client may expect to hold the last reference
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -116,7 +116,7 @@ public abstract class DigestManager {
         final ByteBuf unwrapped = data.unwrap() != null && data.unwrap() instanceof CompositeByteBuf
                 ? data.unwrap() : data;
         ReferenceCountUtil.retain(unwrapped);
-        ReferenceCountUtil.safeRelease(data);
+        ReferenceCountUtil.release(data);
 
         if (unwrapped instanceof CompositeByteBuf) {
             CompositeByteBuf cbb = ((CompositeByteBuf) unwrapped);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -328,7 +328,7 @@ public class ByteBufList extends AbstractReferenceCounted {
                         ctx.write(bx.retainedDuplicate(), i == (buffersCount - 1) ? promise : ctx.voidPromise());
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(b);
+                    ReferenceCountUtil.release(b);
                 }
             } else {
                 ctx.write(msg, promise);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalTest.java
@@ -175,7 +175,7 @@ public class BookieJournalTest {
 
             fc.write(lenBuff);
             fc.write(packet.nioBuffer());
-            ReferenceCountUtil.safeRelease(packet);
+            ReferenceCountUtil.release(packet);
         }
     }
 
@@ -219,7 +219,7 @@ public class BookieJournalTest {
 
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            ReferenceCountUtil.safeRelease(packet);
+            ReferenceCountUtil.release(packet);
         }
         bc.flushAndForceWrite(false);
 
@@ -253,7 +253,7 @@ public class BookieJournalTest {
 
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            ReferenceCountUtil.safeRelease(packet);
+            ReferenceCountUtil.release(packet);
         }
         bc.flushAndForceWrite(false);
 
@@ -286,7 +286,7 @@ public class BookieJournalTest {
             lenBuff.flip();
             bc.write(Unpooled.wrappedBuffer(lenBuff));
             bc.write(packet);
-            ReferenceCountUtil.safeRelease(packet);
+            ReferenceCountUtil.release(packet);
         }
         // write fence key
         ByteBuf packet = generateFenceEntry(1);
@@ -334,7 +334,7 @@ public class BookieJournalTest {
             }
             bc.write(lenBuff);
             bc.write(packet);
-            ReferenceCountUtil.safeRelease(packet);
+            ReferenceCountUtil.release(packet);
             Journal.writePaddingBytes(jc, paddingBuff, JournalChannel.SECTOR_SIZE);
         }
         // write fence key

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CheckpointOnNewLedgersTest.java
@@ -184,14 +184,14 @@ public class CheckpointOnNewLedgersTest {
             assertNotNull(entry);
             assertEquals(l2, entry.readLong());
             assertEquals((long) i, entry.readLong());
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
         }
 
         ByteBuf entry = newBookie.readEntry(l1, 0L);
         assertNotNull(entry);
         assertEquals(l1, entry.readLong());
         assertEquals(0L, entry.readLong());
-        ReferenceCountUtil.safeRelease(entry);
+        ReferenceCountUtil.release(entry);
         newBookie.shutdown();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
@@ -139,15 +139,15 @@ public class TestDirectEntryLogger {
             ByteBuf e2read = elog.readEntry(ledgerId1, 2L, loc2);
             assertEntryEquals(e1read, e1);
             assertEntryEquals(e2read, e2);
-            ReferenceCountUtil.safeRelease(e1read);
-            ReferenceCountUtil.safeRelease(e2read);
+            ReferenceCountUtil.release(e1read);
+            ReferenceCountUtil.release(e2read);
 
             long loc3 = elog.addEntry(ledgerId1, e3.slice());
             elog.flush();
 
             ByteBuf e3read = elog.readEntry(ledgerId1, 3L, loc3);
             assertEntryEquals(e3read, e3);
-            ReferenceCountUtil.safeRelease(e3read);
+            ReferenceCountUtil.release(e3read);
         }
     }
 
@@ -200,7 +200,7 @@ public class TestDirectEntryLogger {
             }
             elog.flush();
             for (Long loc : locations) {
-                ReferenceCountUtil.safeRelease(elog.readEntry(loc));
+                ReferenceCountUtil.release(elog.readEntry(loc));
             }
             assertThat(outstandingReaders.get(), equalTo(maxCachedReaders));
         } finally {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -358,7 +358,7 @@ public class DbLedgerStorageTest {
 
         ByteBuf res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
 
         storage.flush();
 
@@ -371,7 +371,7 @@ public class DbLedgerStorageTest {
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
 
         ByteBuf entry1 = Unpooled.buffer(1024);
         entry1.writeLong(1); // ledger id
@@ -382,21 +382,21 @@ public class DbLedgerStorageTest {
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
 
         storage.flush();
 
         res = storage.getEntry(1, 1);
         assertEquals(entry1, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
 
         res = storage.getEntry(1, 2);
         assertEquals(entry2, res);
-        ReferenceCountUtil.safeRelease(res);
+        ReferenceCountUtil.release(res);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCacheTest.java
@@ -80,7 +80,7 @@ public class WriteCacheTest {
         assertEquals(0, cache.count());
         assertEquals(0, cache.size());
 
-        ReferenceCountUtil.safeRelease(entry1);
+        ReferenceCountUtil.release(entry1);
         cache.close();
     }
 
@@ -121,7 +121,7 @@ public class WriteCacheTest {
 
         assertEquals(0, findCount.get());
 
-        ReferenceCountUtil.safeRelease(entry);
+        ReferenceCountUtil.release(entry);
         cache.close();
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
@@ -301,25 +301,25 @@ public class ByteBufListTest {
 
         @Override
         public ChannelFuture write(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture write(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 

--- a/stream/clients/java/kv/src/main/java/org/apache/bookkeeper/clients/impl/kv/PByteBufSimpleTableImpl.java
+++ b/stream/clients/java/kv/src/main/java/org/apache/bookkeeper/clients/impl/kv/PByteBufSimpleTableImpl.java
@@ -152,10 +152,10 @@ public class PByteBufSimpleTableImpl
         ))
         .thenApply(response -> KvUtils.newRangeResult(response, resultFactory, kvFactory))
         .whenComplete((value, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
             if (null != option.endKey()) {
-                ReferenceCountUtil.safeRelease(option.endKey());
+                ReferenceCountUtil.release(option.endKey());
             }
         });
     }
@@ -176,9 +176,9 @@ public class PByteBufSimpleTableImpl
             ))
             .thenApply(response -> KvUtils.newPutResult(response, resultFactory, kvFactory))
             .whenComplete((ignored, cause) -> {
-                ReferenceCountUtil.safeRelease(pKey);
-                ReferenceCountUtil.safeRelease(lKey);
-                ReferenceCountUtil.safeRelease(value);
+                ReferenceCountUtil.release(pKey);
+                ReferenceCountUtil.release(lKey);
+                ReferenceCountUtil.release(value);
             });
     }
 
@@ -200,10 +200,10 @@ public class PByteBufSimpleTableImpl
         ))
         .thenApply(response -> KvUtils.newDeleteResult(response, resultFactory, kvFactory))
         .whenComplete((ignored, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
             if (null != option.endKey()) {
-                ReferenceCountUtil.safeRelease(option.endKey());
+                ReferenceCountUtil.release(option.endKey());
             }
         });
     }
@@ -223,8 +223,8 @@ public class PByteBufSimpleTableImpl
         ))
         .thenApply(response -> KvUtils.newIncrementResult(response, resultFactory, kvFactory))
         .whenComplete((ignored, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
         });
     }
 
@@ -298,7 +298,7 @@ public class PByteBufSimpleTableImpl
             ))
             .thenApply(response -> KvUtils.newKvTxnResult(response, resultFactory, kvFactory))
             .whenComplete((ignored, cause) -> {
-                ReferenceCountUtil.safeRelease(pKey);
+                ReferenceCountUtil.release(pKey);
                 for (AutoCloseable resource : resourcesToRelease) {
                     closeResource(resource);
                 }

--- a/stream/clients/java/kv/src/main/java/org/apache/bookkeeper/clients/impl/kv/PByteBufTableRangeImpl.java
+++ b/stream/clients/java/kv/src/main/java/org/apache/bookkeeper/clients/impl/kv/PByteBufTableRangeImpl.java
@@ -104,10 +104,10 @@ class PByteBufTableRangeImpl implements PTable<ByteBuf, ByteBuf> {
             executor,
             backoffPolicy
         ).process().whenComplete((value, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
             if (null != option.endKey()) {
-                ReferenceCountUtil.safeRelease(option.endKey());
+                ReferenceCountUtil.release(option.endKey());
             }
         });
     }
@@ -129,9 +129,9 @@ class PByteBufTableRangeImpl implements PTable<ByteBuf, ByteBuf> {
             executor,
             backoffPolicy
         ).process().whenComplete((ignored, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
-            ReferenceCountUtil.safeRelease(value);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
+            ReferenceCountUtil.release(value);
         });
     }
 
@@ -153,10 +153,10 @@ class PByteBufTableRangeImpl implements PTable<ByteBuf, ByteBuf> {
             executor,
             backoffPolicy
         ).process().whenComplete((ignored, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
             if (null != option.endKey()) {
-                ReferenceCountUtil.safeRelease(option.endKey());
+                ReferenceCountUtil.release(option.endKey());
             }
         });
     }
@@ -177,8 +177,8 @@ class PByteBufTableRangeImpl implements PTable<ByteBuf, ByteBuf> {
             executor,
             backoffPolicy
         ).process().whenComplete((ignored, cause) -> {
-            ReferenceCountUtil.safeRelease(pKey);
-            ReferenceCountUtil.safeRelease(lKey);
+            ReferenceCountUtil.release(pKey);
+            ReferenceCountUtil.release(lKey);
         });
     }
 
@@ -252,7 +252,7 @@ class PByteBufTableRangeImpl implements PTable<ByteBuf, ByteBuf> {
                 executor,
                 backoffPolicy
             ).process().whenComplete((ignored, cause) -> {
-                ReferenceCountUtil.safeRelease(pKey);
+                ReferenceCountUtil.release(pKey);
                 for (AutoCloseable resource : resourcesToRelease) {
                     closeResource(resource);
                 }

--- a/stream/common/src/main/java/org/apache/bookkeeper/common/router/AbstractHashRouter.java
+++ b/stream/common/src/main/java/org/apache/bookkeeper/common/router/AbstractHashRouter.java
@@ -39,7 +39,7 @@ public abstract class AbstractHashRouter<K> implements HashRouter<K> {
             return Murmur3.hash128(
                 keyData, keyData.readerIndex(), keyData.readableBytes(), HASH_SEED)[0];
         } finally {
-            ReferenceCountUtil.safeRelease(keyData);
+            ReferenceCountUtil.release(keyData);
         }
     }
 

--- a/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
+++ b/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
@@ -71,9 +71,9 @@ public class TestCompressionCodec {
         decompressedBuf.readBytes(decompressedData);
         assertArrayEquals("The decompressed bytes should be same as the original bytes",
                 data, decompressedData);
-        ReferenceCountUtil.safeRelease(buf);
-        ReferenceCountUtil.safeRelease(compressedBuf);
-        ReferenceCountUtil.safeRelease(decompressedBuf);
+        ReferenceCountUtil.release(buf);
+        ReferenceCountUtil.release(compressedBuf);
+        ReferenceCountUtil.release(decompressedBuf);
     }
 
     private void testCompressionCodec2(CompressionCodec codec) throws Exception {
@@ -94,9 +94,9 @@ public class TestCompressionCodec {
         byte[] decompressedData = new byte[decompressedBuf.readableBytes()];
         decompressedBuf.slice().readBytes(decompressedData);
 
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(compressedBuf);
-        ReferenceCountUtil.safeRelease(decompressedBuf);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(compressedBuf);
+        ReferenceCountUtil.release(decompressedBuf);
     }
 
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
@@ -111,7 +111,7 @@ public class LedgerReader {
                             eid, BKException.Code.DigestMatchException, null, bookieAddress.getSocketAddress());
 
                     } finally {
-                        ReferenceCountUtil.safeRelease(buffer);
+                        ReferenceCountUtil.release(buffer);
                     }
                 }
                 readResults.add(rr);

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntry.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntry.java
@@ -103,7 +103,7 @@ class EnvelopedEntry {
             CompressionCodec codec = CompressionUtils.getCompressionCodec(Type.of(codecCode));
             decompressedBuf = codec.decompress(compressedBuf, originDataLen);
         } finally {
-            ReferenceCountUtil.safeRelease(compressedBuf);
+            ReferenceCountUtil.release(compressedBuf);
         }
         return decompressedBuf;
     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryReader.java
@@ -81,7 +81,7 @@ class EnvelopedEntryReader implements Entry.Reader, RecordStream {
 
     private void releaseBuffer() {
         isExhausted = true;
-        ReferenceCountUtil.safeRelease(this.src);
+        ReferenceCountUtil.release(this.src);
     }
 
     @Override

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
@@ -210,18 +210,18 @@ class EnvelopedEntryWriter implements Writer {
     @Override
     public void completeTransmit(long lssn, long entryId) {
         satisfyPromises(lssn, entryId);
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         synchronized (this) {
-            ReferenceCountUtil.safeRelease(finalizedBuffer);
+            ReferenceCountUtil.release(finalizedBuffer);
         }
     }
 
     @Override
     public void abortTransmit(Throwable reason) {
         cancelPromises(reason);
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         synchronized (this) {
-            ReferenceCountUtil.safeRelease(finalizedBuffer);
+            ReferenceCountUtil.release(finalizedBuffer);
         }
     }
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
@@ -800,7 +800,7 @@ public class BKLogSegmentEntryReader implements Runnable, LogSegmentEntryReader,
                         return;
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(removedEntry);
+                    ReferenceCountUtil.release(removedEntry);
                 }
             } else if (skipBrokenEntries && BKException.Code.DigestMatchException == entry.getRc()) {
                 // skip this entry and move forward

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
@@ -1720,7 +1720,7 @@ import org.slf4j.LoggerFactory;
                     .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(segment.getVersion()))
                     .setEntry(lastEntry.getEntryBuffer())
                     .buildReader();
-            ReferenceCountUtil.safeRelease(lastEntry.getEntryBuffer());
+            ReferenceCountUtil.release(lastEntry.getEntryBuffer());
             LogRecordWithDLSN record = reader.nextRecord();
             LogRecordWithDLSN lastRecord = null;
             while (null != record) {
@@ -2034,7 +2034,7 @@ import org.slf4j.LoggerFactory;
                                     .setEntry(rr.getValue())
                                     .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(metadataVersion))
                                     .buildReader();
-                            ReferenceCountUtil.safeRelease(rr.getValue());
+                            ReferenceCountUtil.release(rr.getValue());
                             printEntry(reader);
                         } else {
                             System.out.println("status = " + BKException.getMessage(rr.getResultCode()));
@@ -2096,7 +2096,7 @@ import org.slf4j.LoggerFactory;
                         .setEntry(entry.getEntryBuffer())
                         .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(metadataVersion))
                         .buildReader();
-                ReferenceCountUtil.safeRelease(entry.getEntryBuffer());
+                ReferenceCountUtil.release(entry.getEntryBuffer());
                 printEntry(reader);
                 ++i;
             }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestEntry.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestEntry.java
@@ -73,7 +73,7 @@ public class TestEntry {
         Assert.assertNull("Empty record set should return null",
             reader.nextRecord());
         assertEquals(refCnt - 1, reader.getSrcBuf().refCnt());
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     @Test(timeout = 20000)
@@ -98,7 +98,7 @@ public class TestEntry {
 
         ByteBuf buffer = writer.getBuffer();
         assertEquals("zero bytes", HEADER_LENGTH, buffer.readableBytes());
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     @Test(timeout = 20000)
@@ -159,7 +159,7 @@ public class TestEntry {
                 .setEntryId(0L)
                 .setEnvelopeEntry(true)
                 .buildReader();
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         LogRecordWithDLSN record = reader.nextRecord();
         int numReads = 0;
         long expectedTxid = 0L;
@@ -277,7 +277,7 @@ public class TestEntry {
                 new DLSN(1L, 1L, 12L), 0, 0, 3,
                 new DLSN(1L, 1L, 12L), 12L);
 
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     void verifyReadResult(ByteBuf data,

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetReader.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetReader.java
@@ -81,10 +81,10 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
             CompressionCodec codec = CompressionUtils.getCompressionCodec(Type.of(codecCode));
             this.reader = codec.decompress(compressedBuf, decompressedDataLen);
         } finally {
-            ReferenceCountUtil.safeRelease(compressedBuf);
+            ReferenceCountUtil.release(compressedBuf);
         }
         if (numRecords == 0) {
-            ReferenceCountUtil.safeRelease(this.reader);
+            ReferenceCountUtil.release(this.reader);
         }
     }
 
@@ -111,7 +111,7 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
 
         // release the record set buffer when exhausting the reader
         if (0 == numRecords) {
-            ReferenceCountUtil.safeRelease(this.reader);
+            ReferenceCountUtil.release(this.reader);
         }
 
         return record;
@@ -121,7 +121,7 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
     public void release() {
         if (0 != numRecords) {
             numRecords = 0;
-            ReferenceCountUtil.safeRelease(reader);
+            ReferenceCountUtil.release(reader);
         }
     }
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
@@ -157,14 +157,14 @@ class EnvelopedRecordSetWriter implements LogRecordSet.Writer {
     @Override
     public synchronized void completeTransmit(long lssn, long entryId, long startSlotId) {
         satisfyPromises(lssn, entryId, startSlotId);
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(recordSetBuffer);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(recordSetBuffer);
     }
 
     @Override
     public synchronized void abortTransmit(Throwable reason) {
         cancelPromises(reason);
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(recordSetBuffer);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(recordSetBuffer);
     }
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
@@ -226,7 +226,7 @@ public class LogRecord {
 
     void setPayloadBuf(ByteBuf payload, boolean copyData) {
         if (null != this.payload) {
-            ReferenceCountUtil.safeRelease(this.payload);
+            ReferenceCountUtil.release(this.payload);
         }
         if (copyData) {
             this.payload = Unpooled.copiedBuffer(payload);

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
@@ -549,7 +549,7 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
         long txId = ++nextRevision;
         return FutureUtils.ensure(
             writer.write(new LogRecord(txId, cmdBuf.nioBuffer())),
-            () -> ReferenceCountUtil.safeRelease(cmdBuf));
+            () -> ReferenceCountUtil.release(cmdBuf));
     }
 
     protected synchronized CompletableFuture<Long> writeCommandBufReturnTxId(ByteBuf cmdBuf) {
@@ -557,7 +557,7 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
         return FutureUtils.ensure(
             writer.write(new LogRecord(txId, cmdBuf.nioBuffer()))
                 .thenApply(dlsn -> txId),
-            () -> ReferenceCountUtil.safeRelease(cmdBuf));
+            () -> ReferenceCountUtil.release(cmdBuf));
     }
 
     //

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/KVUtils.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/KVUtils.java
@@ -77,7 +77,7 @@ final class KVUtils {
         try {
             cmd.writeTo(new ByteBufOutputStream(buf));
         } catch (IOException e) {
-            ReferenceCountUtil.safeRelease(buf);
+            ReferenceCountUtil.release(buf);
             throw e;
         }
         return buf;

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVAsyncStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVAsyncStore.java
@@ -100,7 +100,7 @@ public class RocksdbKVAsyncStore<K, V>
                 byte[] serializedBytes = ByteBufUtil.getBytes(serializedBuf);
                 localStore.put(keyBytes, serializedBytes, revision);
             } finally {
-                ReferenceCountUtil.safeRelease(serializedBuf);
+                ReferenceCountUtil.release(serializedBuf);
             }
             return null;
         }, writeIOScheduler);
@@ -126,7 +126,7 @@ public class RocksdbKVAsyncStore<K, V>
                     return KVUtils.deserialize(valCoder, Unpooled.wrappedBuffer(prevValue));
                 }
             } finally {
-                ReferenceCountUtil.safeRelease(serializedBuf);
+                ReferenceCountUtil.release(serializedBuf);
             }
         }, writeIOScheduler);
     }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecord.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecord.java
@@ -90,7 +90,7 @@ public class MVCCRecord implements Recycled, Predicate<RangeOption<?>> {
 
     public void setValue(ByteBuf buf, ValueType valueType) {
         if (null != value) {
-            ReferenceCountUtil.safeRelease(value);
+            ReferenceCountUtil.release(value);
         }
         this.value = buf;
         this.valueType = valueType;
@@ -105,7 +105,7 @@ public class MVCCRecord implements Recycled, Predicate<RangeOption<?>> {
 
     private void reset() {
         if (null != value) {
-            ReferenceCountUtil.safeRelease(value);
+            ReferenceCountUtil.release(value);
             value = null;
         }
         modRev = -1L;

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecordCoder.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecordCoder.java
@@ -77,7 +77,7 @@ final class MVCCRecordCoder implements Coder<MVCCRecord> {
         buf.writerIndex(buf.writerIndex() + metaLen);
         buf.writeInt(valLen);
         buf.writeBytes(record.getValue().slice());
-        ReferenceCountUtil.safeRelease(buf);
+        ReferenceCountUtil.release(buf);
 
         return data;
     }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
@@ -492,7 +492,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         try {
             record = getKeyRecord(key, rawKey);
         } catch (StateStoreRuntimeException e) {
-            ReferenceCountUtil.safeRelease(rawValBuf);
+            ReferenceCountUtil.release(rawValBuf);
             throw e;
         }
 

--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptor.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptor.java
@@ -228,7 +228,7 @@ public class RoutingHeaderProxyInterceptor implements ClientInterceptor {
             buffer.writeBytes(is, bytes);
         } catch (IOException e) {
             log.warn("Encountered exceptions in transferring bytes to the buffer", e);
-            ReferenceCountUtil.safeRelease(buffer);
+            ReferenceCountUtil.release(buffer);
             throw new RuntimeException("Encountered exceptions in transferring bytes to the buffer", e);
         }
         return method

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
@@ -390,7 +390,7 @@ public class JournalWriter implements Runnable {
                     buf,
                     false,
                     (rc, ledgerId, entryId, addr, ctx) -> {
-                        ReferenceCountUtil.safeRelease(buf);
+                        ReferenceCountUtil.release(buf);
                         if (0 == rc) {
                             if (null != semaphore) {
                                 semaphore.release(len);

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
@@ -90,7 +90,7 @@ abstract class IncrementTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                ReferenceCountUtil.safeRelease(keyBuf);
+                ReferenceCountUtil.release(keyBuf);
             });
     }
 

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
@@ -96,8 +96,8 @@ abstract class WriteTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                ReferenceCountUtil.safeRelease(keyBuf);
-                ReferenceCountUtil.safeRelease(valBuf);
+                ReferenceCountUtil.release(keyBuf);
+                ReferenceCountUtil.release(valBuf);
             });
     }
 

--- a/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/DelCommand.java
+++ b/tools/stream/src/main/java/org/apache/bookkeeper/stream/cli/commands/table/DelCommand.java
@@ -70,7 +70,7 @@ public class DelCommand extends ClientCommand<Flags> {
             ByteBuf value = result(table.delete(
                 Unpooled.wrappedBuffer(key.getBytes(UTF_8))));
             if (null != value) {
-                ReferenceCountUtil.safeRelease(value);
+                ReferenceCountUtil.release(value);
                 spec.console().println("Successfully deleted key: ('" + key + "').");
             } else {
                 spec.console().println("key '" + key + "' doesn't exist.");


### PR DESCRIPTION
Fix #3792 