### PR TITLE
Fix BookieWriteLedgerTest parameterized failed

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -123,6 +123,9 @@ public class BookieWriteLedgerTest extends
     @Override
     @Before
     public void setUp() throws Exception {
+        baseConf.setJournalWriteData(writeJournal);
+        baseClientConf.setUseV2WireProtocol(useV2);
+
         super.setUp();
         rng = new Random(0); // Initialize the Random
         // Number Generator
@@ -136,14 +139,12 @@ public class BookieWriteLedgerTest extends
         String ledgerManagerFactory = "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory";
         // set ledger manager
         baseConf.setLedgerManagerFactoryClassName(ledgerManagerFactory);
-        baseConf.setJournalWriteData(writeJournal);
         /*
          * 'testLedgerCreateAdvWithLedgerIdInLoop2' testcase relies on skipListSizeLimit,
          * so setting it to some small value for making that testcase lite.
          */
         baseConf.setSkipListSizeLimit(4 * 1024 * 1024);
         baseClientConf.setLedgerManagerFactoryClassName(ledgerManagerFactory);
-        baseClientConf.setUseV2WireProtocol(useV2);
     }
 
     /**


### PR DESCRIPTION

### Motivation
https://github.com/apache/bookkeeper/pull/3884 introduced a parameterized test for BookieWriteLedgerTest, but those parameters don't work due to they are set in the constructor method, which doesn't run for each test. We need to set them in the `setUp()` method to ensure they are configured for each test.

### Changes
Move the parameters from the constructor method to the `setUp()` method to make sure they are configured for each test.
