### PR TITLE
[Branch-4.15] Use ReferenceCountUtil.release() instead of ReferenceCountUtil.safeRelease()

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -984,9 +984,9 @@ public class BookieImpl extends BookieCriticalThread implements Bookie {
             stateManager.transitionToReadOnlyMode();
             throw new IOException(e);
         } finally {
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
             if (explicitLACEntry != null) {
-                ReferenceCountUtil.safeRelease(explicitLACEntry);
+                ReferenceCountUtil.release(explicitLACEntry);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -102,7 +102,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         if (closed) {
             return;
         }
-        ReferenceCountUtil.safeRelease(writeBuffer);
+        ReferenceCountUtil.release(writeBuffer);
         fileChannel.close();
         closed = true;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -298,7 +298,7 @@ public interface BookieProtocol {
             ledgerId = -1;
             entryId = -1;
             masterKey = null;
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
             data = null;
             recyclerHandle.recycle(this);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -330,7 +330,7 @@ public class ByteBufList extends AbstractReferenceCounted {
                         ctx.write(bx.retainedDuplicate(), i == (buffersCount - 1) ? promise : ctx.voidPromise());
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(b);
+                    ReferenceCountUtil.release(b);
                 }
             } else {
                 ctx.write(msg, promise);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
@@ -303,25 +303,25 @@ public class ByteBufListTest {
 
         @Override
         public ChannelFuture write(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture write(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
@@ -801,7 +801,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
                         return;
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(removedEntry);
+                    ReferenceCountUtil.release(removedEntry);
                 }
             } else if (skipBrokenEntries && BKException.Code.DigestMatchException == entry.getRc()) {
                 // skip this entry and move forward


### PR DESCRIPTION
Related to https://github.com/apache/bookkeeper/issues/3792