### PR TITLE
Add log for entry log file delete.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -745,6 +745,7 @@ public class GarbageCollectorThread implements Runnable {
                 EntryLogMetadata entryLogMeta = entryLogger.getEntryLogMetadata(entryLogId, throttler);
                 removeIfLedgerNotExists(entryLogMeta);
                 if (entryLogMeta.isEmpty()) {
+                    LOG.info("Entry log file {} is empty, delete it from disk.", entryLogId);
                     entryLogger.removeEntryLog(entryLogId);
                     // remove it from entrylogmetadata-map if it is present in
                     // the map


### PR DESCRIPTION
When deleting the entry log file, we would better add a log for it.
```
2023-03-17T00:25:02,069 - INFO  - [main:GarbageCollectorThread@748] - Entry log file 2 is empty, delete it from disk.
```