### PR TITLE
Fix ReclaimedSpaceViaDeletes stats incorrect problem.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -756,7 +756,7 @@ public class GarbageCollectorThread implements Runnable {
                     // We can remove this entry log file now.
                     LOG.info("Deleting entryLogId {} as it has no active ledgers!", entryLogId);
                     removeEntryLog(entryLogId);
-                    gcStats.getReclaimedSpaceViaDeletes().addCount(meta.getTotalSize());
+                    gcStats.getReclaimedSpaceViaDeletes().addCount(entryLogMeta.getTotalSize());
                 } else {
                     entryLogMetaMap.put(entryLogId, entryLogMeta);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -751,11 +751,12 @@ public class GarbageCollectorThread implements Runnable {
                 EntryLogMetadata entryLogMeta = entryLogger.getEntryLogMetadata(entryLogId, throttler);
                 removeIfLedgerNotExists(entryLogMeta);
                 if (entryLogMeta.isEmpty()) {
-                    LOG.info("Entry log file {} is empty, delete it from disk.", Long.toHexString(entryLogId));
-                    entryLogger.removeEntryLog(entryLogId);
-                    // remove it from entrylogmetadata-map if it is present in
-                    // the map
-                    entryLogMetaMap.remove(entryLogId);
+                    // This means the entry log is not associated with any active
+                    // ledgers anymore.
+                    // We can remove this entry log file now.
+                    LOG.info("Deleting entryLogId {} as it has no active ledgers!", entryLogId);
+                    removeEntryLog(entryLogId);
+                    gcStats.getReclaimedSpaceViaDeletes().addCount(meta.getTotalSize());
                 } else {
                     entryLogMetaMap.put(entryLogId, entryLogMeta);
                 }


### PR DESCRIPTION
Descriptions of the changes in this PR:
https://github.com/apache/bookkeeper/blob/a6387d191f28a59af72f6613b633d6898980a0b0/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java#L487-L517

At line 501, increases getReclaimedSpaceViaDeletes stats.


https://github.com/apache/bookkeeper/blob/a6387d191f28a59af72f6613b633d6898980a0b0/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java#L734-L767

But at line 755, it didn't increases getReclaimedSpaceViaDeletes stats.


