### PR TITLE
fix wrong update checkAllLedgersTime when ledgerReplication disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
@@ -102,6 +102,7 @@ public class AuditorCheckAllLedgersTask extends AuditorTask {
         try {
             if (!isLedgerReplicationEnabled()) {
                 LOG.info("Ledger replication disabled, skipping checkAllLedgers");
+                checkSuccess = true;
                 return;
             }
 


### PR DESCRIPTION
### Motivation

When ledgerReplication disabled, we don't need to register `checkAllLedgersTime` failedEvent because we already skipped the check and didn't encounter any exception.

```java
        Stopwatch stopwatch = Stopwatch.createStarted();
        boolean checkSuccess = false;
        try {
            if (!isLedgerReplicationEnabled()) {
                LOG.info("Ledger replication disabled, skipping checkAllLedgers");
                checkSuccess = true;    <= here
                return;
            }

            LOG.info("Starting checkAllLedgers");
            checkAllLedgers();
            ......
            checkSuccess = true;
        } catch (InterruptedException ie) {
           ......
        } finally {
            if (!checkSuccess) {
                long checkAllLedgersDuration = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS);
                auditorStats.getCheckAllLedgersTime()
                        .registerFailedEvent(checkAllLedgersDuration, TimeUnit.MILLISECONDS);
            }
        }
```