### PR TITLE
Prevent bookie shutdown due to rest api when bookie prohibits readOnlyMode

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -234,6 +234,11 @@ public class BookieStateManager implements StateManager {
     }
 
     @Override
+    public boolean isReadOnlyModeEnabled() {
+        return conf.isReadOnlyModeEnabled();
+    }
+
+    @Override
     public boolean isAvailableForHighPriorityWrites() {
         return availableForHighPriorityWrites;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -54,6 +54,11 @@ public interface StateManager extends AutoCloseable {
     boolean isForceReadOnly();
 
     /**
+     * Check is readOnlyModeEnabled.
+     */
+    boolean isReadOnlyModeEnabled();
+
+    /**
      * Check is Running.
      */
     boolean isRunning();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
@@ -60,6 +60,11 @@ public class BookieStateReadOnlyService implements HttpEndpointService {
                 }
                 stateManager.transitionToWritableMode().get();
             } else if (!stateManager.isReadOnly() && inState.isReadOnly()) {
+                if (!stateManager.isReadOnlyModeEnabled()) {
+                    response.setCode(HttpServer.StatusCode.BAD_REQUEST);
+                    response.setBody("Bookie is disabled ReadOnly mode, cannot transit to readOnly mode");
+                    return response;
+                }
                 stateManager.transitionToReadOnlyMode().get();
             }
         } else if (!HttpServer.Method.GET.equals(request.getMethod())) {


### PR DESCRIPTION
### Motivation

When bookie disabled readOnlyMode, once the user initiates a readOnly conversion through the rest api, the bookie process will be shut down directly.

```java
public void doTransitionToReadOnlyMode() {
       ......
        if (!conf.isReadOnlyModeEnabled()) {
            LOG.warn("ReadOnly mode is not enabled. "
                    + "Can be enabled by configuring "
                    + "'readOnlyModeEnabled=true' in configuration."
                    + " Shutting down bookie");
            shutdownHandler.shutdown(ExitCode.BOOKIE_EXCEPTION);
            return;
        }
       ......
    }
```

I have the following reasons for this PR:
1. If the user wants to shut down the bookie, there is no need to operate it through the rest api, and can directly use the shell shutdown script.
2. The user switches the readOnly state through the rest api, the first purpose is not to shut down the bookie process;
3. Exposing the bookie shutdown logic through the rest api has certain security risks.

You can copy the following code to org.apache.bookkeeper.server.http.TestHttpService#testBookieReadOnlyState to reproduce the shutdown of bookie:
```java
        // disable readOnly mode
        restartBookies(c -> {
            c.setForceReadOnlyBookie(false);
            c.setReadOnlyModeEnabled(false);
            return c;
        });
        MetadataBookieDriver metadataDriver = BookieResources.createMetadataDriver(
                baseConf, NullStatsLogger.INSTANCE);
        BKHttpServiceProvider bkHttpServiceProvider2 = new BKHttpServiceProvider.Builder()
                .setBookieServer(serverByIndex(numberOfBookies - 1))
                .setServerConfiguration(baseConf)
                .setLedgerManagerFactory(metadataDriver.getLedgerManagerFactory())
                .build();
       HttpEndpointService bookieReadOnlyService2 = bkHttpServiceProvider2
                .provideHttpEndpointService(HttpServer.ApiType.BOOKIE_STATE_READONLY);

        request = new HttpServiceRequest(JsonUtil.toJson(new ReadOnlyState(true)), HttpServer.Method.PUT,  null);
        response = bookieReadOnlyService2.handle(request);
        Awaitility.await().untilAsserted(() -> {
            assertFalse(serverByIndex(numberOfBookies - 1).isBookieRunning()); // here the bookie will be shutdown.
        });
```