### PR TITLE
When the thread has been interrupted, there is no need for waitBackOffTime

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -265,12 +265,12 @@ public class ReplicationWorker implements Runnable {
             } catch (UnavailableException e) {
                 LOG.error("UnavailableException "
                         + "while replicating fragments", e);
-                waitBackOffTime(rwRereplicateBackoffMs);
                 if (Thread.currentThread().isInterrupted()) {
                     LOG.error("Interrupted  while replicating fragments");
                     shutdown();
                     return;
                 }
+                waitBackOffTime(rwRereplicateBackoffMs);
             }
         }
         LOG.info("ReplicationWorker exited loop!");


### PR DESCRIPTION
### Motivation

When the thread has been interrupted, there is no need for waitBackOffTime, we can directly shutdown ReplicationWorker.
