### PR TITLE
Fix: typo for ledger-metadata param: restorefromfile

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -814,7 +814,7 @@ public class BookieShell implements Tool {
                 System.err.println("Must specify a ledger id");
                 return -1;
             }
-            if (cmdLine.hasOption("dumptofile") && cmdLine.hasOption("restorefromefile")) {
+            if (cmdLine.hasOption("dumptofile") && cmdLine.hasOption("restorefromfile")) {
                 System.err.println("Only one of --dumptofile and --restorefromfile can be specified");
                 return -2;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/client/LedgerMetaDataCommand.java
@@ -87,7 +87,7 @@ public class LedgerMetaDataCommand extends BookieCommand<LedgerMetaDataCommand.L
         @Parameter(names = { "-d", "--dumptofile" }, description = "Dump metadata for ledger, to a file")
         private String dumpToFile = DEFAULT;
 
-        @Parameter(names = { "-r", "--restorefromefile" }, description = "Restore metadata for ledger, from a file")
+        @Parameter(names = { "-r", "--restorefromfile" }, description = "Restore metadata for ledger, from a file")
         private String restoreFromFile = DEFAULT;
 
         @Parameter(names =  {"-lf", "--ledgeridformatter"}, description = "Set ledger id formatter")


### PR DESCRIPTION
### Motivation

https://github.com/apache/bookkeeper/pull/2019 has introduced a typo in ledgerMetadata bk-shell command which checks invalid input param `restorefromefile` instead of `restorefromfile`. so, this PR fixes that typo which will not cause any compatibility issue for this functionality as such.