### PR TITLE
Format otel module dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
     <module>tests</module>
     <module>native-io</module>
     <module>testtools</module>
-    <module>stats/bookkeeper-stats-providers/otel-metrics-provider</module>
   </modules>
   <mailingLists>
     <mailingList>
@@ -656,6 +655,14 @@
         <groupId>com.yahoo.datasketches</groupId>
         <artifactId>sketches-core</artifactId>
         <version>${datasketches.version}</version>
+      </dependency>
+      <!-- opentelemetry -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${otel.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- http-client -->

--- a/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
@@ -30,18 +30,6 @@
   <artifactId>otel-metrics-provider</artifactId>
   <name>Apache BookKeeper :: Stats Providers :: OpenTelemetry</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>${otel.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.bookkeeper.stats</groupId>

--- a/stats/bookkeeper-stats-providers/pom.xml
+++ b/stats/bookkeeper-stats-providers/pom.xml
@@ -28,6 +28,7 @@
   <modules>
     <module>codahale-metrics-provider</module>
     <module>prometheus-metrics-provider</module>
+    <module>otel-metrics-provider</module>
   </modules>
 
 </project>


### PR DESCRIPTION
### Motivation
Refer to https://github.com/apache/bookkeeper/pull/3968#discussion_r1205098805

### Changes
- Move the otel module from root pom.xml to the sub-module of `Apache BookKeeper :: Stats :: Parent`