### PR TITLE
Remove avro, hadoop-auth and jersey-json dependencies from hadoop-common to resolve CVE-2019-10202, CVE-2023-1370 and CVE-2022-45685

### DIFF
--- a/stream/distributedlog/io/dlfs/pom.xml
+++ b/stream/distributedlog/io/dlfs/pom.xml
@@ -63,8 +63,8 @@
           <artifactId>avro</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-auth</artifactId>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.github.pjfanning</groupId>

--- a/stream/distributedlog/io/dlfs/pom.xml
+++ b/stream/distributedlog/io/dlfs/pom.xml
@@ -58,6 +58,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/stream/distributedlog/io/dlfs/pom.xml
+++ b/stream/distributedlog/io/dlfs/pom.xml
@@ -62,6 +62,14 @@
           <groupId>org.apache.avro</groupId>
           <artifactId>avro</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-auth</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.github.pjfanning</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Motivation
#### [CVE-2019-10202](https://www.cve.org/CVERecord?id=CVE-2019-10202)
After upgrading the Hadoop version to 3.3.5, the CVE-2019-10202 still exists.

Detailed paths
Introduced through: org.apache.distributedlog:dlfs@4.16.0-SNAPSHOT › org.apache.hadoop:hadoop-common@3.3.5 › org.apache.avro:avro@1.7.7 › org.codehaus.jackson:jackson-mapper-asl@1.9.13

#### [CVE-2023-1370](https://www.cve.org/CVERecord?id=CVE-2023-1370)
Detailed paths
Introduced through: org.apache.distributedlog:dlfs@4.16.0-SNAPSHOT › org.apache.hadoop:hadoop-common@3.3.5 › org.apache.hadoop:hadoop-auth@3.3.5 › net.minidev:json-smart@2.4.7
Fix: No remediation path available.

#### [CVE-2022-45685](https://www.cve.org/CVERecord?id=CVE-2022-45685)
Detailed paths
Introduced through: org.apache.distributedlog:dlfs@4.16.0-SNAPSHOT › org.apache.hadoop:hadoop-common@3.3.5 › com.github.pjfanning:jersey-json@1.20 › org.codehaus.jettison:jettison@1.1
Fix: No remediation path available.

After checking the code of package `org.apache.distributedlog.fs`, those classes only use `org.apache.hadoop.conf`, `org.apache.hadoop.fs` and `org.apache.hadoop.util` packages. They don't use any Avro-related, json-smart and jersey-json dependencies. It is safe to remove the those dependencies to resolve the CVE issue.
https://github.com/apache/bookkeeper/tree/master/stream/distributedlog/io/dlfs/src/main/java/org/apache/distributedlog/fs

### Changes
Exclude the Avro dependency from `hadoop-common`
