### PR TITLE
[WIP][improve] Force ReSchedule Auditor tasks

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerUnderreplicationManager.java
@@ -159,6 +159,39 @@ public interface LedgerUnderreplicationManager extends AutoCloseable {
             throws ReplicationException.UnavailableException;
 
     /**
+     * Emit Auditor tasks re-schedule.
+     *
+     */
+    void emitScheduleAuditorTasks()
+            throws ReplicationException.UnavailableException;
+
+    /**
+     * Finishing Auditor tasks re-schedule.
+     *
+     */
+    void finishedScheduleAuditorTasks()
+            throws ReplicationException.UnavailableException;
+
+    /**
+     * Check whether the Auditor tasks re-schedule is emitted or not. This will return
+     * true if the schedule task is emitted, otherwise return false.
+     *
+     * @return - return true if it is emitted otherwise return false
+     */
+    boolean isAuditorTasksReScheduleEmit()
+            throws ReplicationException.UnavailableException;
+
+    /**
+     * Receive notification asynchronously when the schedule auditor tasks
+     * is emitted.
+     *
+     * @param cb
+     *            - callback implementation to receive the notification
+     */
+    void notifyReScheduleAuditorTasksChanged(GenericCallback<Void> cb)
+            throws ReplicationException.UnavailableException;
+
+    /**
      * Creates the zNode for lostBookieRecoveryDelay with the specified value and returns true.
      * If the node is already existing, then it returns false.
      *

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/NullMetadataBookieDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/NullMetadataBookieDriver.java
@@ -359,6 +359,16 @@ public class NullMetadataBookieDriver implements MetadataBookieDriver {
         @Override
         public void notifyLedgerReplicationEnabled(GenericCallback<Void> cb) {}
         @Override
+        public void emitScheduleAuditorTasks() {}
+        @Override
+        public void finishedScheduleAuditorTasks() {}
+        @Override
+        public boolean isAuditorTasksReScheduleEmit() {
+            return false;
+        }
+        @Override
+        public void notifyReScheduleAuditorTasksChanged(GenericCallback<Void> cb) {}
+        @Override
         public boolean initializeLostBookieRecoveryDelay(int lostBookieRecoveryDelay) {
             return false;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/BookKeeperConstants.java
@@ -50,6 +50,7 @@ public class BookKeeperConstants {
     public static final String LAYOUT_ZNODE = "LAYOUT";
     public static final String INSTANCEID = "INSTANCEID";
     public static final String DISABLE_HEALTH_CHECK = "disableHealthCheck";
+    public static final String SCHEDULE_AUDITOR_NODE = "scheduleAuditor";
 
     /**
      * Set the max log size limit to 1GB. It makes extra room for entry log file before


### PR DESCRIPTION
### Motivation

This PR follows up the comments in this PR #3945 

Now when we manually trigger auditor check, we need to restart Auditor or trigger a round of auditor election to take effect.

So I hope we can trigger auditor check more smoothly. Support for Auditor Tasks rescheduling is available.

### Changes

By registering the specified zk node, the callback logic of Auditor tasks rescheduling is triggered.
