### PR TITLE
Fix keys leak in EntryLocationIndex when ledgersToDelete is empty

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -208,14 +208,14 @@ public class EntryLocationIndex implements Closeable {
     }
 
     public void removeOffsetFromDeletedLedgers() throws IOException {
-        LongPairWrapper firstKeyWrapper = LongPairWrapper.get(-1, -1);
-        LongPairWrapper lastKeyWrapper = LongPairWrapper.get(-1, -1);
-
         Set<Long> ledgersToDelete = deletedLedgers.items();
 
         if (ledgersToDelete.isEmpty()) {
             return;
         }
+
+        LongPairWrapper firstKeyWrapper = LongPairWrapper.get(-1, -1);
+        LongPairWrapper lastKeyWrapper = LongPairWrapper.get(-1, -1);
 
         log.info("Deleting indexes for ledgers: {}", ledgersToDelete);
         long startTime = System.nanoTime();


### PR DESCRIPTION
### Motivation
In EntryLocationIndex#removeOffsetFromDeletedLedgers, if there are no ledgers to delete, the key pair will leak.

### Changes
Check the ledgers to deletion Set first, and if the set is not empty, then generate the keys.