### PR TITLE
Remove compiling with `-Werror` to support Java 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -930,7 +930,6 @@
           <source>${javac.target}</source>
           <target>${javac.target}</target>
           <compilerArgs>
-            <compilerArg>-Werror</compilerArg>
             <compilerArg>-Xlint:deprecation</compilerArg>
             <compilerArg>-Xlint:unchecked</compilerArg>
             <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->


### PR DESCRIPTION
### Motivation

Building BK with Java 19 fails because there is a deprecation warning and it's being treated as an error.

In a few places, we are using `Thread.getId()` which has been deprecated since Java 19. There is now a new replacement: `Thread.getThreadId()`. 

The problem is that we cannot use the new method (which is only in Java 19+) and the build fails with the deprecated method.

I believe the best solution is to not use `-Werrror` flag in the build.