### PR TITLE
Fixed back API of Crc32cIntChecksum

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Crc32cIntChecksum.java
@@ -47,6 +47,28 @@ public class Crc32cIntChecksum {
     }
 
     /**
+     * Computes crc32c checksum: if it is able to load crc32c native library then it computes using that native library
+     * which is faster as it computes using hardware machine instruction else it computes using crc32c algo.
+     *
+     * @param payload
+     * @return
+     */
+    public static int computeChecksum(ByteBuf payload, int offset, int len) {
+        return CRC32C_HASH.calculate(payload, offset, len);
+    }
+
+    /**
+     * Computes incremental checksum with input previousChecksum and input payload
+     *
+     * @param previousChecksum : previously computed checksum
+     * @param payload
+     * @return
+     */
+    public static int resumeChecksum(int previousChecksum, ByteBuf payload) {
+        return CRC32C_HASH.resume(previousChecksum, payload);
+    }
+
+    /**
      * Computes incremental checksum with input previousChecksum and input payload
      *
      * @param previousChecksum : previously computed checksum


### PR DESCRIPTION
### Motivation

In #3810 the signature of `Crc32cIntChecksum.resumeChecksum()` was changed to accept `offset` & `len` in the buffer.

Since this method is also used externally (in Pulsar), we should leave also the old method signature to avoid breaking the API when upgrading BK.
