### PR TITLE
Return activeLogChannel if new create

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogManagerForSingleEntryLog.java
@@ -93,6 +93,7 @@ class EntryLogManagerForSingleEntryLog extends EntryLogManagerBase {
         if (null == activeLogChannel) {
             // log channel can be null because the file is deferred to be created
             createNewLog(UNASSIGNED_LEDGERID, "because current active log channel has not initialized yet");
+            return activeLogChannel;
         }
 
         boolean reachEntryLogLimit = rollLog ? reachEntryLogLimit(activeLogChannel, entrySize)


### PR DESCRIPTION

### Motivation

If the activeLogChannel is new create, we should fast return it

### Changes

Fast return if new create activeLogChannel

