### PR TITLE
Do not skip opened ledger in repair not adhering placement ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTask.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTask.java
@@ -257,66 +257,66 @@ public class AuditorPlacementPolicyCheckTask extends AuditorTask {
         LedgerMetadata metadata = metadataVer.getValue();
         int writeQuorumSize = metadata.getWriteQuorumSize();
         int ackQuorumSize = metadata.getAckQuorumSize();
-        if (metadata.isClosed()) {
-            boolean foundSegmentNotAdheringToPlacementPolicy = false;
-            boolean foundSegmentSoftlyAdheringToPlacementPolicy = false;
-            for (Map.Entry<Long, ? extends List<BookieId>> ensemble : metadata
-                    .getAllEnsembles().entrySet()) {
-                long startEntryIdOfSegment = ensemble.getKey();
-                List<BookieId> ensembleOfSegment = ensemble.getValue();
-                EnsemblePlacementPolicy.PlacementPolicyAdherence segmentAdheringToPlacementPolicy = admin
-                        .isEnsembleAdheringToPlacementPolicy(ensembleOfSegment, writeQuorumSize,
-                                ackQuorumSize);
-                if (segmentAdheringToPlacementPolicy == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
-                    foundSegmentNotAdheringToPlacementPolicy = true;
-                    LOG.warn(
-                            "For ledger: {}, Segment starting at entry: {}, with ensemble: {} having "
-                                    + "writeQuorumSize: {} and ackQuorumSize: {} is not adhering to "
-                                    + "EnsemblePlacementPolicy",
-                            ledgerId, startEntryIdOfSegment, ensembleOfSegment, writeQuorumSize,
-                            ackQuorumSize);
-                } else if (segmentAdheringToPlacementPolicy
-                        == EnsemblePlacementPolicy.PlacementPolicyAdherence.MEETS_SOFT) {
-                    foundSegmentSoftlyAdheringToPlacementPolicy = true;
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "For ledger: {}, Segment starting at entry: {}, with ensemble: {}"
-                                        + " having writeQuorumSize: {} and ackQuorumSize: {} is"
-                                        + " softly adhering to EnsemblePlacementPolicy",
-                                ledgerId, startEntryIdOfSegment, ensembleOfSegment, writeQuorumSize,
-                                ackQuorumSize);
-                    }
-                }
-            }
-            if (foundSegmentNotAdheringToPlacementPolicy) {
-                numOfLedgersFoundNotAdheringInPlacementPolicyCheck.incrementAndGet();
-                //If user enable repaired, mark this ledger to under replication manager.
-                if (conf.isRepairedPlacementPolicyNotAdheringBookieEnable()) {
-                    ledgerUnderreplicationManager.markLedgerUnderreplicatedAsync(ledgerId,
-                            Collections.emptyList()).whenComplete((res, e) -> {
-                        if (e != null) {
-                            LOG.error("For ledger: {}, the placement policy not adhering bookie "
-                                            + "storage, mark it to under replication manager failed.",
-                                    ledgerId, e);
-                            return;
-                        }
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("For ledger: {}, the placement policy not adhering bookie"
-                                    + " storage, mark it to under replication manager", ledgerId);
-                        }
-                    });
-                }
-            } else if (foundSegmentSoftlyAdheringToPlacementPolicy) {
-                numOfLedgersFoundSoftlyAdheringInPlacementPolicyCheck
-                        .incrementAndGet();
-            }
-            numOfClosedLedgersAuditedInPlacementPolicyCheck.incrementAndGet();
-        } else {
+        if (!metadata.isClosed()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Ledger: {} is not yet closed, so skipping the placementPolicy"
+                LOG.debug("Ledger: {} is not yet closed, but do not skipping the placementPolicy"
                         + "check analysis for now", ledgerId);
             }
         }
+        boolean foundSegmentNotAdheringToPlacementPolicy = false;
+        boolean foundSegmentSoftlyAdheringToPlacementPolicy = false;
+        for (Map.Entry<Long, ? extends List<BookieId>> ensemble : metadata
+                .getAllEnsembles().entrySet()) {
+            long startEntryIdOfSegment = ensemble.getKey();
+            List<BookieId> ensembleOfSegment = ensemble.getValue();
+            EnsemblePlacementPolicy.PlacementPolicyAdherence segmentAdheringToPlacementPolicy = admin
+                    .isEnsembleAdheringToPlacementPolicy(ensembleOfSegment, writeQuorumSize,
+                            ackQuorumSize);
+            if (segmentAdheringToPlacementPolicy == EnsemblePlacementPolicy.PlacementPolicyAdherence.FAIL) {
+                foundSegmentNotAdheringToPlacementPolicy = true;
+                LOG.warn(
+                        "For ledger: {}, Segment starting at entry: {}, with ensemble: {} having "
+                                + "writeQuorumSize: {} and ackQuorumSize: {} is not adhering to "
+                                + "EnsemblePlacementPolicy",
+                        ledgerId, startEntryIdOfSegment, ensembleOfSegment, writeQuorumSize,
+                        ackQuorumSize);
+            } else if (segmentAdheringToPlacementPolicy
+                    == EnsemblePlacementPolicy.PlacementPolicyAdherence.MEETS_SOFT) {
+                foundSegmentSoftlyAdheringToPlacementPolicy = true;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "For ledger: {}, Segment starting at entry: {}, with ensemble: {}"
+                                    + " having writeQuorumSize: {} and ackQuorumSize: {} is"
+                                    + " softly adhering to EnsemblePlacementPolicy",
+                            ledgerId, startEntryIdOfSegment, ensembleOfSegment, writeQuorumSize,
+                            ackQuorumSize);
+                }
+            }
+        }
+        if (foundSegmentNotAdheringToPlacementPolicy) {
+            numOfLedgersFoundNotAdheringInPlacementPolicyCheck.incrementAndGet();
+            //If user enable repaired, mark this ledger to under replication manager.
+            if (conf.isRepairedPlacementPolicyNotAdheringBookieEnable()) {
+                ledgerUnderreplicationManager.markLedgerUnderreplicatedAsync(ledgerId,
+                        Collections.emptyList()).whenComplete((res, e) -> {
+                    if (e != null) {
+                        LOG.error("For ledger: {}, the placement policy not adhering bookie "
+                                        + "storage, mark it to under replication manager failed.",
+                                ledgerId, e);
+                        return;
+                    }
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("For ledger: {}, the placement policy not adhering bookie"
+                                + " storage, mark it to under replication manager", ledgerId);
+                    }
+                });
+            }
+        } else if (foundSegmentSoftlyAdheringToPlacementPolicy) {
+            numOfLedgersFoundSoftlyAdheringInPlacementPolicyCheck
+                    .incrementAndGet();
+        }
+        numOfClosedLedgersAuditedInPlacementPolicyCheck.incrementAndGet();
+
         iterCallback.processResult(BKException.Code.OK, null, null);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -388,9 +388,6 @@ public class ReplicationWorker implements Runnable {
                 LedgerMetadata metadata = metadataVer.getValue();
                 int writeQuorumSize = metadata.getWriteQuorumSize();
                 int ackQuorumSize = metadata.getAckQuorumSize();
-                if (!metadata.isClosed()) {
-                    return;
-                }
                 Long curEntryId = null;
                 EnsemblePlacementPolicy.PlacementPolicyAdherence previousSegmentAdheringToPlacementPolicy = null;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -1239,11 +1239,21 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         //This ledger not adhering placement policy, the combine(0,1,2) rack is 1.
         LedgerHandle lh = bkc.createLedger(3, 3, 3, BookKeeper.DigestType.CRC32, TESTPASSWD);
 
+        //This ledger not adhering placement policy, the combine(0,1,2) rack is 1 and this ledger is not closed.
+        LedgerHandle lh2 = bkc.createLedger(3, 3, 3, BookKeeper.DigestType.CRC32, TESTPASSWD);
+
         int entrySize = 10;
         for (int i = 0; i < entrySize; i++) {
             lh.addEntry(data);
+            lh2.addEntry(data);
         }
         lh.close();
+
+        LedgerMetadata metadata = bkc.getLedgerManager().readLedgerMetadata(lh.getId()).get().getValue();
+        LedgerMetadata metadata2 = bkc.getLedgerManager().readLedgerMetadata(lh2.getId()).get().getValue();
+
+        assertTrue(metadata.isClosed());
+        assertFalse(metadata2.isClosed());
 
         int minNumRacksPerWriteQuorumConfValue = 2;
 
@@ -1259,7 +1269,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
             Gauge<? extends Number> ledgersNotAdheringToPlacementPolicyGuage = statsLogger
                     .getGauge(ReplicationStats.NUM_LEDGERS_NOT_ADHERING_TO_PLACEMENT_POLICY);
             assertEquals("NUM_LEDGERS_NOT_ADHERING_TO_PLACEMENT_POLICY guage value",
-                    1, ledgersNotAdheringToPlacementPolicyGuage.getSample());
+                    2, ledgersNotAdheringToPlacementPolicyGuage.getSample());
             Gauge<? extends Number> ledgersSoftlyAdheringToPlacementPolicyGuage = statsLogger
                     .getGauge(ReplicationStats.NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY);
             assertEquals("NUM_LEDGERS_SOFTLY_ADHERING_TO_PLACEMENT_POLICY guage value",
@@ -1276,6 +1286,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         assertNotNull(stat);
 
         baseConf.setRepairedPlacementPolicyNotAdheringBookieEnable(true);
+        baseConf.setOpenLedgerRereplicationGracePeriod("1000");
         BookKeeper bookKeeper = new BookKeeperTestClient(baseClientConf) {
             @Override
             protected EnsemblePlacementPolicy initializeEnsemblePlacementPolicy(ClientConfiguration conf,
@@ -1310,9 +1321,15 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         }
 
         Awaitility.await().untilAsserted(() -> {
-            LedgerMetadata metadata = bkc.getLedgerManager().readLedgerMetadata(lh.getId()).get().getValue();
-            List<BookieId> newBookies = metadata.getAllEnsembles().get(0L);
+            LedgerMetadata lhMetadata = bkc.getLedgerManager().readLedgerMetadata(lh.getId()).get().getValue();
+            List<BookieId> newBookies = lhMetadata.getAllEnsembles().get(0L);
             assertTrue(newBookies.contains(newBookieId));
+            assertTrue(lhMetadata.isClosed());
+
+            LedgerMetadata lh2Metadata = bkc.getLedgerManager().readLedgerMetadata(lh2.getId()).get().getValue();
+            List<BookieId> newBookies2 = lh2Metadata.getAllEnsembles().get(0L);
+            assertTrue(newBookies2.contains(newBookieId));
+            assertTrue(lh2Metadata.isClosed());
         });
 
         Awaitility.await().untilAsserted(() -> {


### PR DESCRIPTION
### Motivation

In order to completely fix not adhering placement ledgers, also repair the opened ledger in feature "auto recover support repaired not adhering placement ledger"

### Changes

remove "if (!metadata.isClosed())" in two function. 

It is ok to recover opened ledger because the ledger would become fence when do recovery.


Master Issue: #3971
