### PR TITLE
Upgrade rocksDB version to 6.29.4.1

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -257,7 +257,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.16.4.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -330,7 +330,7 @@ Apache Software License, Version 2.
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
-[23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
+[23] Source available at https://github.com/facebook/rocksdb/tree/v6.29.4.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -586,7 +586,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.16.4.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.29.4.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -257,7 +257,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar [22]
-- lib/org.rocksdb-rocksdbjni-6.16.4.jar [23]
+- lib/org.rocksdb-rocksdbjni-6.29.4.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -327,7 +327,7 @@ Apache Software License, Version 2.
 [20] Source available at https://git-wip-us.apache.org/repos/asf?p=commons-lang.git;a=shortlog;h=refs/tags/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.6.2
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
-[23] Source available at https://github.com/facebook/rocksdb/tree/v6.16.4
+[23] Source available at https://github.com/facebook/rocksdb/tree/v6.29.4.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -582,7 +582,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-6.16.4.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-6.29.4.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <protoc3.version>3.19.6</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>6.16.4</rocksdb.version>
+    <rocksdb.version>6.29.4.1</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>1.32</snakeyaml.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
Upgrade the RocksDB version to 6.29.4.1 to make sure BookKeeper 4.16.0 can roll back 4.14.x

Refer to: https://github.com/apache/bookkeeper/issues/3734#issuecomment-1407626941

### Changes

(Describe: what changes you have made)

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
