### PR TITLE
fix mailing-lists dead links

### DIFF
--- a/site3/website/src/pages/community/mailing-lists.md
+++ b/site3/website/src/pages/community/mailing-lists.md
@@ -10,7 +10,7 @@ If you use Apache BookKeeper, please subscribe to the BookKeeper user mailing li
 
 * [Subscribe](mailto:user-subscribe@bookkeeper.apache.org)
 * [Unsubscribe](mailto:user-unsubscribe@bookkeeper.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/bookkeeper-user/)
+* [Archives](https://lists.apache.org/list.html?user@bookkeeper.apache.org)
 
 ## Developers
 
@@ -18,7 +18,7 @@ If you'd like to contribute to the Apache BookKeeper project, please subscribe t
 
 * [Subscribe](mailto:dev-subscribe@bookkeeper.apache.org)
 * [Unsubscribe](mailto:dev-unsubscribe@bookkeeper.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/bookkeeper-dev/)
+* [Archives](https://lists.apache.org/list.html?dev@bookkeeper.apache.org)
 
 ## Issues
 
@@ -27,7 +27,7 @@ BookKeeper issues mailing list at [issues@bookkeeper.apache.org](mailto:issues@b
 
 * [Subscribe](mailto:issues-subscribe@bookkeeper.apache.org)
 * [Unsubscribe](mailto:issues-unsubscribe@bookkeeper.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/bookkeeper-issues/)
+* [Archives](https://lists.apache.org/list.html?issues@bookkeeper.apache.org)
 
 ### Mail Filters
 
@@ -45,4 +45,4 @@ If you'd like to see changes made in BookKeeper's version control system then su
 
 * [Subscribe](mailto:commits-subscribe@bookkeeper.apache.org)
 * [Unsubscribe](mailto:commits-unsubscribe@bookkeeper.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/bookkeeper-commits/)
+* [Archives](https://lists.apache.org/list.html?commits@bookkeeper.apache.org)

--- a/site3/website/src/pages/community/meeting.md
+++ b/site3/website/src/pages/community/meeting.md
@@ -1,6 +1,6 @@
 # Community meetings
 
-The community meeting runs bi-weekly on Thursday 8am - 9am PST. The meeting link is [https://goo.gl/iyRA6G](https://goo.gl/iyRA6G).
+The community meeting runs bi-weekly on Thursday 8am - 9am PST.
 
 The meeting is typically comprised of 3 parts:
 


### PR DESCRIPTION
### Motivation
Fix the mailing-lists.md dead links which cause Dead link checker failed.
There are some links looks like not stable, we can use new link to replace it.

CI filed link:https://github.com/apache/bookkeeper/actions/runs/4260370313/jobs/7413461899

```
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-user/
ERROR: 4 dead links found!
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-dev/
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-issues/
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-commits/

20 links checked.
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-user/ → Status: 0
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-dev/ → Status: 0
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-issues/ → Status: 0
[✖] http://mail-archives.apache.org/mod_mbox/bookkeeper-commits/ → Status: 0
```
### Changes
1. use new link to replace the dead links in mailing-lists.md.
