### PR TITLE
[improve] Support client max idle connections minutes

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -199,6 +199,8 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected static final String CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING =
             "clientConnectBookieUnavailableLogThrottling";
 
+    protected static final String CLIENT_MAX_IDLE_CONNECTIONS_MINUTES = "clientMaxIdleConnectionsMinutes";
+
     /**
      * Construct a default client-side configuration.
      */
@@ -2056,6 +2058,32 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public long getClientConnectBookieUnavailableLogThrottlingMs() {
         return getLong(CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING, 5_000L);
+    }
+
+    /**
+     * Set the client max idle connections time for no any read-write operations happened, in minutes.
+     * After this time, the connection will be closed.
+     *
+     * @param maxIdleConnectionsMinutes
+     *        Default is -1 (disabled)
+     * @param unit
+     * @return client configuration.
+     */
+    public ClientConfiguration setClientMaxIdleConnectionsMinutes(
+            int maxIdleConnectionsMinutes, TimeUnit unit) {
+        setProperty(CLIENT_MAX_IDLE_CONNECTIONS_MINUTES, unit.toMinutes(maxIdleConnectionsMinutes));
+        return this;
+    }
+
+    /**
+     * Get the client max idle connections time for no any read-write operations happened, in minutes.
+     * After this time, the connection will be closed.
+     *
+     * @return max idle connections for no any read-write operations happened, in minutes.
+     *         Default is -1 (disabled)
+     */
+    public long getClientMaxIdleConnectionsMinutes() {
+        return getLong(CLIENT_MAX_IDLE_CONNECTIONS_MINUTES, -1);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Related to this PR #3913, I noticed that the bookkeeper client often needs to maintain a permanent long connection with the bookie server that has established a connection. I guess the reason is that the creation of ensemble is based on the polling selection of all bookie nodes. Long-running services are bound to Keep in touch with all bookie servers repeatedly.

Permanent long connections, especially when the client and server do not have any read-write operations, are a waste of resources (such as server-side file handles, resources occupied by socket creation internal objects, possible memory leaks).

When the `AutoRecovery` service runs for a long time, its detection task will generally occur once every 1 day, 7 days, or even longer. Once the connection is established with all bookie servers, it will not actively release the connection unless some abnormality occurs.

### Changes

For this reason, I want to add a maximum idle connection time on the client side to actively close some network connections that have not performed read-write operations for a long time.
This future is disabled by default.
New configuration: `clientMaxIdleConnectionsMinutes`, Default is -1 (disabled)
