### PR TITLE
[fix] DigestManager should not advance readerIndex

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManager.java
@@ -159,7 +159,7 @@ public abstract class DigestManager {
         buf.readerIndex(0);
 
         if (isSmallEntry) {
-            buf.writeBytes(unwrapped);
+            buf.writeBytes(unwrapped, unwrapped.readerIndex(), unwrapped.readableBytes());
             unwrapped.release();
             return buf;
         } else {


### PR DESCRIPTION
Descriptions of the changes in this PR:

#3783 introduced a change in the behavior of `LedgerHandle#asyncAddEntry`. This PR re-introduces the original behavior.

### Motivation

Apache Pulsar just upgraded to Bookkeeper client version 4.16.0. In doing so, we observed new errors related to unexpected reader positions in the passed in byte buffer. Here is a thread discussing some of the observations: https://lists.apache.org/thread/n4dpmbo5t9bvq5t1fp8fn4m6c6d9d9so.

Based on my analysis, it seems that the core issue is with the type of `ByteBuf` being passed to the BK client. Previously, the `readerIndex` for the `ByteBuf` that was passed did not change. Now, it seems to move forward. I am assuming this is because of specific conditions related to `CompositeByteBuf`, but I haven't yet been able to create a test to show the problem. Perhaps someone is more familiar with these data structures and can provide me with insight into how to test this change?

### Changes

Update `DigestManager#computeDigestAndPackageForSendingV2` in the case of a small entry to use a copy method that does not modify the `readerIndex` on the parameterized buffer.

Below are the Javadocs for the old and the new method.

```java
    /**
     * Transfers the specified source buffer's data to this buffer starting at
     * the current {@code writerIndex} until the source buffer becomes
     * unreadable, and increases the {@code writerIndex} by the number of
     * the transferred bytes.  This method is basically same with
     * {@link #writeBytes(ByteBuf, int, int)}, except that this method
     * increases the {@code readerIndex} of the source buffer by the number of
     * the transferred bytes while {@link #writeBytes(ByteBuf, int, int)}
     * does not.
     * If {@code this.writableBytes} is less than {@code src.readableBytes},
     * {@link #ensureWritable(int)} will be called in an attempt to expand
     * capacity to accommodate.
     */
    public abstract ByteBuf writeBytes(ByteBuf src);

    /**
     * Transfers the specified source buffer's data to this buffer starting at
     * the current {@code writerIndex} and increases the {@code writerIndex}
     * by the number of the transferred bytes (= {@code length}).
     * If {@code this.writableBytes} is less than {@code length}, {@link #ensureWritable(int)}
     * will be called in an attempt to expand capacity to accommodate.
     *
     * @param srcIndex the first index of the source
     * @param length   the number of bytes to transfer
     *
     * @throws IndexOutOfBoundsException
     *         if the specified {@code srcIndex} is less than {@code 0}, or
     *         if {@code srcIndex + length} is greater than {@code src.capacity}
     */
    public abstract ByteBuf writeBytes(ByteBuf src, int srcIndex, int length);
```