### PR TITLE
Optimize getEntryLogMetadata

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1037,7 +1037,7 @@ public class DefaultEntryLogger implements EntryLogger {
         try {
             return extractEntryLogMetadataFromIndex(entryLogId);
         } catch (FileNotFoundException fne) {
-            LOG.warn("Cannot find entry log file {}.log : {}", entryLogId, fne.getMessage());
+            LOG.warn("Cannot find entry log file {}.log : {}", Long.toHexString(entryLogId), fne.getMessage());
             throw fne;
         } catch (Exception e) {
             LOG.info("Failed to get ledgers map index from: {}.log : {}", entryLogId, e.getMessage());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1036,9 +1036,9 @@ public class DefaultEntryLogger implements EntryLogger {
         // entry log
         try {
             return extractEntryLogMetadataFromIndex(entryLogId);
-        } catch (FileNotFoundException ex) {
-            LOG.warn("Cannot find entry log file {}.log", entryLogId);
-            throw new IOException(ex);
+        } catch (FileNotFoundException fne) {
+            LOG.warn("Cannot find entry log file {}.log : {}", entryLogId, e.getMessage());
+            throw fne;
         } catch (Exception e) {
             LOG.info("Failed to get ledgers map index from: {}.log : {}", entryLogId, e.getMessage());
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1037,7 +1037,7 @@ public class DefaultEntryLogger implements EntryLogger {
         try {
             return extractEntryLogMetadataFromIndex(entryLogId);
         } catch (FileNotFoundException fne) {
-            LOG.warn("Cannot find entry log file {}.log : {}", entryLogId, e.getMessage());
+            LOG.warn("Cannot find entry log file {}.log : {}", entryLogId, fne.getMessage());
             throw fne;
         } catch (Exception e) {
             LOG.info("Failed to get ledgers map index from: {}.log : {}", entryLogId, e.getMessage());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1036,6 +1036,9 @@ public class DefaultEntryLogger implements EntryLogger {
         // entry log
         try {
             return extractEntryLogMetadataFromIndex(entryLogId);
+        } catch (FileNotFoundException ex) {
+            LOG.warn("Cannot find entry log file {}.log", entryLogId);
+            throw new IOException(ex);
         } catch (Exception e) {
             LOG.info("Failed to get ledgers map index from: {}.log : {}", entryLogId, e.getMessage());
 


### PR DESCRIPTION
In the `getEntryLogMetadata` method, the `FileNotFoundException` exception is caught before the more general Exception. This modification ensures that if the log file is not found, there is no need to proceed with the `extractEntryLogMetadataByScanning(entryLogId, throttler)` method call.

This enhancement improves the code's error handling by distinguishing between different exceptions that may occur during the retrieval of entry log metadata. It ensures that unnecessary operations, scanning the log, are skipped when the log file is not found.