### PR TITLE
Support build in the aarch64 linux platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1284,6 +1284,18 @@
       </build>
     </profile>
     <profile>
+      <id>aarch64-linux-nar-aol</id>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <nar.aolProperties>src/aarch64_aol.properties</nar.aolProperties>
+      </properties>
+    </profile>
+    <profile>
       <id>mac-apple-silicon</id>
       <activation>
         <os>
@@ -1292,7 +1304,7 @@
         </os>
       </activation>
       <properties>
-        <nar.aolProperties>src/apple_m1_aol.properties</nar.aolProperties>
+        <nar.aolProperties>src/aarch64_aol.properties</nar.aolProperties>
       </properties>
     </profile>
     <profile>

--- a/src/aarch64_aol.properties
+++ b/src/aarch64_aol.properties
@@ -36,3 +36,37 @@ aarch64.MacOSX.gpp.shared.extension=dylib
 aarch64.MacOSX.gpp.plugin.extension=bundle
 aarch64.MacOSX.gpp.jni.extension=jnilib
 aarch64.MacOSX.gpp.executable.extension=
+
+
+#
+# aarch64 (arm64) Linux
+#
+aarch64.Linux.linker=g++
+
+aarch64.Linux.gpp.c.compiler=gcc
+aarch64.Linux.gpp.c.defines=Linux GNU_GCC
+aarch64.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC
+aarch64.Linux.gpp.c.includes=**/*.c
+aarch64.Linux.gpp.c.excludes=
+
+# options for gcc linker front end
+aarch64.Linux.gpp.linker.options=-shared -shared-libgcc -fPIC -fexceptions
+aarch64.Linux.gpp.linker.sysLibs=stdc++
+aarch64.Linux.gpp.linker.libs=
+
+aarch64.Linux.gpp.java.include=include;include/linux
+aarch64.Linux.gpp.java.runtimeDirectory=jre/lib/i386/client
+
+aarch64.Linux.gpp.lib.prefix=lib
+aarch64.Linux.gpp.shared.prefix=lib
+aarch64.Linux.gpp.static.extension=a
+aarch64.Linux.gpp.shared.extension=so
+aarch64.Linux.gpp.plugin.extension=so
+aarch64.Linux.gpp.jni.extension=so
+aarch64.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+aarch64.Linux.gcc.static.extension=a
+aarch64.Linux.gcc.shared.extension=so*
+aarch64.Linux.gcc.plugin.extension=so
+aarch64.Linux.gcc.jni.extension=so


### PR DESCRIPTION
---
### Motivation

When releasing the bookkeeper on aarch64 Mac OS, it will build aarch64 linux image to release operations. Add aol properties for the aarch64 linux.

the properties come from https://github.com/maven-nar/nar-maven-plugin/blob/master/src/main/resources/com/github/maven_nar/aol.properties#L583