### PR TITLE
Fix: bookie-shell ledger-metadata usage with correct param

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -840,7 +840,7 @@ public class BookieShell implements Tool {
 
         @Override
         String getUsage() {
-            return "ledgermetadata -ledgerid <ledgerid> [--dump-to-file FILENAME|--restore-from-file FILENAME]";
+            return "ledgermetadata -ledgerid <ledgerid> [--dumptofile FILENAME|--restorefromfile FILENAME]";
         }
 
         @Override


### PR DESCRIPTION
### Motivation

`./bin/bookkeeper shell ledgermetadata` usage is showing incorrect params `dump-to-file` , `restore-from` to user while executing the command.

### Changes

Fix usage with correct param `dumptofile` and `restorefromfile`

