### PR TITLE
Fixed locking of PendingAddOp

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1870,7 +1870,8 @@ public class LedgerHandle implements WriteHandle {
                 LOG.debug("Ensemble change is disabled. Retry sending to failed bookies {} for ledger {}.",
                     failedBookies, ledgerId);
             }
-            unsetSuccessAndSendWriteRequest(getCurrentEnsemble(), failedBookies.keySet());
+            executeOrdered(() ->
+                    unsetSuccessAndSendWriteRequest(getCurrentEnsemble(), failedBookies.keySet()));
             return;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -231,7 +231,7 @@ class PendingAddOp implements WriteCallback {
     /**
      * Initiate the add operation.
      */
-    public void initiate() {
+    public synchronized void initiate() {
         hasRun = true;
         if (callbackTriggered) {
             // this should only be true if the request was failed due
@@ -452,7 +452,7 @@ class PendingAddOp implements WriteCallback {
     }
 
 
-    private void maybeRecycle() {
+    private synchronized void maybeRecycle() {
         /**
          * We have opportunity to recycle two objects here.
          * PendingAddOp#toSend and LedgerHandle#pendingAddOp
@@ -482,7 +482,7 @@ class PendingAddOp implements WriteCallback {
         }
     }
 
-    public void recyclePendAddOpObject() {
+    public synchronized void recyclePendAddOpObject() {
         entryId = LedgerHandle.INVALID_ENTRY_ID;
         currentLedgerLength = -1;
         if (payload != null) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -358,7 +358,7 @@ class PendingAddOp implements WriteCallback {
             } else {
                 LOG.warn("Failed to write entry ({}, {}) to bookie ({}, {}): {}",
                         ledgerId, entryId, bookieIndex, addr, BKException.getMessage(rc));
-                lh.executeOrdered(() -> lh.handleBookieFailure(ImmutableMap.of(bookieIndex, addr)));
+                lh.handleBookieFailure(ImmutableMap.of(bookieIndex, addr));
             }
             return;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -358,7 +358,7 @@ class PendingAddOp implements WriteCallback {
             } else {
                 LOG.warn("Failed to write entry ({}, {}) to bookie ({}, {}): {}",
                         ledgerId, entryId, bookieIndex, addr, BKException.getMessage(rc));
-                lh.handleBookieFailure(ImmutableMap.of(bookieIndex, addr));
+                lh.executeOrdered(() -> lh.handleBookieFailure(ImmutableMap.of(bookieIndex, addr)));
             }
             return;
         }


### PR DESCRIPTION
### Motivation

Fix #3805

The test was failing because the updates to the object, done in the `initiate()` method, were not immediately visible to other threads. We must use synchronized consistently in all the accesses.