### PR TITLE
Disable trimStackTrack for code-coverage profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1122,6 +1122,7 @@
               <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
               <forkCount>${forkCount.variable}</forkCount>
               <reuseForks>false</reuseForks>
+              <trimStackTrace>false</trimStackTrace>
               <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
               <rerunFailingTestsCount>${testRetryCount}</rerunFailingTestsCount>
             </configuration>


### PR DESCRIPTION
### Motivation
We run unit tests in CI based on the `code-coverage` profile, and it enabled the trimStackTrack by default, which trimmed the stack for some failed tests.

### Modifications
Disable `trimStackTrack` for the `code-coverage` profile.