### PR TITLE
Fix memory leak issue of reading small entries

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -271,6 +271,7 @@ public class BookieProtoEncoding {
 
                     if (isSmallEntry) {
                         buf.writeBytes(rr.getData());
+                        rr.release();
                         return buf;
                     } else {
                         return ByteBufList.get(buf, rr.getData());


### PR DESCRIPTION
### Motivation

Fix the memory leak issue of reading small entries.
It will not impact the existing releases. But it should be a blocker for the 4.16.0 release
It was introduced by https://github.com/apache/bookkeeper/pull/3597

### Changes

Release the original buffer after copied the data into a single buffer (header + payload)
