### PR TITLE
Fix NPE in BenchThroughputLatency

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -111,7 +111,9 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
     Random rand = new Random();
     public void close() throws InterruptedException, BKException {
         for (int i = 0; i < numberOfLedgers; i++) {
-            lh[i].close();
+            if (lh[i] != null) {
+                lh[i].close();
+            }
         }
         bk.close();
     }


### PR DESCRIPTION
### Motivation
When I start up a standalone bookie and use the following command the test the bookie server performance `bin/benchmark writes`, it throws the following exception and the benchmark process is blocked.
```
2023-03-12T11:22:37,685 - INFO  - [main:BenchThroughputLatency@376] - Calculating percentiles
2023-03-12T11:22:37,797 - INFO  - [main:BenchThroughputLatency@397] - 0 completions in 60003 milliseconds: 0 ops/sec
2023-03-12T11:22:38,185 - INFO  - [main:BenchThroughputLatency@416] - 99th percentile latency: NaN
2023-03-12T11:22:38,185 - INFO  - [main:BenchThroughputLatency@417] - 95th percentile latency: NaN
Exception in thread "main" java.lang.NullPointerException
	at org.apache.bookkeeper.benchmark.BenchThroughputLatency.close(BenchThroughputLatency.java:114)
	at org.apache.bookkeeper.benchmark.BenchThroughputLatency.main(BenchThroughputLatency.java:419)
```

The root cause is that the benchmark creates ledgers with EnsembleSize = 3, writeQorumSize = 2, and ackQorumSize=2, but I only startup one bookie, so the ledger creation failed. However, when we close the benchmark process, it will use the LedgerHandle to close the ledger, but the LedgerHandle is null due to ledger creation failure.
https://github.com/apache/bookkeeper/blob/cd43c91addb252f139cc207fe10adbb9344f9590/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java#L112-L117

### Modifications
Check whether the LedgerHandle is null before calling close method.
