### PR TITLE
Avoid unnecessary force write.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -380,7 +380,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
             return forceWriteWaiters.size();
         }
-        
+
         private void flushFileToDisk() throws IOException {
             if (!flushed) {
                 logFile.forceWrite(false);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -365,6 +365,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         private boolean shouldClose;
         private long lastFlushedPosition;
         private long logId;
+        private boolean flushedToDisk;
 
         public int process() {
             closeFileIfNecessary();
@@ -379,6 +380,13 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
             return forceWriteWaiters.size();
         }
+        
+        private void flushToDisk() throws IOException {
+            if (!flushedToDisk) {
+                logFile.forceWrite(false);
+                flushedToDisk = true;
+            }
+        }
 
         public void closeFileIfNecessary() {
             // Close if shouldClose is set
@@ -386,7 +394,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                 // We should guard against exceptions so its
                 // safe to call in catch blocks
                 try {
-                    logFile.forceWrite(false);
+                    flushToDisk();
                     logFile.close();
                     // Call close only once
                     shouldClose = false;
@@ -525,7 +533,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         private void syncJournal(ForceWriteRequest lastRequest) throws IOException {
             long fsyncStartTime = MathUtils.nowInNano();
             try {
-                lastRequest.logFile.forceWrite(false);
+                lastRequest.flushToDisk();
                 journalStats.getJournalSyncStats().registerSuccessfulEvent(MathUtils.elapsedNanos(fsyncStartTime),
                         TimeUnit.NANOSECONDS);
                 lastLogMark.setCurLogMark(lastRequest.logId, lastRequest.lastFlushedPosition);


### PR DESCRIPTION
Descriptions of the changes in this PR:
The batch requests logFile is the same one, and the last request happens to be rolloverFileRequest, it may force write logFile twice.
The first force write: https://github.com/apache/bookkeeper/blob/57031323166bd55004aaf50e3f46611dbb7eacf7/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java#L535
The second force write:
https://github.com/apache/bookkeeper/blob/57031323166bd55004aaf50e3f46611dbb7eacf7/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java#L390



