### PR TITLE
check indexBaseDir specified with ledgerBaseDir

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -163,7 +163,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         } else {
             // if indexDir is specified, set new value
             indexBaseDir = indexDirsManager.getAllLedgerDirs().get(0).getPath();
-            log.info("indexDir is specified a separate dir, creating another directory db ledger storage on {}",
+            log.info("indexDir is specified a separate dir, creating single directory db ledger storage on {}",
                     indexBaseDir);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -156,7 +156,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         String ledgerBaseDir = ledgerDirsManager.getAllLedgerDirs().get(0).getPath();
         // indexBaseDir default use ledgerBaseDir
         String indexBaseDir = ledgerBaseDir;
-        if (CollectionUtils.isEmpty(indexDirsManager.getAllLedgerDirs())) {
+        if (CollectionUtils.isEmpty(indexDirsManager.getAllLedgerDirs())
+                || ledgerBaseDir.equals(indexDirsManager.getAllLedgerDirs().get(0).getPath())) {
             log.info("indexDir is not specified, use default, creating single directory db ledger storage on {}",
                     indexBaseDir);
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -158,12 +158,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         String indexBaseDir = ledgerBaseDir;
         if (CollectionUtils.isEmpty(indexDirsManager.getAllLedgerDirs())
                 || ledgerBaseDir.equals(indexDirsManager.getAllLedgerDirs().get(0).getPath())) {
-            log.info("indexDir is not specified, use default, creating single directory db ledger storage on {}",
+            log.info("indexDir is equals ledgerBaseDir, creating single directory db ledger storage on {}",
                     indexBaseDir);
         } else {
             // if indexDir is specified, set new value
             indexBaseDir = indexDirsManager.getAllLedgerDirs().get(0).getPath();
-            log.info("indexDir is specified, creating single directory db ledger storage on {}", indexBaseDir);
+            log.info("indexDir is specified a separate dir, creating another directory db ledger storage on {}",
+                    indexBaseDir);
         }
 
         StatsLogger ledgerIndexDirStatsLogger = statsLogger


### PR DESCRIPTION
### Motivation

I deployed the pulsar-3.0.0 version, and I observed the log of bookkeeper-4.16.1 as follows, I did not config special indexDirectories, but the printed log told me that indexDirectories was specified, which is wrong.

```
2023-05-23T19:52:45,192+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.SingleDirectoryDbLedgerStorage - indexDir is specified, creating single directory db ledger storage on /data0/pulsar/data/ledgers/current
2023-05-23T19:52:45,322+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB - Searching for a RocksDB configuration file in /usr/local/pulsar/apache-pulsar-3.0.0/conf/ledger_metadata_rocksdb.conf
2023-05-23T19:52:45,322+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB - Found a RocksDB configuration file and using it to initialize the RocksDB
2023-05-23T19:52:45,337+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB - Searching for a RocksDB configuration file in /usr/local/pulsar/apache-pulsar-3.0.0/conf/entry_location_rocksdb.conf
2023-05-23T19:52:45,337+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB - Found a RocksDB configuration file and using it to initialize the RocksDB
```

here ledgerDirsManager == indexDirsManager, so ledgerDir is always equals indexDir.

https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java#L181
```java
for (int i = 0; i < ledgerDirsManager.getAllLedgerDirs().size(); i++) {
            File ledgerDir = ledgerDirsManager.getAllLedgerDirs().get(i);
            File indexDir = indexDirsManager.getAllLedgerDirs().get(i);
            // Create a ledger dirs manager for the single directory
            File[] lDirs = new File[1];
            // Remove the `/current` suffix which will be appended again by LedgersDirManager
            lDirs[0] = ledgerDir.getParentFile();
            LedgerDirsManager ldm = new LedgerDirsManager(conf, lDirs, ledgerDirsManager.getDiskChecker(),
                    NullStatsLogger.INSTANCE);

            // Create a index dirs manager for the single directory
            File[] iDirs = new File[1];
            // Remove the `/current` suffix which will be appended again by LedgersDirManager
            iDirs[0] = indexDir.getParentFile();
            LedgerDirsManager idm = new LedgerDirsManager(conf, iDirs, indexDirsManager.getDiskChecker(),
                    NullStatsLogger.INSTANCE);

             ......

            ledgerStorageList.add(newSingleDirectoryDbLedgerStorage(conf, ledgerManager, ldm,
                idm, entrylogger,
                statsLogger, perDirectoryWriteCacheSize,
                perDirectoryReadCacheSize,
                readAheadCacheBatchSize, readAheadCacheBatchBytesSize));

              ......
}
```
