### PR TITLE
Modify the response code from 404 to 405 when method not allowed.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/AutoRecoveryStatusService.java
@@ -64,7 +64,7 @@ public class AutoRecoveryStatusService implements HttpEndpointService {
                                 return handlePutStatus(request, ledgerUnderreplicationManager);
                             default:
                                 return new HttpServiceResponse("Not found method. Should be GET or PUT method",
-                                        HttpServer.StatusCode.NOT_FOUND);
+                                        HttpServer.StatusCode.METHOD_NOT_ALLOWED);
                         }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieInfoService.java
@@ -61,7 +61,7 @@ public class BookieInfoService implements HttpEndpointService {
         HttpServiceResponse response = new HttpServiceResponse();
 
         if (HttpServer.Method.GET != request.getMethod()) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only GET is supported.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieIsReadyService.java
@@ -43,7 +43,7 @@ public class BookieIsReadyService implements HttpEndpointService {
         HttpServiceResponse response = new HttpServiceResponse();
 
         if (HttpServer.Method.GET != request.getMethod()) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only support GET method check if bookie is ready.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieSanityService.java
@@ -76,7 +76,7 @@ public class BookieSanityService implements HttpEndpointService {
         HttpServiceResponse response = new HttpServiceResponse();
 
         if (HttpServer.Method.GET != request.getMethod()) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only support GET method to retrieve bookie sanity state.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
@@ -58,7 +58,7 @@ public class BookieStateReadOnlyService implements HttpEndpointService {
                 stateManager.transitionToReadOnlyMode().get();
             }
         } else if (!HttpServer.Method.GET.equals(request.getMethod())) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Unsupported method. Should be GET or PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateService.java
@@ -71,7 +71,7 @@ public class BookieStateService implements HttpEndpointService {
         HttpServiceResponse response = new HttpServiceResponse();
 
         if (HttpServer.Method.GET != request.getMethod()) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only support GET method to retrieve bookie state.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ClusterInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ClusterInfoService.java
@@ -82,7 +82,7 @@ public class ClusterInfoService implements HttpEndpointService {
         final HttpServiceResponse response = new HttpServiceResponse();
 
         if (HttpServer.Method.GET != request.getMethod()) {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only GET is supported.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ConfigurationService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ConfigurationService.java
@@ -52,7 +52,7 @@ public class ConfigurationService implements HttpEndpointService {
         } else if (HttpServer.Method.PUT == request.getMethod()) {
             String requestBody = request.getBody();
             if (null == requestBody) {
-                response.setCode(HttpServer.StatusCode.NOT_FOUND);
+                response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
                 response.setBody("Request body not found. should contains k-v pairs");
                 return response;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DecommissionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DecommissionService.java
@@ -100,7 +100,7 @@ public class DecommissionService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DeleteLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/DeleteLedgerService.java
@@ -75,7 +75,7 @@ public class DeleteLedgerService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be DELETE method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ExpandStorageService.java
@@ -108,7 +108,7 @@ public class ExpandStorageService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GCDetailsService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GCDetailsService.java
@@ -76,7 +76,7 @@ public class GCDetailsService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Only support GET method to retrieve GC details."
                 + " If you want to trigger gc, send a POST to gc endpoint.");
             return response;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLastLogMarkService.java
@@ -106,7 +106,7 @@ public class GetLastLogMarkService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/GetLedgerMetaService.java
@@ -79,7 +79,7 @@ public class GetLedgerMetaService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookieInfoService.java
@@ -124,7 +124,7 @@ public class ListBookieInfoService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookiesService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListBookiesService.java
@@ -95,7 +95,7 @@ public class ListBookiesService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListDiskFilesService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListDiskFilesService.java
@@ -125,7 +125,7 @@ public class ListDiskFilesService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListLedgerService.java
@@ -155,7 +155,7 @@ public class ListLedgerService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListUnderReplicatedLedgerService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ListUnderReplicatedLedgerService.java
@@ -141,7 +141,7 @@ public class ListUnderReplicatedLedgerService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/LostBookieRecoveryDelayService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/LostBookieRecoveryDelayService.java
@@ -97,7 +97,7 @@ public class LostBookieRecoveryDelayService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/MetricsService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/MetricsService.java
@@ -48,7 +48,7 @@ public class MetricsService implements HttpEndpointService {
     public HttpServiceResponse handle(HttpServiceRequest request) throws Exception {
         HttpServiceResponse response = new HttpServiceResponse();
         if (Method.GET != request.getMethod()) {
-            response.setCode(StatusCode.FORBIDDEN);
+            response.setCode(StatusCode.METHOD_NOT_ALLOWED);
             response.setBody(request.getMethod() + " is forbidden. Should be GET method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ReadLedgerEntryService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ReadLedgerEntryService.java
@@ -113,7 +113,7 @@ public class ReadLedgerEntryService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method, with ledger_id provided");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/RecoveryBookieService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/RecoveryBookieService.java
@@ -127,7 +127,7 @@ public class RecoveryBookieService implements HttpEndpointService {
             response.setBody("Success send recovery request command.");
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ResumeCompactionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/ResumeCompactionService.java
@@ -77,7 +77,7 @@ public class ResumeCompactionService implements HttpEndpointService {
                 return response;
             }
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT to resume major or minor compaction, Or GET to get "
                     + "compaction state.");
             return response;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/SuspendCompactionService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/SuspendCompactionService.java
@@ -90,7 +90,7 @@ public class SuspendCompactionService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT to suspend major or minor compaction, "
                     + "Or GET to get compaction state.");
             return response;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerAuditService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerAuditService.java
@@ -70,7 +70,7 @@ public class TriggerAuditService implements HttpEndpointService {
             }
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT method");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
@@ -93,7 +93,7 @@ public class TriggerGCService implements HttpEndpointService {
             response.setCode(HttpServer.StatusCode.OK);
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT to trigger GC, Or GET to get Force GC state.");
             return response;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/WhoIsAuditorService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/WhoIsAuditorService.java
@@ -79,7 +79,7 @@ public class WhoIsAuditorService implements HttpEndpointService {
             }
             return response;
         } else {
-            response.setCode(HttpServer.StatusCode.NOT_FOUND);
+            response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be GET method");
             return response;
         }


### PR DESCRIPTION
### Motivation
Response code 405 `METHOD_NOT_ALLOWED` is better than 404 `NOT_FOUND` when client request used not allowed method from REST API.

### Changes
1. Modify response code 404 to 405 when client request used not allowed method.