### PR TITLE
[Branch-4.14] Use ReferenceCountUtil.release() instead of ReferenceCountUtil.safeRelease()

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -1416,9 +1416,9 @@ public class Bookie extends BookieCriticalThread {
             stateManager.transitionToReadOnlyMode();
             throw new IOException(e);
         }  finally {
-            ReferenceCountUtil.safeRelease(entry);
+            ReferenceCountUtil.release(entry);
             if (explicitLACEntry != null) {
-                ReferenceCountUtil.safeRelease(explicitLACEntry);
+                ReferenceCountUtil.release(explicitLACEntry);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -102,7 +102,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
         if (closed) {
             return;
         }
-        ReferenceCountUtil.safeRelease(writeBuffer);
+        ReferenceCountUtil.release(writeBuffer);
         fileChannel.close();
         closed = true;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogger.java
@@ -189,7 +189,7 @@ public class EntryLogger {
                     throw e;
                 }
             } finally {
-                ReferenceCountUtil.safeRelease(serializedMap);
+                ReferenceCountUtil.release(serializedMap);
             }
             // Flush the ledger's map out before we write the header.
             // Otherwise the header might point to something that is not fully
@@ -837,7 +837,7 @@ public class EntryLogger {
         ByteBuf data = allocator.buffer(entrySize, entrySize);
         int rc = readFromLogChannel(entryLogId, fc, data, pos);
         if (rc != entrySize) {
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
             throw new IOException("Bad entry read from log file id: " + entryLogId,
                     new EntryLookupException("Short read for " + ledgerId + "@"
                                               + entryId + " in " + entryLogId + "@"
@@ -875,7 +875,7 @@ public class EntryLogger {
             int ledgersCount = headers.readInt();
             return new Header(headerVersion, ledgersMapOffset, ledgersCount);
         } finally {
-            ReferenceCountUtil.safeRelease(headers);
+            ReferenceCountUtil.release(headers);
         }
     }
 
@@ -1021,7 +1021,7 @@ public class EntryLogger {
                 pos += entrySize;
             }
         } finally {
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
         }
     }
 
@@ -1110,7 +1110,7 @@ public class EntryLogger {
         } catch (IndexOutOfBoundsException e) {
             throw new IOException(e);
         } finally {
-            ReferenceCountUtil.safeRelease(ledgersMap);
+            ReferenceCountUtil.release(ledgersMap);
         }
 
         if (meta.getLedgersMap().size() != header.ledgersCount) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -345,7 +345,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
                     lac = bb.readLong();
                     lac = ledgerCache.updateLastAddConfirmed(ledgerId, lac);
                 } finally {
-                    ReferenceCountUtil.safeRelease(bb);
+                    ReferenceCountUtil.release(bb);
                 }
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -293,7 +293,7 @@ public interface BookieProtocol {
             ledgerId = -1;
             entryId = -1;
             masterKey = null;
-            ReferenceCountUtil.safeRelease(data);
+            ReferenceCountUtil.release(data);
             data = null;
             recyclerHandle.recycle(this);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -330,7 +330,7 @@ public class ByteBufList extends AbstractReferenceCounted {
                         ctx.write(bx.retainedDuplicate(), i == (buffersCount - 1) ? promise : ctx.voidPromise());
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(b);
+                    ReferenceCountUtil.release(b);
                 }
             } else {
                 ctx.write(msg, promise);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/ByteBufListTest.java
@@ -303,25 +303,25 @@ public class ByteBufListTest {
 
         @Override
         public ChannelFuture write(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture write(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg) {
-            ReferenceCountUtil.safeRelease(msg);
+            ReferenceCountUtil.release(msg);
             return null;
         }
 

--- a/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
+++ b/stream/distributedlog/common/src/test/java/org/apache/distributedlog/io/TestCompressionCodec.java
@@ -71,9 +71,9 @@ public class TestCompressionCodec {
         decompressedBuf.readBytes(decompressedData);
         assertArrayEquals("The decompressed bytes should be same as the original bytes",
                 data, decompressedData);
-        ReferenceCountUtil.safeRelease(buf);
-        ReferenceCountUtil.safeRelease(compressedBuf);
-        ReferenceCountUtil.safeRelease(decompressedBuf);
+        ReferenceCountUtil.release(buf);
+        ReferenceCountUtil.release(compressedBuf);
+        ReferenceCountUtil.release(decompressedBuf);
     }
 
     private void testCompressionCodec2(CompressionCodec codec) throws Exception {
@@ -94,9 +94,9 @@ public class TestCompressionCodec {
         byte[] decompressedData = new byte[decompressedBuf.readableBytes()];
         decompressedBuf.slice().readBytes(decompressedData);
 
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(compressedBuf);
-        ReferenceCountUtil.safeRelease(decompressedBuf);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(compressedBuf);
+        ReferenceCountUtil.release(decompressedBuf);
     }
 
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
@@ -111,7 +111,7 @@ public class LedgerReader {
                             eid, BKException.Code.DigestMatchException, null, bookieAddress.getSocketAddress());
 
                     } finally {
-                        ReferenceCountUtil.safeRelease(buffer);
+                        ReferenceCountUtil.release(buffer);
                     }
                 }
                 readResults.add(rr);

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntry.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntry.java
@@ -103,7 +103,7 @@ class EnvelopedEntry {
             CompressionCodec codec = CompressionUtils.getCompressionCodec(Type.of(codecCode));
             decompressedBuf = codec.decompress(compressedBuf, originDataLen);
         } finally {
-            ReferenceCountUtil.safeRelease(compressedBuf);
+            ReferenceCountUtil.release(compressedBuf);
         }
         return decompressedBuf;
     }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryReader.java
@@ -81,7 +81,7 @@ class EnvelopedEntryReader implements Entry.Reader, RecordStream {
 
     private void releaseBuffer() {
         isExhausted = true;
-        ReferenceCountUtil.safeRelease(this.src);
+        ReferenceCountUtil.release(this.src);
     }
 
     @Override

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/EnvelopedEntryWriter.java
@@ -210,18 +210,18 @@ class EnvelopedEntryWriter implements Writer {
     @Override
     public void completeTransmit(long lssn, long entryId) {
         satisfyPromises(lssn, entryId);
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         synchronized (this) {
-            ReferenceCountUtil.safeRelease(finalizedBuffer);
+            ReferenceCountUtil.release(finalizedBuffer);
         }
     }
 
     @Override
     public void abortTransmit(Throwable reason) {
         cancelPromises(reason);
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         synchronized (this) {
-            ReferenceCountUtil.safeRelease(finalizedBuffer);
+            ReferenceCountUtil.release(finalizedBuffer);
         }
     }
 }

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/logsegment/BKLogSegmentEntryReader.java
@@ -801,7 +801,7 @@ public class BKLogSegmentEntryReader implements SafeRunnable, LogSegmentEntryRea
                         return;
                     }
                 } finally {
-                    ReferenceCountUtil.safeRelease(removedEntry);
+                    ReferenceCountUtil.release(removedEntry);
                 }
             } else if (skipBrokenEntries && BKException.Code.DigestMatchException == entry.getRc()) {
                 // skip this entry and move forward

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/tools/DistributedLogTool.java
@@ -1720,7 +1720,7 @@ import org.slf4j.LoggerFactory;
                     .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(segment.getVersion()))
                     .setEntry(lastEntry.getEntryBuffer())
                     .buildReader();
-            ReferenceCountUtil.safeRelease(lastEntry.getEntryBuffer());
+            ReferenceCountUtil.release(lastEntry.getEntryBuffer());
             LogRecordWithDLSN record = reader.nextRecord();
             LogRecordWithDLSN lastRecord = null;
             while (null != record) {
@@ -2034,7 +2034,7 @@ import org.slf4j.LoggerFactory;
                                     .setEntry(rr.getValue())
                                     .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(metadataVersion))
                                     .buildReader();
-                            ReferenceCountUtil.safeRelease(rr.getValue());
+                            ReferenceCountUtil.release(rr.getValue());
                             printEntry(reader);
                         } else {
                             System.out.println("status = " + BKException.getMessage(rr.getResultCode()));
@@ -2096,7 +2096,7 @@ import org.slf4j.LoggerFactory;
                         .setEntry(entry.getEntryBuffer())
                         .setEnvelopeEntry(LogSegmentMetadata.supportsEnvelopedEntries(metadataVersion))
                         .buildReader();
-                ReferenceCountUtil.safeRelease(entry.getEntryBuffer());
+                ReferenceCountUtil.release(entry.getEntryBuffer());
                 printEntry(reader);
                 ++i;
             }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestEntry.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestEntry.java
@@ -73,7 +73,7 @@ public class TestEntry {
         Assert.assertNull("Empty record set should return null",
             reader.nextRecord());
         assertEquals(refCnt - 1, reader.getSrcBuf().refCnt());
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     @Test(timeout = 20000)
@@ -98,7 +98,7 @@ public class TestEntry {
 
         ByteBuf buffer = writer.getBuffer();
         assertEquals("zero bytes", HEADER_LENGTH, buffer.readableBytes());
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     @Test(timeout = 20000)
@@ -159,7 +159,7 @@ public class TestEntry {
                 .setEntryId(0L)
                 .setEnvelopeEntry(true)
                 .buildReader();
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
         LogRecordWithDLSN record = reader.nextRecord();
         int numReads = 0;
         long expectedTxid = 0L;
@@ -277,7 +277,7 @@ public class TestEntry {
                 new DLSN(1L, 1L, 12L), 0, 0, 3,
                 new DLSN(1L, 1L, 12L), 12L);
 
-        ReferenceCountUtil.safeRelease(buffer);
+        ReferenceCountUtil.release(buffer);
     }
 
     void verifyReadResult(ByteBuf data,

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetReader.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetReader.java
@@ -81,10 +81,10 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
             CompressionCodec codec = CompressionUtils.getCompressionCodec(Type.of(codecCode));
             this.reader = codec.decompress(compressedBuf, decompressedDataLen);
         } finally {
-            ReferenceCountUtil.safeRelease(compressedBuf);
+            ReferenceCountUtil.release(compressedBuf);
         }
         if (numRecords == 0) {
-            ReferenceCountUtil.safeRelease(this.reader);
+            ReferenceCountUtil.release(this.reader);
         }
     }
 
@@ -111,7 +111,7 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
 
         // release the record set buffer when exhausting the reader
         if (0 == numRecords) {
-            ReferenceCountUtil.safeRelease(this.reader);
+            ReferenceCountUtil.release(this.reader);
         }
 
         return record;
@@ -121,7 +121,7 @@ class EnvelopedRecordSetReader implements LogRecordSet.Reader {
     public void release() {
         if (0 != numRecords) {
             numRecords = 0;
-            ReferenceCountUtil.safeRelease(reader);
+            ReferenceCountUtil.release(reader);
         }
     }
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/EnvelopedRecordSetWriter.java
@@ -157,14 +157,14 @@ class EnvelopedRecordSetWriter implements LogRecordSet.Writer {
     @Override
     public synchronized void completeTransmit(long lssn, long entryId, long startSlotId) {
         satisfyPromises(lssn, entryId, startSlotId);
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(recordSetBuffer);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(recordSetBuffer);
     }
 
     @Override
     public synchronized void abortTransmit(Throwable reason) {
         cancelPromises(reason);
-        ReferenceCountUtil.safeRelease(buffer);
-        ReferenceCountUtil.safeRelease(recordSetBuffer);
+        ReferenceCountUtil.release(buffer);
+        ReferenceCountUtil.release(recordSetBuffer);
     }
 }

--- a/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
+++ b/stream/distributedlog/protocol/src/main/java/org/apache/distributedlog/LogRecord.java
@@ -226,7 +226,7 @@ public class LogRecord {
 
     void setPayloadBuf(ByteBuf payload, boolean copyData) {
         if (null != this.payload) {
-            ReferenceCountUtil.safeRelease(this.payload);
+            ReferenceCountUtil.release(this.payload);
         }
         if (copyData) {
             this.payload = Unpooled.copiedBuffer(payload);

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/journal/AbstractStateStoreWithJournal.java
@@ -549,7 +549,7 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
         long txId = ++nextRevision;
         return FutureUtils.ensure(
             writer.write(new LogRecord(txId, cmdBuf.nioBuffer())),
-            () -> ReferenceCountUtil.safeRelease(cmdBuf));
+            () -> ReferenceCountUtil.release(cmdBuf));
     }
 
     protected synchronized CompletableFuture<Long> writeCommandBufReturnTxId(ByteBuf cmdBuf) {
@@ -557,7 +557,7 @@ public abstract class AbstractStateStoreWithJournal<LocalStateStoreT extends Sta
         return FutureUtils.ensure(
             writer.write(new LogRecord(txId, cmdBuf.nioBuffer()))
                 .thenApply(dlsn -> txId),
-            () -> ReferenceCountUtil.safeRelease(cmdBuf));
+            () -> ReferenceCountUtil.release(cmdBuf));
     }
 
     //

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/KVUtils.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/KVUtils.java
@@ -77,7 +77,7 @@ final class KVUtils {
         try {
             cmd.writeTo(new ByteBufOutputStream(buf));
         } catch (IOException e) {
-            ReferenceCountUtil.safeRelease(buf);
+            ReferenceCountUtil.release(buf);
             throw e;
         }
         return buf;

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVAsyncStore.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/kv/RocksdbKVAsyncStore.java
@@ -100,7 +100,7 @@ public class RocksdbKVAsyncStore<K, V>
                 byte[] serializedBytes = ByteBufUtil.getBytes(serializedBuf);
                 localStore.put(keyBytes, serializedBytes, revision);
             } finally {
-                ReferenceCountUtil.safeRelease(serializedBuf);
+                ReferenceCountUtil.release(serializedBuf);
             }
             return null;
         }, writeIOScheduler);
@@ -126,7 +126,7 @@ public class RocksdbKVAsyncStore<K, V>
                     return KVUtils.deserialize(valCoder, Unpooled.wrappedBuffer(prevValue));
                 }
             } finally {
-                ReferenceCountUtil.safeRelease(serializedBuf);
+                ReferenceCountUtil.release(serializedBuf);
             }
         }, writeIOScheduler);
     }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecord.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecord.java
@@ -88,7 +88,7 @@ public class MVCCRecord implements Recycled, Predicate<RangeOption<?>> {
 
     public void setValue(ByteBuf buf, ValueType valueType) {
         if (null != value) {
-            ReferenceCountUtil.safeRelease(value);
+            ReferenceCountUtil.release(value);
         }
         this.value = buf;
         this.valueType = valueType;
@@ -99,7 +99,7 @@ public class MVCCRecord implements Recycled, Predicate<RangeOption<?>> {
 
     private void reset() {
         if (null != value) {
-            ReferenceCountUtil.safeRelease(value);
+            ReferenceCountUtil.release(value);
             value = null;
         }
         modRev = -1L;

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecordCoder.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCRecordCoder.java
@@ -75,7 +75,7 @@ final class MVCCRecordCoder implements Coder<MVCCRecord> {
         buf.writerIndex(buf.writerIndex() + metaLen);
         buf.writeInt(valLen);
         buf.writeBytes(record.getValue().slice());
-        ReferenceCountUtil.safeRelease(buf);
+        ReferenceCountUtil.release(buf);
 
         return data;
     }

--- a/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
+++ b/stream/statelib/src/main/java/org/apache/bookkeeper/statelib/impl/mvcc/MVCCStoreImpl.java
@@ -491,7 +491,7 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         try {
             record = getKeyRecord(key, rawKey);
         } catch (StateStoreRuntimeException e) {
-            ReferenceCountUtil.safeRelease(rawValBuf);
+            ReferenceCountUtil.release(rawValBuf);
             throw e;
         }
 

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/journal/JournalWriter.java
@@ -390,7 +390,7 @@ public class JournalWriter implements Runnable {
                     buf,
                     false,
                     (rc, ledgerId, entryId, addr, ctx) -> {
-                        ReferenceCountUtil.safeRelease(buf);
+                        ReferenceCountUtil.release(buf);
                         if (0 == rc) {
                             if (null != semaphore) {
                                 semaphore.release(len);

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/IncrementTask.java
@@ -90,7 +90,7 @@ abstract class IncrementTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                ReferenceCountUtil.safeRelease(keyBuf);
+                ReferenceCountUtil.release(keyBuf);
             });
     }
 

--- a/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
+++ b/tools/perf/src/main/java/org/apache/bookkeeper/tools/perf/table/WriteTask.java
@@ -96,8 +96,8 @@ abstract class WriteTask extends BenchmarkTask {
                     );
                     writeOpStats.recordOp(latencyMicros);
                 }
-                ReferenceCountUtil.safeRelease(keyBuf);
-                ReferenceCountUtil.safeRelease(valBuf);
+                ReferenceCountUtil.release(keyBuf);
+                ReferenceCountUtil.release(valBuf);
             });
     }
 


### PR DESCRIPTION
Fix #3792 for branch-4.14