### PR TITLE
[Flaky] Fix flaky test in testRaceGuavaEvictAndReleaseBeforeRetain

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/FileInfoBackingCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/FileInfoBackingCacheTest.java
@@ -250,25 +250,21 @@ public class FileInfoBackingCacheTest {
             LongStream.range(0L, 2L).mapToObj(
                     (i) -> {
                         Callable<Set<CachedFileInfo>> c = () -> {
-                            try {
-                                Set<CachedFileInfo> allFileInfos = new HashSet<>();
-                                while (!done.get()) {
-                                    CachedFileInfo fi = null;
+                            Set<CachedFileInfo> allFileInfos = new HashSet<>();
+                            while (!done.get()) {
+                                CachedFileInfo fi = null;
 
-                                    do {
-                                        fi = guavaCache.get(
-                                            i, () -> cache.loadFileInfo(i, masterKey));
-                                        allFileInfos.add(fi);
-                                        Thread.sleep(random.nextInt(100));
-                                    } while (!fi.tryRetain());
+                                do {
+                                    fi = guavaCache.get(
+                                        i, () -> cache.loadFileInfo(i, masterKey));
+                                    allFileInfos.add(fi);
+                                    Thread.sleep(random.nextInt(100));
+                                } while (!fi.tryRetain());
 
-                                    Assert.assertFalse(fi.isClosed());
-                                    fi.release();
-                                }
-                                return allFileInfos;
-                            } catch (Exception e) {
-                                return null;
+                                Assert.assertFalse(fi.isClosed());
+                                fi.release();
                             }
+                            return allFileInfos;
                         };
                         return executor.submit(c);
                     }).collect(Collectors.toList());


### PR DESCRIPTION
### Motivations
The unit test `testRaceGuavaEvictAndReleaseBeforeRetain` sometimes runs timeout https://github.com/apache/bookkeeper/actions/runs/4382055343/jobs/7670828738

The root cause is that two threads sleep same time to run the logic, which leads to them interacting with each other and can't exit the while loop.
https://github.com/apache/bookkeeper/blob/cd43c91addb252f139cc207fe10adbb9344f9590/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/FileInfoBackingCacheTest.java#L255-L260

Due to the guavaCache size being one, when a new item putting into the cache, it will evict the previous one. The while loop can't exit with the following steps.
```
- Thread 1 put item A into the cache
- Thread 1 runs into sleep 100ms
- Thread 2 trigger evict item A from the cache
- Thread 2 put item B into the cache
- Thread 2 runs into sleep 100ms
- Thread 1 wake up, check item A's status, and found it has been released
- Thread 1 create a new item A and try to put it into the cache
- Thread 1 trigger evict item B from the cache.
- Thread 1 put item A into the cache
- Thread 1 runs into sleep 100ms
- Thread 2 woke up, check item B's status, and found it has been released.
- ...
```

### Modifications
Change the thread sleep time to a random value to break the dead loop logic.
