### PR TITLE
Add V2 protocol support for BenchReadThroughputLatency

### DIFF
--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -157,6 +157,7 @@ public class BenchReadThroughputLatency {
         options.addOption("password", true, "Password used to access ledgers (default 'benchPasswd')");
         options.addOption("zookeeper", true, "Zookeeper ensemble, default \"localhost:2181\"");
         options.addOption("sockettimeout", true, "Socket timeout for bookkeeper client. In seconds. Default 5");
+        options.addOption("useV2", false, "Whether use V2 protocol to read ledgers from the bookie server. Default is false");
         options.addOption("help", false, "This message");
 
         CommandLineParser parser = new PosixParser();
@@ -193,6 +194,10 @@ public class BenchReadThroughputLatency {
 
         final ClientConfiguration conf = new ClientConfiguration();
         conf.setReadTimeout(sockTimeout).setZkServers(servers);
+
+        if (cmd.hasOption("useV2")) {
+            conf.setUseV2WireProtocol(true);
+        }
 
         try (ZooKeeperClient zk = ZooKeeperClient.newBuilder()
                 .connectString(servers)

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -157,8 +157,7 @@ public class BenchReadThroughputLatency {
         options.addOption("password", true, "Password used to access ledgers (default 'benchPasswd')");
         options.addOption("zookeeper", true, "Zookeeper ensemble, default \"localhost:2181\"");
         options.addOption("sockettimeout", true, "Socket timeout for bookkeeper client. In seconds. Default 5");
-        options.addOption("useV2", false,
-            "Whether use V2 protocol to read ledgers from the bookie server. Default is false");
+        options.addOption("useV2", false, "Whether use V2 protocol to read ledgers from the bookie server.");
         options.addOption("help", false, "This message");
 
         CommandLineParser parser = new PosixParser();

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchReadThroughputLatency.java
@@ -157,7 +157,8 @@ public class BenchReadThroughputLatency {
         options.addOption("password", true, "Password used to access ledgers (default 'benchPasswd')");
         options.addOption("zookeeper", true, "Zookeeper ensemble, default \"localhost:2181\"");
         options.addOption("sockettimeout", true, "Socket timeout for bookkeeper client. In seconds. Default 5");
-        options.addOption("useV2", false, "Whether use V2 protocol to read ledgers from the bookie server. Default is false");
+        options.addOption("useV2", false,
+            "Whether use V2 protocol to read ledgers from the bookie server. Default is false");
         options.addOption("help", false, "This message");
 
         CommandLineParser parser = new PosixParser();

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -257,7 +257,8 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
         options.addOption("skipwarmup", false, "Skip warm up, default false");
         options.addOption("sendlimit", true, "Max number of entries to send. Default 20000000");
         options.addOption("latencyFile", true, "File to dump latencies. Default is latencyDump.dat");
-        options.addOption("useV2", false, "Whether use V2 protocol to send requests to the bookie server. Default is false");
+        options.addOption("useV2", false,
+            "Whether use V2 protocol to send requests to the bookie server. Default is false");
         options.addOption("warmupMessages", true, "Number of messages to warm up. Default 10000");
         options.addOption("help", false, "This message");
 

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -257,8 +257,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
         options.addOption("skipwarmup", false, "Skip warm up, default false");
         options.addOption("sendlimit", true, "Max number of entries to send. Default 20000000");
         options.addOption("latencyFile", true, "File to dump latencies. Default is latencyDump.dat");
-        options.addOption("useV2", false,
-            "Whether use V2 protocol to send requests to the bookie server. Default is false");
+        options.addOption("useV2", false, "Whether use V2 protocol to send requests to the bookie server.");
         options.addOption("warmupMessages", true, "Number of messages to warm up. Default 10000");
         options.addOption("help", false, "This message");
 

--- a/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
+++ b/bookkeeper-benchmark/src/main/java/org/apache/bookkeeper/benchmark/BenchThroughputLatency.java
@@ -257,7 +257,7 @@ public class BenchThroughputLatency implements AddCallback, Runnable {
         options.addOption("skipwarmup", false, "Skip warm up, default false");
         options.addOption("sendlimit", true, "Max number of entries to send. Default 20000000");
         options.addOption("latencyFile", true, "File to dump latencies. Default is latencyDump.dat");
-        options.addOption("useV2", false, "Whether use V2 protocol to send requests to the bookie server");
+        options.addOption("useV2", false, "Whether use V2 protocol to send requests to the bookie server. Default is false");
         options.addOption("warmupMessages", true, "Number of messages to warm up. Default 10000");
         options.addOption("help", false, "This message");
 


### PR DESCRIPTION

### Motivation
The `BenchReadThroughputLatency` only supports the V3 protocol to read ledgers from the bookie server. Add the V2 protocol support.

### Changes
Add V2 protocol support for BenchReadThroughputLatency