### PR TITLE
[improve] Enhance LedgerFragment toString method

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragment.java
@@ -229,9 +229,9 @@ public class LedgerFragment {
     @Override
     public String toString() {
         return String.format("Fragment(LedgerID: %d, FirstEntryID: %d[%d], "
-                + "LastKnownEntryID: %d[%d], Host: %s, Closed: %s)", ledgerId, firstEntryId,
+                        + "LastKnownEntryID: %d[%d], Host: %s, Closed: %s, Type: %s)", ledgerId, firstEntryId,
                 getFirstStoredEntryId(), lastKnownEntryId, getLastStoredEntryId(),
-                getAddresses(), isLedgerClosed);
+                getAddresses(), isLedgerClosed, replicateType);
     }
 
     /**


### PR DESCRIPTION
### Motivation

LedgerFragment adds the state of replicateType, but it has not been added to the toString method. I think the replicateType should be added to the toString method to track the state of LF and troubleshoot problems.

### Changes

LedgerFragment is generally in `DATA_LOSS` or `DATA_NOT_ADHERING_PLACEMENT` state.
But it shouldn't have status when it's in detection progress or used elsewhere, so I added `NULL` status.

The following log shows the result:

replicating `DATA_LOSS` LedgerFragment
![image](https://user-images.githubusercontent.com/35599757/222430978-7216f8ac-79da-4298-b12d-8c200613ec0e.png)

replicating `DATA_NOT_ADHERING_PLACEMENT` LedgerFragment
![image](https://user-images.githubusercontent.com/35599757/222431002-3b57a771-adc6-4d37-aaf6-e7f1b0c7bc87.png)

checking LedgerFragment in `NULL` type
![image](https://user-images.githubusercontent.com/35599757/222431053-8c0194b9-518e-4988-8f9e-b11c38f2f3cf.png)
