### PR TITLE
[Improve] Fix var name for stats logger

### DIFF
--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
@@ -65,16 +65,16 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
     @Override
     public void registerFailedEvent(long eventLatency, TimeUnit unit) {
-        double valueMillis = unit.toMicros(eventLatency) / 1000.0;
+        double valueMicros = unit.toMicros(eventLatency) / 1000.0;
 
         failCountAdder.increment();
-        failSumAdder.add((long) valueMillis);
+        failSumAdder.add((long) valueMicros);
 
         LocalData localData = current.localData.get();
 
         long stamp = localData.lock.readLock();
         try {
-            localData.failSketch.update(valueMillis);
+            localData.failSketch.update(valueMicros);
         } finally {
             localData.lock.unlockRead(stamp);
         }
@@ -82,16 +82,16 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
     @Override
     public void registerSuccessfulEvent(long eventLatency, TimeUnit unit) {
-        double valueMillis = unit.toMicros(eventLatency) / 1000.0;
+        double valueMicros = unit.toMicros(eventLatency) / 1000.0;
 
         successCountAdder.increment();
-        successSumAdder.add((long) valueMillis);
+        successSumAdder.add((long) valueMicros);
 
         LocalData localData = current.localData.get();
 
         long stamp = localData.lock.readLock();
         try {
-            localData.successSketch.update(valueMillis);
+            localData.successSketch.update(valueMicros);
         } finally {
             localData.lock.unlockRead(stamp);
         }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

In the following code logic, the time unit we record is nanoseconds.

https://github.com/apache/bookkeeper/blob/94e15b3dc0286de1dda1bd3989fd8b9de12e8d05/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java#L461-L467

When converting the time unit, we convert nanoseconds to microseconds, but the name of the variable here shows milliseconds, which is easy to cause misunderstanding.

https://github.com/apache/bookkeeper/blob/94e15b3dc0286de1dda1bd3989fd8b9de12e8d05/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java#L67-L98

### Changes

Replace `valueMillis` with `valueMicros`
