### PR TITLE
Fix release-major script bug

### DIFF
--- a/site3/website/scripts/release-major.sh
+++ b/site3/website/scripts/release-major.sh
@@ -29,8 +29,6 @@ cd site3/website
 sidebar_file="sidebars.json"
 docs_dir="docs"
 
-cd site3/website
-
 # create versioned sidebar file
 cp $sidebar_file versioned_sidebars/version-${NEW_RELEASE}-sidebars.json
 # add unique id for each item in the sidebar


### PR DESCRIPTION
### Motivation
The release-major script execute `cd site3/website` twice, which will lead to `No such directory` error