### PR TITLE
Improved efficiency in DigestManager.verify()

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32CDigestManager.java
@@ -52,9 +52,9 @@ class CRC32CDigestManager extends DigestManager {
     }
 
     @Override
-    void update(ByteBuf data) {
+    void update(ByteBuf data, int offset, int len) {
         MutableInt current = currentCrc.get();
         final int lastCrc = current.intValue();
-        current.setValue(Crc32cIntChecksum.resumeChecksum(lastCrc, data));
+        current.setValue(Crc32cIntChecksum.resumeChecksum(lastCrc, data, offset, len));
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/CRC32DigestManager.java
@@ -33,7 +33,7 @@ class CRC32DigestManager extends DigestManager {
     interface CRC32Digest {
         long getValueAndReset();
 
-        void update(ByteBuf buf);
+        void update(ByteBuf buf, int offset,  int len);
     }
 
     private static final FastThreadLocal<CRC32Digest> crc = new FastThreadLocal<CRC32Digest>() {
@@ -62,7 +62,7 @@ class CRC32DigestManager extends DigestManager {
     }
 
     @Override
-    void update(ByteBuf data) {
-        crc.get().update(data);
+    void update(ByteBuf data, int offset, int len) {
+        crc.get().update(data, offset, len);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DirectMemoryCRC32Digest.java
@@ -43,10 +43,7 @@ class DirectMemoryCRC32Digest implements CRC32Digest {
     }
 
     @Override
-    public void update(ByteBuf buf) {
-        int index = buf.readerIndex();
-        int length = buf.readableBytes();
-
+    public void update(ByteBuf buf, int index, int length) {
         try {
             if (buf.hasMemoryAddress()) {
                 // Calculate CRC directly from the direct memory pointer

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DummyDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DummyDigestManager.java
@@ -38,7 +38,7 @@ public class DummyDigestManager extends DigestManager {
     }
 
     @Override
-    void update(ByteBuf buffer) {}
+    void update(ByteBuf buffer, int offset, int len) {}
 
     @Override
     void populateValueAndReset(ByteBuf buffer) {}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/MacDigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/MacDigestManager.java
@@ -96,8 +96,8 @@ public class MacDigestManager extends DigestManager {
     }
 
     @Override
-    void update(ByteBuf data) {
-        mac.get().update(data.nioBuffer());
+    void update(ByteBuf data, int offset, int len) {
+        mac.get().update(data.slice(offset, len).nioBuffer());
     }
 
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/StandardCRC32Digest.java
@@ -36,7 +36,7 @@ class StandardCRC32Digest implements CRC32Digest {
     }
 
     @Override
-    public void update(ByteBuf buf) {
-        crc.update(buf.nioBuffer());
+    public void update(ByteBuf buf, int offset, int len) {
+        crc.update(buf.slice(offset, len).nioBuffer());
     }
 }

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
@@ -53,8 +53,8 @@ public class Crc32cIntChecksum {
      * @param payload
      * @return
      */
-    public static int resumeChecksum(int previousChecksum, ByteBuf payload) {
-        return CRC32C_HASH.resume(previousChecksum, payload);
+    public static int resumeChecksum(int previousChecksum, ByteBuf payload, int offset, int len) {
+        return CRC32C_HASH.resume(previousChecksum, payload, offset, len);
     }
 
 }

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/IntHash.java
@@ -22,5 +22,10 @@ import io.netty.buffer.ByteBuf;
 
 public interface IntHash {
     int calculate(ByteBuf buffer);
+
+    int calculate(ByteBuf buffer, int offset, int len);
+
     int resume(int current, ByteBuf buffer);
+
+    int resume(int current, ByteBuf buffer, int offset, int len);
 }

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java8IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java8IntHash.java
@@ -36,11 +36,21 @@ public class Java8IntHash implements IntHash {
 
     @Override
     public int resume(int current, ByteBuf buffer) {
+        return resume(current, buffer, buffer.readerIndex(), buffer.readableBytes());
+    }
+
+    @Override
+    public int calculate(ByteBuf buffer, int offset, int len) {
+        return resume(0, buffer, offset, len);
+    }
+
+    @Override
+    public int resume(int current, ByteBuf buffer, int offset, int len) {
         if (buffer.hasArray()) {
-            return hash.resume(current, buffer.array(), buffer.arrayOffset() + buffer.readerIndex(),
-                    buffer.readableBytes());
+            return hash.resume(current, buffer.array(), buffer.arrayOffset() + offset,
+                    len);
         } else {
-            return hash.resume(current, buffer.nioBuffer());
+            return hash.resume(current, buffer.slice(offset, len).nioBuffer());
         }
     }
 }

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/JniIntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/JniIntHash.java
@@ -28,19 +28,27 @@ public class JniIntHash implements IntHash {
 
     @Override
     public int calculate(ByteBuf buffer) {
-        return resume(0, buffer);
+        return calculate(buffer, buffer.readerIndex(), buffer.readableBytes());
     }
 
     @Override
     public int resume(int current, ByteBuf buffer) {
+        return resume(current, buffer, buffer.readerIndex(), buffer.readableBytes());
+    }
+
+    @Override
+    public int calculate(ByteBuf buffer, int offset, int len) {
+        return resume(0, buffer, offset, len);
+    }
+
+    @Override
+    public int resume(int current, ByteBuf buffer, int offset, int len) {
         if (buffer.hasMemoryAddress()) {
-            return hash.resume(current, buffer.memoryAddress() + buffer.readerIndex(),
-                    buffer.readableBytes());
+            return hash.resume(current, buffer.memoryAddress() + offset, len);
         } else if (buffer.hasArray()) {
-            return hash.resume(current, buffer.array(), buffer.arrayOffset() + buffer.readerIndex(),
-                    buffer.readableBytes());
+            return hash.resume(current, buffer.array(), buffer.arrayOffset() + offset, len);
         } else {
-            return hash.resume(current, buffer.nioBuffer());
+            return hash.resume(current, buffer.slice(offset, len).nioBuffer());
         }
     }
 }

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/ChecksumTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/ChecksumTest.java
@@ -44,7 +44,7 @@ public class ChecksumTest {
     @Test
     public void testCrc32cValueResume() {
         final byte[] bytes = "Some String".getBytes();
-        int checksum = Crc32cIntChecksum.resumeChecksum(0, Unpooled.wrappedBuffer(bytes));
+        int checksum = Crc32cIntChecksum.resumeChecksum(0, Unpooled.wrappedBuffer(bytes), 0, bytes.length);
 
         assertEquals(608512271, checksum);
     }
@@ -58,19 +58,19 @@ public class ChecksumTest {
 
         checksum = Crc32cIntChecksum.computeChecksum(Unpooled.wrappedBuffer(bytes, 0, 1));
         for (int i = 1; i < bytes.length; i++) {
-            checksum = Crc32cIntChecksum.resumeChecksum(checksum, Unpooled.wrappedBuffer(bytes, i, 1));
+            checksum = Crc32cIntChecksum.resumeChecksum(checksum, Unpooled.wrappedBuffer(bytes), i, 1);
         }
         assertEquals(608512271, checksum);
 
         checksum = Crc32cIntChecksum.computeChecksum(Unpooled.wrappedBuffer(bytes, 0, 4));
-        checksum = Crc32cIntChecksum.resumeChecksum(checksum, Unpooled.wrappedBuffer(bytes, 4, 7));
+        checksum = Crc32cIntChecksum.resumeChecksum(checksum, Unpooled.wrappedBuffer(bytes), 4, 7);
         assertEquals(608512271, checksum);
 
 
         ByteBuf buffer = Unpooled.wrappedBuffer(bytes, 0, 4);
         checksum = Crc32cIntChecksum.computeChecksum(buffer);
         checksum = Crc32cIntChecksum.resumeChecksum(
-            checksum, Unpooled.wrappedBuffer(bytes, 4, bytes.length - 4));
+            checksum, Unpooled.wrappedBuffer(bytes), 4, bytes.length - 4);
 
         assertEquals(608512271, checksum);
     }
@@ -86,7 +86,7 @@ public class ChecksumTest {
     @Test
     public void testCrc32cLongValueResume() {
         final byte[] bytes = "Some String".getBytes();
-        long checksum = Crc32cIntChecksum.resumeChecksum(0, Unpooled.wrappedBuffer(bytes));
+        long checksum = Crc32cIntChecksum.resumeChecksum(0, Unpooled.wrappedBuffer(bytes), 0, bytes.length);
 
         assertEquals(608512271L, checksum);
     }

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManagerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManagerBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.proto.checksum;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;
+import org.apache.bookkeeper.util.ByteBufList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmarks for different digest type
+ * getting started:
+ * 1. http://tutorials.jenkov.com/java-performance/jmh.html
+ * 2. http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/
+ * 3. google
+ * To run:
+ * build project from command line.
+ * execute ./run.sh
+ */
+public class DigestManagerBenchmark {
+
+    static byte[] randomBytes(int sz) {
+        byte[] b = new byte[sz];
+        ThreadLocalRandom.current().nextBytes(b);
+        return b;
+    }
+
+    /**
+     * MyState.
+     */
+    @State(Scope.Thread)
+    public static class MyState {
+
+        @Param({"64", "1024", "4086", "8192"})
+        public int entrySize;
+
+        private DigestManager dm;
+
+        public ByteBuf digestBuf;
+
+        @Setup(Level.Trial)
+        public void doSetup() throws Exception {
+            final byte[] password = "password".getBytes(StandardCharsets.UTF_8);
+
+            dm = DigestManager.instantiate(ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE),
+                    password, DigestType.CRC32C, PooledByteBufAllocator.DEFAULT, true);
+
+            ByteBuf data = ByteBufAllocator.DEFAULT.directBuffer(entrySize, entrySize);
+            data.writeBytes(randomBytes(entrySize));
+
+            digestBuf = ByteBufAllocator.DEFAULT.directBuffer();
+            digestBuf.writeBytes(ByteBufList.coalesce(
+                    dm.computeDigestAndPackageForSending(1234, 1234, entrySize, data)));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Threads(2)
+    @Fork(1)
+    public void verifyDigest(MyState state) throws Exception {
+        state.digestBuf.readerIndex(0);
+        state.dm.verifyDigestAndReturnData(1234, state.digestBuf);
+    }
+}

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestTypeBenchmark.java
@@ -172,7 +172,7 @@ public class DigestTypeBenchmark {
     public void digestManager(MyState state) {
         final ByteBuf buff = state.getByteBuff(state.bufferType);
         final DigestManager dm = state.getDigestManager(state.digest);
-        dm.update(buff);
+        dm.update(buff, 0, buff.readableBytes());
         state.digestBuf.clear();
         dm.populateValueAndReset(state.digestBuf);
     }


### PR DESCRIPTION
### Motivation

In `DigestManager.verifyDigestAndReturnData()` there are a couple of simple improvements: 

 1. For the temp buffer where to store the digest, do not acquire a buffer from the pool each time. Instead, use a thread-local buffer.
 2. Instead of taking slices() at each time, extend the interface to take a "offset, length" pair and save the allocations.
 

### Benchmarks: 

#### Before

```
Benchmark                            (entrySize)   Mode  Cnt   Score   Error   Units
DigestManagerBenchmark.verifyDigest           64  thrpt    3  13.450 ± 3.634  ops/us
DigestManagerBenchmark.verifyDigest         1024  thrpt    3   7.908 ± 2.637  ops/us
DigestManagerBenchmark.verifyDigest         4086  thrpt    3   3.233 ± 0.882  ops/us
DigestManagerBenchmark.verifyDigest         8192  thrpt    3   1.846 ± 0.047  ops/us
```

Allocations: 230 bytes per operation

#### After

```
Benchmark                            (entrySize)   Mode  Cnt   Score   Error   Units
DigestManagerBenchmark.verifyDigest           64  thrpt    3  46.312 ± 7.414  ops/us
DigestManagerBenchmark.verifyDigest         1024  thrpt    3  13.379 ± 1.069  ops/us
DigestManagerBenchmark.verifyDigest         4086  thrpt    3   3.787 ± 0.059  ops/us
DigestManagerBenchmark.verifyDigest         8192  thrpt    3   1.956 ± 0.052  ops/us
```

Allocations: 64 bytes per operation

Note: these remaining 64 bytes are only due to the Java9 reflection access. It would not be present on the JNI-based CRC32c backend (though that does not work on Mac M1).

![image](https://user-images.githubusercontent.com/62500/221421437-702e4fa0-a2b3-41bb-aefa-bd8368fff4b9.png)
