### PR TITLE
Filter duplicated fence request for v2

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -20,12 +20,14 @@
  */
 package org.apache.bookkeeper.proto;
 
+import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
+import java.util.Arrays;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
 
 /**
@@ -320,6 +322,28 @@ public interface BookieProtocol {
             read.flags = flags;
             read.masterKey = masterKey;
             return read;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ReadRequest)) {
+                return false;
+            }
+            ReadRequest that = (ReadRequest) o;
+            return protocolVersion == that.protocolVersion
+                    && opCode == that.opCode
+                    && ledgerId == that.ledgerId
+                    && entryId == that.entryId
+                    && flags == that.flags
+                    && Arrays.equals(masterKey, that.masterKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(protocolVersion, opCode, ledgerId, entryId, flags, Arrays.hashCode(masterKey));
         }
 
         boolean isFencing() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -678,7 +678,8 @@ public class BookieRequestProcessor implements RequestProcessor {
                 null == highPriorityThreadPool ? null : highPriorityThreadPool.chooseThread(requestHandler.ctx());
         ReadEntryProcessor read = ReadEntryProcessor.create(r, requestHandler,
                 this, fenceThreadPool, throttleReadResponses);
-        if (r.isFencing()) {
+        boolean isFencing = r.isFencing();
+        if (isFencing) {
             AtomicBoolean pending = new AtomicBoolean(false);
             pendingFencing.compute(r, (request, fencingReadList) -> {
                 if (fencingReadList == null) {
@@ -720,7 +721,6 @@ public class BookieRequestProcessor implements RequestProcessor {
                 }
                 getRequestStats().getReadEntryRejectedCounter().inc();
 
-                boolean isFencing = r.isFencing();
                 List<ReadEntryProcessor> pendingFenceRead = pendingFencing.remove(r);
                 read.sendResponse(
                     BookieProtocol.ETOOMANYREQUESTS,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -36,7 +36,6 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -719,13 +719,15 @@ public class BookieRequestProcessor implements RequestProcessor {
                             r.entryId);
                 }
                 getRequestStats().getReadEntryRejectedCounter().inc();
+
+                boolean isFencing = r.isFencing();
+                List<ReadEntryProcessor> pendingFenceRead = pendingFencing.remove(r);
                 read.sendResponse(
                     BookieProtocol.ETOOMANYREQUESTS,
                     ResponseBuilder.buildErrorResponse(BookieProtocol.ETOOMANYREQUESTS, r),
                     requestStats.getReadRequestStats());
                 onReadRequestFinish();
-                if (r.isFencing()) {
-                    List<ReadEntryProcessor> pendingFenceRead = pendingFencing.remove(r);
+                if (isFencing) {
                     if (CollectionUtils.isNotEmpty(pendingFenceRead)) {
                         for (ReadEntryProcessor readEntryProcessor : pendingFenceRead) {
                             readEntryProcessor.sendResponse(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -131,9 +131,9 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
         if (LOG.isTraceEnabled()) {
             LOG.trace("Read entry rc = {} for {}", errorCode, request);
         }
+        List<ReadEntryProcessor> pendingFenceRead = requestProcessor.getPendingFencing().remove(request);
         sendResponse(data, errorCode, startTimeNanos);
         if (isFencing) {
-            List<ReadEntryProcessor> pendingFenceRead = requestProcessor.getPendingFencing().remove(request);
             if (CollectionUtils.isNotEmpty(pendingFenceRead)) {
                 for (ReadEntryProcessor readEntryProcessor : pendingFenceRead) {
                     if (data != null) {


### PR DESCRIPTION
### Motivation

The fence request should only process once. And the process could be a little long because of scaning rocksDB.  So the client could send many fence request for the same ledgerId because of client timeout.   The duplicated fence request will queue in the thread pool waiting to process.

This patch will filter the duplicated fence request and put them into a `pendingMap`. The key of the map is `ReadRequest`. Once the first fence request complete,  all the other request in `pendingMap` with th same key will complete with the same result.


<img width="638" alt="image" src="https://user-images.githubusercontent.com/10233437/234195637-54b5defa-9e14-4477-b19b-f865a9829205.png">

### Changes

- Add a `Map<BookieProtocol.ReadRequest, List<ReadEntryProcessor>> pendingFencing` to save the duplicated fence request
- Add `equals` and `hashCode` method for `ReadRequest`