### PR TITLE
Upgrade docker base image to resolve CVE-2023-0286

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.6-eclipse-temurin-11
+FROM maven:3.9.0-eclipse-temurin-11
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.8.6-eclipse-temurin-8
+FROM maven:3.9.0-eclipse-temurin-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake gnupg2 vim subversion


### PR DESCRIPTION
### Motivation
#### [CVE-2023-0286](https://www.cve.org/CVERecord?id=CVE-2023-0286)

Detailed paths
Introduced through: maven@3.8.6-eclipse-temurin-11 › openssl/libssl3@3.0.2-0ubuntu1.7
Fix: No remediation path available.
Introduced through: maven@3.8.6-eclipse-temurin-11 › openssl@3.0.2-0ubuntu1.7
Fix: Upgrade to openssl@3.0.2-0ubuntu1.8 

  | BASE IMAGE | VULNERABILITIES | SEVERITY |  
-- | -- | -- | -- | --
Current image | maven:3.8.6-eclipse-temurin-11 | 48 | 0C1H22M25L |  
Minor upgrades | maven:3.9.0-eclipse-temurin-11 | 19 | 0C0H2M17L


### Changes
Upgrade the docker base image to `maven:3.9.0-eclipse-temurin-11` to resolve the CVE