### PR TITLE
Support update ledger metadata option bk-cli

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -805,6 +805,7 @@ public class BookieShell implements Tool {
             opts.addOption("l", "ledgerid", true, "Ledger ID");
             opts.addOption("dumptofile", true, "Dump metadata for ledger, to a file");
             opts.addOption("restorefromfile", true, "Restore metadata for ledger, from a file");
+            opts.addOption("update", false, "Update metadata if ledger already exist");
         }
 
         @Override
@@ -827,6 +828,7 @@ public class BookieShell implements Tool {
             if (cmdLine.hasOption("restorefromfile")) {
                 flag.restoreFromFile(cmdLine.getOptionValue("restorefromfile"));
             }
+            flag.update(cmdLine.hasOption("update"));
 
             LedgerMetaDataCommand cmd = new LedgerMetaDataCommand(ledgerIdFormatter);
             cmd.apply(bkConf, flag);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.apache.bookkeeper.client.BKException.BKLedgerExistException;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
@@ -38,6 +39,7 @@ import org.apache.bookkeeper.tools.cli.helpers.BookieCommand;
 import org.apache.bookkeeper.tools.framework.CliFlags;
 import org.apache.bookkeeper.tools.framework.CliSpec;
 import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +94,10 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
 
         @Parameter(names =  {"-lf", "--ledgeridformatter"}, description = "Set ledger id formatter")
         private String ledgerIdFormatter = DEFAULT;
+
+        @Parameter(names = { "-u",
+                "--update" }, description = "Update metadata if already exist while restoring metadata")
+        private boolean update = false;
     }
 
     @Override
@@ -124,7 +130,15 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
                     byte[] serialized = Files.readAllBytes(
                         FileSystems.getDefault().getPath(flag.restoreFromFile));
                     LedgerMetadata md = serDe.parseConfig(serialized, flag.ledgerId, Optional.empty());
-                    m.createLedgerMetadata(flag.ledgerId, md).join();
+                    try {
+                        m.createLedgerMetadata(flag.ledgerId, md).join();
+                    } catch (Exception be) {
+                        if (!flag.update || !(be.getCause() instanceof BKLedgerExistException)) {
+                            throw be;
+                        }
+                        m.writeLedgerMetadata(flag.ledgerId, md, new LongVersion(-1L)).join();
+                        LOG.info("successsfully updated ledger metadata {}", flag.ledgerId);
+                    }
                 } else {
                     printLedgerMetadata(flag.ledgerId, m.readLedgerMetadata(flag.ledgerId).get().getValue(), true);
                 }


### PR DESCRIPTION
### Motivation

Bk-CLI api supports creating ledger metadata from the metadata binary payload-file but it doesn't support updating metadata for existing ledger which will require some time during updating metadata in some operational update usecases. Therefore, support update metadata if ledger already exists by adding a flag.

### Changes

`bookkeeper shell ledgermetadata -restorefromfile` command can update ledger-metadata by passing additional `--update flag`.
