### PR TITLE
Leak release ledgerHandler when no missing fragments in checkAllLedgers

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
@@ -267,19 +267,19 @@ public class AuditorCheckAllLedgersTask extends AuditorTask {
                 if (bookies.isEmpty()) {
                     // no missing fragments
                     callback.processResult(BKException.Code.OK, null, null);
-                    return;
+                } else {
+                    publishSuspectedLedgersAsync(bookies.stream().map(BookieId::toString).collect(Collectors.toList()),
+                            Sets.newHashSet(lh.getId())
+                    ).whenComplete((result, cause) -> {
+                        if (null != cause) {
+                            LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
+                                    lh.getId(), bookies, cause);
+                            callback.processResult(BKException.Code.ReplicationException, null, null);
+                        } else {
+                            callback.processResult(BKException.Code.OK, null, null);
+                        }
+                    });
                 }
-                publishSuspectedLedgersAsync(bookies.stream().map(BookieId::toString).collect(Collectors.toList()),
-                        Sets.newHashSet(lh.getId())
-                ).whenComplete((result, cause) -> {
-                    if (null != cause) {
-                        LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
-                                lh.getId(), bookies, cause);
-                        callback.processResult(BKException.Code.ReplicationException, null, null);
-                    } else {
-                        callback.processResult(BKException.Code.OK, null, null);
-                    }
-                });
             } else {
                 callback.processResult(rc, null, null);
             }


### PR DESCRIPTION
### Motivation
In checkAllLedgers when the ledger no missing fragments, will miss close ledgerHandler, which cause autorecovery not invoke `unregisterLedgerMetadataListener` to release ledger metadata listeners. Heap memory be used too much and maybe will cause OOM;

<img width="1567" alt="image" src="https://user-images.githubusercontent.com/84127069/227937422-1113af68-9bf3-4466-97fa-d9b7cc5d72be.png">


### Changes
1.  Invoke` lh.closeAsync()` when no missing fragments;
