### PR TITLE
Modify incorrect rocksDB config level_compaction_dynamic_level_bytes to CFOptions

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
@@ -54,6 +54,7 @@ public class KeyValueStorageRocksDBTest {
         assertEquals(64 * 1024 * 1024, options.writeBufferSize());
         assertEquals(4, options.maxWriteBufferNumber());
         assertEquals(256 * 1024 * 1024, options.maxBytesForLevelBase());
+        assertEquals(true, options.levelCompactionDynamicLevelBytes());
         rocksDB.close();
     }
 
@@ -78,6 +79,7 @@ public class KeyValueStorageRocksDBTest {
         assertEquals(CompressionType.LZ4_COMPRESSION, familyOptions.compressionType());
         assertEquals(1024, familyOptions.writeBufferSize());
         assertEquals(1, familyOptions.maxWriteBufferNumber());
+        assertEquals(true, familyOptions.levelCompactionDynamicLevelBytes());
         rocksDB.close();
     }
 
@@ -112,5 +114,21 @@ public class KeyValueStorageRocksDBTest {
         // https://github.com/facebook/rocksdb/issues/5297
         // After the PR: https://github.com/facebook/rocksdb/pull/10826 merge, we can turn on this test.
         assertEquals(ChecksumType.kxxHash, ((BlockBasedTableConfig) familyOptions.tableFormatConfig()).checksumType());
+    }
+
+    @Test
+    public void testLevelCompactionDynamicLevelBytesFromConfigurationFile() throws Exception {
+        ServerConfiguration configuration = new ServerConfiguration();
+        URL url = getClass().getClassLoader().getResource("conf/entry_location_rocksdb.conf");
+        configuration.setEntryLocationRocksdbConf(url.getPath());
+        File tmpDir = Files.createTempDirectory("bk-kv-rocksdbtest-file").toFile();
+        Files.createDirectory(Paths.get(tmpDir.toString(), "subDir"));
+        KeyValueStorageRocksDB rocksDB = new KeyValueStorageRocksDB(tmpDir.toString(), "subDir",
+                KeyValueStorageFactory.DbConfigType.EntryLocation, configuration);
+        assertNotNull(rocksDB.getColumnFamilyDescriptors());
+
+        List<ColumnFamilyDescriptor> columnFamilyDescriptorList = rocksDB.getColumnFamilyDescriptors();
+        ColumnFamilyOptions familyOptions = columnFamilyDescriptorList.get(0).getOptions();
+        assertEquals(true, familyOptions.levelCompactionDynamicLevelBytes());
     }
 }

--- a/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
@@ -51,6 +51,8 @@
  max_bytes_for_level_base=268435456
  # set by jni: options.setTargetFileSizeBase
  target_file_size_base=67108864
+ # set by jni: options.setLevelCompactionDynamicLevelBytes
+ level_compaction_dynamic_level_bytes=true
 
 [TableOptions/BlockBasedTable "default"]
  # set by jni: tableOptions.setBlockSize
@@ -65,5 +67,3 @@
  filter_policy=rocksdb.BloomFilter:10:false
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks
  cache_index_and_filter_blocks=true
- # set by jni: options.setLevelCompactionDynamicLevelBytes
- level_compaction_dynamic_level_bytes=true

--- a/bookkeeper-server/src/test/resources/test_entry_location_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/test_entry_location_rocksdb.conf
@@ -31,6 +31,8 @@
  write_buffer_size=1024
  # set by jni: options.setMaxWriteBufferNumber
  max_write_buffer_number=1
+ # set by jni: options.setLevelCompactionDynamicLevelBytes
+ level_compaction_dynamic_level_bytes=true
 
 [TableOptions/BlockBasedTable "default"]
  # set by jni: tableOptions.setBlockSize
@@ -45,5 +47,3 @@
  filter_policy=rocksdb.BloomFilter:10:false
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks
  cache_index_and_filter_blocks=true
- # set by jni: options.setLevelCompactionDynamicLevelBytes
- level_compaction_dynamic_level_bytes=true

--- a/conf/entry_location_rocksdb.conf.default
+++ b/conf/entry_location_rocksdb.conf.default
@@ -51,6 +51,8 @@
  max_bytes_for_level_base=268435456
  # set by jni: options.setTargetFileSizeBase
  target_file_size_base=67108864
+ # set by jni: options.setLevelCompactionDynamicLevelBytes
+ level_compaction_dynamic_level_bytes=true
 
 [TableOptions/BlockBasedTable "default"]
  # set by jni: tableOptions.setBlockSize
@@ -65,5 +67,3 @@
  filter_policy=rocksdb.BloomFilter:10:false
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks
  cache_index_and_filter_blocks=true
- # set by jni: options.setLevelCompactionDynamicLevelBytes
- level_compaction_dynamic_level_bytes=true


### PR DESCRIPTION
### Motivation
After PR #3056 , Bookkeeper set `level_compaction_dynamic_level_bytes=true` as `TableOptions` in `entry_location_rocksdb.conf.default` , which will cause `level_compaction_dynamic_level_bytes` lose efficacy and will cause rocksDB .sst file compact sort chaos when update bookie release.
As RocksDB  conf, `level_compaction_dynamic_level_bytes` need set as `CFOptions` https://github.com/facebook/rocksdb/blob/master/examples/rocksdb_option_file_example.ini

<img width="703" alt="image" src="https://user-images.githubusercontent.com/84127069/224640399-d5481fe5-7b75-4229-ac06-3d280aa9ae6d.png">


<img width="240" alt="image" src="https://user-images.githubusercontent.com/84127069/224640621-737d0a42-4e01-4f38-bd5a-862a93bc4b32.png">

### Changes

1. Change `level_compaction_dynamic_level_bytes=true` from `TableOptions` to `CFOptions`  in `entry_location_rocksdb.conf.default` ;

