### PR TITLE
[ISSUE 3891] Optimize log4j dependency in Bookkeeper

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -153,6 +153,14 @@
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -830,14 +830,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
     </dependency>

--- a/testtools/pom.xml
+++ b/testtools/pom.xml
@@ -25,4 +25,15 @@
     <artifactId>testtools</artifactId>
     <name>Apache BookKeeper :: Test Tools</name>
     <version>4.16.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
### Motivation
The current parent pom in Bookkeeper includes log4j-core and slf4j-log4j-impl dependencies, which are being transitively passed down to many modules. This has resulted in an unnecessary increase in the number of dependencies for these modules.

### Changes
- move the log4j-impl and log4j-core to testtools
- declare log4j-impl and log4j-core dependency in bookkeeper server module.

Fix #3891 

Also see
- https://github.com/apache/pulsar/issues/19484
- https://github.com/apache/pulsar/pull/19937
