### PR TITLE
Fix cannot transit to writable mode from forceReadOnly mode

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -194,6 +194,11 @@ public class BookieStateManager implements StateManager {
     }
 
     @Override
+    public boolean isForceReadOnly(){
+        return forceReadOnly.get();
+    }
+
+    @Override
     public boolean isAvailableForHighPriorityWrites() {
         return availableForHighPriorityWrites;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -49,6 +49,11 @@ public interface StateManager extends AutoCloseable {
     boolean isReadOnly();
 
     /**
+     * Check is forceReadOnly.
+     */
+    boolean isForceReadOnly();
+
+    /**
      * Check is Running.
      */
     boolean isRunning();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
@@ -53,6 +53,11 @@ public class BookieStateReadOnlyService implements HttpEndpointService {
         if (HttpServer.Method.PUT.equals(request.getMethod())) {
             ReadOnlyState inState = JsonUtil.fromJson(request.getBody(), ReadOnlyState.class);
             if (stateManager.isReadOnly() && !inState.isReadOnly()) {
+                if (stateManager.isForceReadOnly()) {
+                    response.setCode(HttpServer.StatusCode.BAD_REQUEST);
+                    response.setBody("Bookie is in forceReadOnly mode, cannot transit to writable mode");
+                    return response;
+                }
                 stateManager.transitionToWritableMode().get();
             } else if (!stateManager.isReadOnly() && inState.isReadOnly()) {
                 stateManager.transitionToReadOnlyMode().get();


### PR DESCRIPTION
## Motivation

When running in a "forceReadOnly" mode (by starting Bookie with the "readonly" parameter), attempts to invoke the API `PUT /api/v1/bookie/state/readonly` to transition to a writable mode results in no feedback or messages indicating that the mode has not been updated successfully.

## Changes

When attempting to transition from "forceReadOnly" mode to a writable mode, a BAD_REQUEST error will be outputted stating that the transition cannot be completed because the server is currently in "forceReadOnly" mode. This will provide more meaningful feedback to users attempting to transition out of this mode.