### PR TITLE
[Bug] SingleDirectoryDbLedgerStorage#flushMutex does not release lock on all exception paths

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -843,21 +843,22 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             // Leave IOExecption as it is
             throw e;
         } finally {
-            cleanupExecutor.execute(() -> {
-                // There can only be one single cleanup task running because the cleanupExecutor
-                // is single-threaded
-                try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Removing deleted ledgers from db indexes");
-                    }
-
-                    entryLocationIndex.removeOffsetFromDeletedLedgers();
-                    ledgerIndex.removeDeletedLedgers();
-                } catch (Throwable t) {
-                    log.warn("Failed to cleanup db indexes", t);
-                }
-            });
             try {
+                cleanupExecutor.execute(() -> {
+                    // There can only be one single cleanup task running because the cleanupExecutor
+                    // is single-threaded
+                    try {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Removing deleted ledgers from db indexes");
+                        }
+
+                        entryLocationIndex.removeOffsetFromDeletedLedgers();
+                        ledgerIndex.removeDeletedLedgers();
+                    } catch (Throwable t) {
+                        log.warn("Failed to cleanup db indexes", t);
+                    }
+                });
+
                 isFlushOngoing.set(false);
             } finally {
                 flushMutex.unlock();


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

fix: #3908 

### Changes

1.  finally unlock SingleDirectoryDbLedgerStorage#flushMutex