### PR TITLE
[fix][gc] Change order of doGcLedgers and extractMetaFromEntryLogs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -410,12 +410,13 @@ public class GarbageCollectorThread implements Runnable {
         compactor.cleanUpAndRecover();
 
         try {
-         // Extract all of the ledger ID's that comprise all of the entry logs
+            // gc inactive/deleted ledgers
+            // this is used in extractMetaFromEntryLogs to calculate the usage of entry log
+            doGcLedgers();
+
+            // Extract all of the ledger ID's that comprise all of the entry logs
             // (except for the current new one which is still being written to).
             extractMetaFromEntryLogs();
-
-            // gc inactive/deleted ledgers
-            doGcLedgers();
 
             // gc entry logs
             doGcEntryLogs();


### PR DESCRIPTION
### Motivation

Garbage collector does
```
 extractMetaFromEntryLogs();
 doGcLedgers();
```

where extractMetaFromEntryLogs checks if ledger exists in the storage and doGcLedgers removes deleted ledgers from the storage.

Logically, these should be reordered.
Currently it means that deleted ledgers will be either re-verified during compaction and skipped (if verifyMetadataOnGC is true) or picked up on the next GC run.  
In prod it means data released later.

The tests pass as they tend to do
```
        getGCThread().enableForceGC();
        getGCThread().triggerGC().get();
```
where both of these calls trigger gc.

### Changes

reordered operations