### PR TITLE
Fix website deploy build failed

### DIFF
--- a/.github/workflows/website-deploy.yaml
+++ b/.github/workflows/website-deploy.yaml
@@ -46,6 +46,11 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
+        with:
+          maven-version: 3.8.7
+
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
### Motivation
Website deployment build failed
https://github.com/apache/bookkeeper/actions/runs/4340797094/jobs/7579680220

It may be caused by the maven 3.9.0 bug
https://issues.apache.org/jira/browse/MNG-7679

### Modifications
Set the maven version to 3.8.7 instead of the default 3.9.0 to fix the issue.