### PR TITLE
Add branch-4.16 force push protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -87,6 +87,7 @@ github:
     branch-4.13: {}
     branch-4.14: {}
     branch-4.15: {}
+    branch-4.16: {}
 
 notifications:
   commits:      commits@bookkeeper.apache.org


### PR DESCRIPTION

### Motivation
The branch-4.16 doesn't enable force push protection, we need to enable it.

### Changes
Enable branch-4.16 force push protection