### PR TITLE
Upgrade bc-fips to 1.0.2.4 to fix CVE-2022-45146

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -703,10 +703,10 @@ Bundled as
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
 
 Bundled as
-  - lib/org.bouncycastle-bc-fips-1.0.2.3.jar
+  - lib/org.bouncycastle-bc-fips-1.0.2.4.jar
 ------------------------------------------------------------------------------------
 This product uses the annotations from The Checker Framework, which are licensed under
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -703,7 +703,7 @@ Bundled as
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
 
 Bundled as
   - lib/org.bouncycastle-bc-fips-1.0.2.4.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -591,10 +591,10 @@ Bundled as
 Source available at https://github.com/google/google-auth-library-java/tree/1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
 
 Bundled as
-  - lib/org.bouncycastle-bc-fips-1.0.2.3.jar
+  - lib/org.bouncycastle-bc-fips-1.0.2.4.jar
 ------------------------------------------------------------------------------------
 
 This product uses the annotations from The Checker Framework, which are licensed under

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -591,7 +591,7 @@ Bundled as
 Source available at https://github.com/google/google-auth-library-java/tree/1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
 
 Bundled as
   - lib/org.bouncycastle-bc-fips-1.0.2.4.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -692,7 +692,7 @@ Bundled as
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
 
 Bundled as
   - lib/org.bouncycastle-bc-fips-1.0.2.4.jar

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -692,10 +692,10 @@ Bundled as
 Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
-For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html
+For license details, see deps/bouncycastle-1.0.2.4/LICENSE.html
 
 Bundled as
-  - lib/org.bouncycastle-bc-fips-1.0.2.3.jar
+  - lib/org.bouncycastle-bc-fips-1.0.2.4.jar
 ------------------------------------------------------------------------------------
 This product uses the annotations from The Checker Framework, which are licensed under
 MIT License. For details, see deps/checker-qual-3.5.0/LICENSE

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <commons-io.version>2.7</commons-io.version>
-    <bouncycastle.version>1.0.2.3</bouncycastle.version>
+    <bouncycastle.version>1.0.2.4</bouncycastle.version>
     <curator.version>5.1.0</curator.version>
     <dropwizard.version>4.1.12.1</dropwizard.version>
     <etcd.version>0.5.11</etcd.version>


### PR DESCRIPTION
### Motivation
#### [CVE-2022-45146](https://www.cve.org/CVERecord?id=CVE-2022-45146)
Detailed paths
Introduced through: org.apache.distributedlog:dlfs@4.16.0-SNAPSHOT › org.apache.distributedlog:distributedlog-core@4.16.0-SNAPSHOT › org.apache.bookkeeper:bookkeeper-server@4.16.0-SNAPSHOT › org.bouncycastle:bc-fips@1.0.2.3

Fixed in org.bouncycastle:bc-fips@1.0.2.4

### Changes
Upgrade the org.bouncycastle:bc-fips dependency from 1.0.2.3 to 1.0.2.4
