### PR TITLE
Avoid using thread-local WriteSet when possible

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DistributionSchedule.java
@@ -136,10 +136,22 @@ public interface DistributionSchedule {
             }
         };
 
+    int getWriteQuorumSize();
+
     /**
      * Return the set of bookie indices to send the message to.
      */
     WriteSet getWriteSet(long entryId);
+
+    /**
+     * Return the WriteSet bookie index for a given and index
+     * in the WriteSet.
+     *
+     * @param entryId
+     * @param writeSetIndex
+     * @return
+     */
+    int getWriteSetBookieIndex(long entryId, int writeSetIndex);
 
     /**
      * Return the set of bookies indices to send the messages to the whole ensemble.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -443,18 +443,17 @@ public class LedgerChecker {
                                                   }
                                               });
 
-                DistributionSchedule.WriteSet writeSet = lh.getDistributionSchedule().getWriteSet(entryToRead);
-                for (int i = 0; i < writeSet.size(); i++) {
+                DistributionSchedule ds = lh.getDistributionSchedule();
+                for (int i = 0; i < ds.getWriteQuorumSize(); i++) {
                     try {
                         acquirePermit();
-                        BookieId addr = curEnsemble.get(writeSet.get(i));
+                        BookieId addr = curEnsemble.get(ds.getWriteSetBookieIndex(entryToRead, i));
                         bookieClient.readEntry(addr, lh.getId(), entryToRead,
                                 eecb, null, BookieProtocol.FLAG_NONE);
                     } catch (InterruptedException e) {
                         LOG.error("InterruptedException when checking entry : {}", entryToRead, e);
                     }
                 }
-                writeSet.recycle();
                 return;
             } else {
                 fragments.add(lastLedgerFragment);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -198,14 +198,9 @@ class PendingAddOp implements WriteCallback {
         // completes.
         //
         // We call sendAddSuccessCallback when unsetting t cover this case.
-        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);
-        try {
-            if (!writeSet.contains(bookieIndex)) {
-                lh.sendAddSuccessCallbacks();
-                return;
-            }
-        } finally {
-            writeSet.recycle();
+        if (!lh.distributionSchedule.hasEntry(entryId, bookieIndex)) {
+            lh.sendAddSuccessCallbacks();
+            return;
         }
 
         if (callbackTriggered) {
@@ -256,14 +251,8 @@ class PendingAddOp implements WriteCallback {
         lh.maybeHandleDelayedWriteBookieFailure();
 
         // Iterate over set and trigger the sendWriteRequests
-        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(entryId);
-
-        try {
-            for (int i = 0; i < writeSet.size(); i++) {
-                sendWriteRequest(ensemble, writeSet.get(i));
-            }
-        } finally {
-            writeSet.recycle();
+        for (int i = 0; i < lh.distributionSchedule.getWriteQuorumSize(); i++) {
+            sendWriteRequest(ensemble, lh.distributionSchedule.getWriteSetBookieIndex(entryId, i));
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -79,13 +79,9 @@ class PendingWriteLacOp implements WriteLacCallback {
 
     void initiate(ByteBufList toSend) {
         this.toSend = toSend;
-        DistributionSchedule.WriteSet writeSet = lh.distributionSchedule.getWriteSet(lac);
-        try {
-            for (int i = 0; i < writeSet.size(); i++) {
-                sendWriteLacRequest(writeSet.get(i));
-            }
-        } finally {
-            writeSet.recycle();
+
+        for (int i = 0; i < lh.distributionSchedule.getWriteQuorumSize(); i++) {
+            sendWriteLacRequest(lh.distributionSchedule.getWriteSetBookieIndex(lac, i));
         }
     }
 


### PR DESCRIPTION
### Motivation

For computing WriteSet we use a `Recycler` to avoid instantiating a new object each time. While that avoid allocations, it's based on thread-locals and has non-zero cost.

In most cases the usage of WriteSet that we are doing is very basic: 
 * Get a `WriteSet` from the recycler
 * check the bookie indices
 * recycle the write-set

Instead, we can just expose a method in the `DistributionSchedule` interface and avoid any recycler or object allocations.