### PR TITLE
drop invalid entryFormat arg from shell command

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -87,7 +87,6 @@ Environment variables:
    BOOKIE_ZK_CONF         Configuration file for zookeeper (default: $DEFAULT_ZK_CONF)
    BOOKIE_EXTRA_OPTS      Extra options to be passed to the jvm
    BOOKIE_EXTRA_CLASSPATH Add extra paths to the bookkeeper classpath
-   ENTRY_FORMATTER_CLASS  Entry formatter class to format entries.
    BOOKIE_PID_DIR         Folder where the Bookie server PID file should be stored
    BOOKIE_STOP_TIMEOUT    Wait time before forcefully kill the Bookie server instance, if the stop is not successful
 
@@ -173,8 +172,7 @@ elif [ $COMMAND == "zookeeper" ]; then
     BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"zookeeper.log"}
     exec "${JAVA}" $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
 elif [ ${COMMAND} == "shell" ]; then
-  ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
-  exec "${JAVA}" ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "help" ]; then
   bookkeeper_help;
 else

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -43,9 +43,6 @@
 # Wait time before forcefully kill the Bookie server instance, if the stop is not successful
 # BOOKIE_STOP_TIMEOUT=
 
-# Entry formatter class to format entries.
-# ENTRY_FORMATTER_CLASS=
-
 # this default config dir should match the 'localBookiesConfigDirectory' config value in the conf file of LocalBookKeeper
 # LOCALBOOKIES_CONFIG_DIR=/tmp/localbookies-config
 

--- a/site3/website/docs/reference/cli.md
+++ b/site3/website/docs/reference/cli.md
@@ -14,7 +14,6 @@ Manages bookies.
 | `BOOKIE_LOG_CONF`        | The Log4j configuration file.                                                                        | `${bookkeeperHome}/bookkeeper-server/conf/log4j2.xml`     | 
 | `BOOKIE_CONF`            | The configuration file for the bookie.                                                               | `${bookkeeperHome}/bookkeeper-server/conf/bk_server.conf` | 
 | `BOOKIE_EXTRA_CLASSPATH` | Extra paths to add to BookKeeper's [classpath](https://en.wikipedia.org/wiki/Classpath_(Java)).      |                                                           | 
-| `ENTRY_FORMATTER_CLASS`  | The entry formatter class used to format entries.                                                    |                                                           | 
 | `BOOKIE_PID_DIR`         | The directory where the bookie server PID file is stored.                                            |                                                           | 
 | `BOOKIE_STOP_TIMEOUT`    | The wait time before forcefully killing the bookie server instance if stopping it is not successful. |                                                           | 
 

--- a/tests/docker-images/statestore-image/bin/bookkeeper
+++ b/tests/docker-images/statestore-image/bin/bookkeeper
@@ -112,8 +112,7 @@ elif [ $COMMAND == "zookeeper" ]; then
     BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"zookeeper.log"}
     exec $JAVA $OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE -Dzookeeper.4lw.commands.whitelist='*' org.apache.zookeeper.server.quorum.QuorumPeerMain $BOOKIE_ZK_CONF $@
 elif [ ${COMMAND} == "shell" ]; then
-  ENTRY_FORMATTER_ARG="-DentryFormatterClass=${ENTRY_FORMATTER_CLASS:-org.apache.bookkeeper.util.StringEntryFormatter}"
-  exec ${JAVA} ${OPTS} ${ENTRY_FORMATTER_ARG} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
+  exec ${JAVA} ${OPTS} org.apache.bookkeeper.bookie.BookieShell -conf ${BOOKIE_CONF} $@
 else
   exec ${JAVA} ${OPTS} ${COMMAND} $@
 fi


### PR DESCRIPTION
### Motivation

According to the configuration of ENTRY_FORMATTER_CLASS in the bookkeeper shell command, it will never take effect, we should remove it,

We can use -entryformat or configure in bookie config to take effect.