### PR TITLE
fix wrong implementation for `percentile` in bookkeeper-benchmark

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -431,14 +431,9 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
     private static double percentile(long[] latency, int percentile) {
         int size = latency.length;
         double percent = (double) percentile / 100;
-        int sampleSize = (int) (size * percent);
-        long total = 0;
-        int count = 0;
-        for (int i = 0; i < sampleSize; i++) {
-            total += latency[i];
-            count++;
-        }
-        return ((double) total / (double) count) / 1000000.0;
+        int index = (int) (size * percent);
+        double lat = index > 0 ? (double) latency[index - 1] / 1000000.0 : 0.0;
+        return lat;
     }
 
     /**


### PR DESCRIPTION
According to `https://stackoverflow.com/questions/12808934/what-is-p99-latency`, the implementation for `percentile` in bookkeeper-benchmark is wrong.

Descriptions of the changes in this PR:



### Motivation

When I did benchmark tests using bookeeper-benchmark, I found that the percentile output seemed wrong. After checking the source code I think the current implementation is wrong.

### Changes

Fix function `percentile` in bookkeeper-benchmark to make it corrent.