### PR TITLE
[Bug] Always one orphan ledger is created

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
@@ -382,9 +382,12 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
                 allocatePath, DistributedLogConstants.EMPTY_BYTES, (int) version.getLongVersion());
         ZKVersionedSetOp commitOp = new ZKVersionedSetOp(zkSetDataOp, this);
         tryObtainTxn.addOp(commitOp);
-        if (this.phase != Phase.ALLOCATED) {
-            setPhase(Phase.HANDING_OVER);
-        }
+        if (this.phase == Phase.ALLOCATED) {
+            // please check issue: https://github.com/apache/bookkeeper/issues/3812
+            allocatePromise.complete(lh);
+            return;
+        } // otherwise, it is ALLOCATING phase
+        setPhase(Phase.HANDING_OVER);
         allocatePromise.complete(lh);
     }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
@@ -382,7 +382,9 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
                 allocatePath, DistributedLogConstants.EMPTY_BYTES, (int) version.getLongVersion());
         ZKVersionedSetOp commitOp = new ZKVersionedSetOp(zkSetDataOp, this);
         tryObtainTxn.addOp(commitOp);
-        setPhase(Phase.HANDING_OVER);
+        if (this.phase != Phase.ALLOCATED) {
+            setPhase(Phase.HANDING_OVER);
+        }
         allocatePromise.complete(lh);
     }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/bk/SimpleLedgerAllocator.java
@@ -310,7 +310,9 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
                 tryObtainTxn = null;
                 tryObtainListener = null;
                 // mark flag to issue an allocation request
-                shouldAllocate = true;
+                if (lhToNotify == null) {
+                    shouldAllocate = true;
+                }
             }
         }
         if (null != listenerToNotify && null != lhToNotify) {
@@ -382,11 +384,6 @@ public class SimpleLedgerAllocator implements LedgerAllocator, FutureEventListen
                 allocatePath, DistributedLogConstants.EMPTY_BYTES, (int) version.getLongVersion());
         ZKVersionedSetOp commitOp = new ZKVersionedSetOp(zkSetDataOp, this);
         tryObtainTxn.addOp(commitOp);
-        if (this.phase == Phase.ALLOCATED) {
-            // please check issue: https://github.com/apache/bookkeeper/issues/3812
-            allocatePromise.complete(lh);
-            return;
-        } // otherwise, it is ALLOCATING phase
         setPhase(Phase.HANDING_OVER);
         allocatePromise.complete(lh);
     }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogWriteHandler.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogWriteHandler.java
@@ -23,8 +23,13 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.distributedlog.api.AsyncLogWriter;
 import org.apache.distributedlog.api.DistributedLogManager;
+import org.apache.distributedlog.api.LogWriter;
 import org.apache.distributedlog.api.namespace.NamespaceBuilder;
 import org.apache.distributedlog.bk.LedgerAllocator;
 import org.apache.distributedlog.bk.LedgerAllocatorPool;
@@ -89,6 +94,49 @@ public class TestBKLogWriteHandler extends TestDistributedLogBase {
         AsyncLogWriter writer = Utils.ioResult(dlm.openAsyncLogWriter());
         writer.write(DLMTestUtil.getLogRecordInstance(1L));
         Utils.close(writer);
+    }
+
+    @Test
+    public void testLedgerNumber() throws Exception {
+        URI uri = createDLMURI("/" + runtime.getMethodName());
+        ensureURICreated(zkc, uri);
+
+        DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
+        confLocal.addConfiguration(conf);
+        confLocal.setOutputBufferSize(0);
+
+        BKDistributedLogNamespace namespace = (BKDistributedLogNamespace)
+            NamespaceBuilder.newBuilder()
+                .conf(confLocal)
+                .uri(uri)
+                .build();
+        DistributedLogManager dlm = namespace.openLog("test-log");
+        BookKeeperAdmin admin = new BookKeeperAdmin(zkServers);
+
+        Set<Long> s1 = getLedgers(admin);
+        LOG.info("Ledgers after init: " + s1);
+
+        LogWriter writer = dlm.openLogWriter();
+        writer.write(new LogRecord(1, "test-data".getBytes(StandardCharsets.UTF_8)));
+        writer.close();
+
+        Set<Long> s2 = getLedgers(admin);
+        LOG.info("Ledgers after write: " + s2);
+        dlm.delete();
+
+        Set<Long> s3 = getLedgers(admin);
+        LOG.info("Ledgers after delete: " + s3);
+
+        assertEquals(0, s3.size());
+        assertEquals(s1.size() + 1, s2.size());
+
+    }
+
+    // Get all ledgers from BK admin
+    private Set<Long> getLedgers(BookKeeperAdmin bkAdmin) throws IOException {
+        Set<Long> res = new HashSet<>();
+        bkAdmin.listLedgers().forEach(res::add);
+        return res;
     }
 
 }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogWriteHandler.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestBKLogWriteHandler.java
@@ -123,12 +123,12 @@ public class TestBKLogWriteHandler extends TestDistributedLogBase {
         Set<Long> s2 = getLedgers(admin);
         LOG.info("Ledgers after write: " + s2);
         dlm.delete();
+        assertEquals(1, s2.size() - s1.size()); // exact 1 ledger created only
 
         Set<Long> s3 = getLedgers(admin);
         LOG.info("Ledgers after delete: " + s3);
 
-        assertEquals(0, s3.size());
-        assertEquals(s1.size() + 1, s2.size());
+        assertEquals(s1.size(), s3.size());
 
     }
 

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestRollLogSegments.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestRollLogSegments.java
@@ -293,6 +293,7 @@ public class TestRollLogSegments extends TestDistributedLogBase {
 
         List<LogSegmentMetadata> segments = dlm.getLogSegments();
         logger.info("LogSegments : {}", segments);
+        logger.info("LogSegments size: {}", segments.size());
 
         assertTrue(segments.size() >= 2);
         ensureOnlyOneInprogressLogSegments(segments);
@@ -308,6 +309,7 @@ public class TestRollLogSegments extends TestDistributedLogBase {
 
         segments = dlm.getLogSegments();
         logger.info("LogSegments : {}", segments);
+        logger.info("LogSegments size: {}", segments.size());
 
         assertEquals(numSegmentsAfterAsyncWrites + numLogSegments / 2, segments.size());
         ensureOnlyOneInprogressLogSegments(segments);


### PR DESCRIPTION
Issue #3812

Descriptions of the changes in this PR:

Fix bug and one UT for verification


### Motivation

Fix the bug

### Changes

To avoid the ledger being created twice, add a state check before setting a new state

