### PR TITLE
Fixed CI PR validation

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name:  Generate Javadoc
         if: steps.check_changes.outputs.docs_only != 'true'
-        run: mvn -B -nsu -am -pl bookkeeper-common,bookkeeper-server,:bookkeeper-stats-api,:bookkeeper-stats-providers,:codahale-metrics-provider,:prometheus-metrics-provider javadoc:aggregate -DskipTests -Pdelombok -Dchesktyle.skip -Dspotbugs.skip
+        run: mvn -B -nsu -am -pl testtools,bookkeeper-common,bookkeeper-server,:bookkeeper-stats-api,:bookkeeper-stats-providers,:codahale-metrics-provider,:prometheus-metrics-provider javadoc:aggregate -DskipTests -Pdelombok -Dchesktyle.skip -Dspotbugs.skip
 
   unit-tests:
     name: ${{ matrix.step_name }}

--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -81,7 +81,9 @@ jobs:
 
       - name: Validate pull request
         if: steps.check_changes.outputs.docs_only != 'true'
-        run: mvn clean -T 1C -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: |
+          mvn -T 1C -B -nsu clean install -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+          mvn -T 1C -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Check license files
         if: steps.check_changes.outputs.docs_only != 'true'
@@ -89,7 +91,7 @@ jobs:
 
       - name:  Generate Javadoc
         if: steps.check_changes.outputs.docs_only != 'true'
-        run: mvn -B -nsu -am -pl testtools,bookkeeper-common,bookkeeper-server,:bookkeeper-stats-api,:bookkeeper-stats-providers,:codahale-metrics-provider,:prometheus-metrics-provider javadoc:aggregate -DskipTests -Pdelombok -Dchesktyle.skip -Dspotbugs.skip
+        run: mvn -B -nsu -am -pl bookkeeper-common,bookkeeper-server,:bookkeeper-stats-api,:bookkeeper-stats-providers,:codahale-metrics-provider,:prometheus-metrics-provider javadoc:aggregate -DskipTests -Pdelombok -Dchesktyle.skip -Dspotbugs.skip
 
   unit-tests:
     name: ${{ matrix.step_name }}


### PR DESCRIPTION
### Motivation

CI started failing on the Javadoc step of PR validation. eg: https://github.com/apache/bookkeeper/actions/runs/4317981493/jobs/7535724009 

It looks like the testtools module is not added and not installed before.