### PR TITLE
[Branch-4.16] Upgrade python client version to 4.16.1

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -19,7 +19,7 @@ import setuptools
 
 name = 'apache-bookkeeper-client'
 description = 'Apache BookKeeper client library'
-version = '4.16.0'
+version = '4.16.1'
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
### Motivation

Prepare for BookKeeper 4.16.1 release, and upgrade the Python client version to 4.16.1