### PR TITLE
Fix Spotbugs check failed

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -159,6 +159,11 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: Build
         run: |
           projects_list=
@@ -230,6 +235,11 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: Build with Maven
         run: mvn -B -nsu clean install -Pdocker -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
@@ -271,6 +281,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
+
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
 
       - name: Build with Maven
         run: mvn -B -nsu clean install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
@@ -318,6 +333,11 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: mvn package
         run: mvn -B -nsu clean package -DskipTests
 
@@ -349,6 +369,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
+
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
 
       - name: mvn package
         run: mvn -B -nsu clean package -DskipTests
@@ -394,6 +419,11 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.jdk_version }}
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: Build with Maven
         run: mvn clean package -B -nsu -DskipBookKeeperServerTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
@@ -428,6 +458,11 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
+
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
 
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with

--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -79,6 +79,11 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: Validate pull request
         if: steps.check_changes.outputs.docs_only != 'true'
         run: |

--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -81,7 +81,9 @@ jobs:
 
       - name: Validate pull request
         if: steps.check_changes.outputs.docs_only != 'true'
-        run: mvn clean -T 1C -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: |
+          mvn -T 1C -B -nsu clean install -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+          mvn -T 1C -B -nsu apache-rat:check checkstyle:check spotbugs:check package -Ddistributedlog -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
 
       - name: Check license files
         if: steps.check_changes.outputs.docs_only != 'true'

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -23,6 +23,7 @@ import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_NONE;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
@@ -80,6 +81,7 @@ class PendingAddOp implements WriteCallback {
     boolean allowFailFast = false;
     List<BookieId> ensemble;
 
+    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
     static PendingAddOp create(LedgerHandle lh, ClientContext clientCtx,
                                List<BookieId> ensemble,
                                ByteBuf payload, EnumSet<WriteFlag> writeFlags,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/PageCacheUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/PageCacheUtil.java
@@ -95,7 +95,7 @@ public final class PageCacheUtil {
         }
         try {
             NATIVE_IO.posix_fadvise(fd, offset, len, POSIX_FADV_DONTNEED);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.warn("Failed to perform posix_fadvise: {}", e.getMessage());
             fadvisePossible = false;
         }

--- a/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml
+++ b/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml
@@ -317,6 +317,11 @@
     <!-- generated code, we can't be held responsible for findbugs in it //-->
     <Class name="~.*\.TransformedRecord" />
   </Match>
+  <!-- distributedlog-messaging -->
+  <Match>
+    <!-- generated code, we can't be held responsible for findbugs in it //-->
+    <Class name="~org\.apache\.bookkeeper\.bookie\.generated.*" />
+  </Match>
   <Match>
     <!-- it is safe to store external bytes reference here. //-->
     <Class name="org.apache.distributedlog.messaging.PartitionedMultiWriter" />

--- a/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml
+++ b/buildtools/src/main/resources/bookkeeper/findbugsExclude.xml
@@ -317,7 +317,7 @@
     <!-- generated code, we can't be held responsible for findbugs in it //-->
     <Class name="~.*\.TransformedRecord" />
   </Match>
-  <!-- distributedlog-messaging -->
+  <!-- micro-benchmarks -->
   <Match>
     <!-- generated code, we can't be held responsible for findbugs in it //-->
     <Class name="~org\.apache\.bookkeeper\.bookie\.generated.*" />

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/GroupSortBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/GroupSortBenchmark.java
@@ -21,8 +21,10 @@
 
 package org.apache.bookkeeper.bookie;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.storage.ldb.ArrayGroupSort;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -55,7 +57,7 @@ public class GroupSortBenchmark {
         private long[] items;
 
         public TestState() {
-            Random r = new Random();
+            Random r = ThreadLocalRandom.current();
             for (int i = 0; i < (N * 4); i++) {
                 randomItems[i] = r.nextLong();
             }

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/GroupSortBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/GroupSortBenchmark.java
@@ -21,7 +21,6 @@
 
 package org.apache.bookkeeper.bookie;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>9.3</puppycrawl.checkstyle.version>
-    <spotbugs-maven-plugin.version>4.6.0.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.7.3.2</spotbugs-maven-plugin.version>
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1317,7 +1317,6 @@
           --add-opens java.base/java.io=ALL-UNNAMED
           --add-opens java.base/java.lang=ALL-UNNAMED
           --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-          --add-opens java.base/java.lang.invoke=ALL-UNNAMED
           --add-opens java.base/java.net=ALL-UNNAMED
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -1118,7 +1118,7 @@
             <version>${maven-surefire-plugin.version}</version>
             <configuration>
               <!-- @{argLine} is a variable injected by JaCoCo-->
-              <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid ${test.additional.args}</argLine>
+              <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid</argLine>
               <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
               <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1118,7 +1118,7 @@
             <version>${maven-surefire-plugin.version}</version>
             <configuration>
               <!-- @{argLine} is a variable injected by JaCoCo-->
-              <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid</argLine>
+              <argLine>-Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid ${test.additional.args}</argLine>
               <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
               <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -1317,6 +1317,7 @@
           --add-opens java.base/java.io=ALL-UNNAMED
           --add-opens java.base/java.lang=ALL-UNNAMED
           --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens java.base/java.lang.invoke=ALL-UNNAMED
           --add-opens java.base/java.net=ALL-UNNAMED
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED


### PR DESCRIPTION
### Motivation
The Spotbugs check failed, which blocked the PRs' CI
- https://github.com/apache/bookkeeper/actions/runs/4315781701/jobs/7530640684
- https://github.com/apache/bookkeeper/actions/runs/4319029437/jobs/7538019260
- When generating javadoc, it throws NPE:
```
[ERROR] NullPointerException
java.lang.NullPointerException
    at org.apache.maven.lifecycle.internal.MojoExecutor.executeForkedExecutions (MojoExecutor.java:439)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:175)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:76)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:163)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:160)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:260)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:172)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:100)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:821)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:270)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```
It is caused by a maven 3.9.0: https://issues.apache.org/jira/browse/MNG-7679

However, our GitHub CI uses maven 3.9.0 by default

### Modifications
- Fix Spotbugs check failed.
- Set GitHub CI's maven version to 3.8.7