### PR TITLE
Fix Journal without flush

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -421,6 +421,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
 
         private void recycle() {
             logFile = null;
+            flushed = false;
             if (forceWriteWaiters != null) {
                 forceWriteWaiters.recycle();
                 forceWriteWaiters = null;


### PR DESCRIPTION
### Motivation
    
 In the given code snippet, a ForceWriteRequest object is created with the flushed flag always set to true when calling the createForceWriteRequest method, reused from a recycle pool. Consequently, when the flushFileToDisk method is invoked, it checks the flushed flag and only performs the file flush if it is false. However, since the flushed flag is always true due to the recycling process, the file flush is skipped.

```
private ForceWriteRequest createForceWriteRequest(JournalChannel logFile,
                          long logId,
                          long lastFlushedPosition,
                          RecyclableArrayList<QueueEntry> forceWriteWaiters,
                          boolean shouldClose) {
        ForceWriteRequest req = forceWriteRequestsRecycler.get();
        req.forceWriteWaiters = forceWriteWaiters;
        req.logFile = logFile;
        req.logId = logId;
        req.lastFlushedPosition = lastFlushedPosition;
        req.shouldClose = shouldClose;
        journalStats.getForceWriteQueueSize().inc();
        return req;
    }
```
```
private void flushFileToDisk() throws IOException {
            if (!flushed) {
                logFile.forceWrite(false);
                flushed = true;
            }
        }
```

### Changes:
To address this issue, the recycle() method should be modified to set the flushed flag to false when recycling a ForceWriteRequest object. This ensures that the flushFileToDisk method will correctly perform the file flush when needed. The updated recycle() method could look like this:
```
public void recycle() {
    // Reset other fields to their initial state
    forceWriteWaiters = null;
    logFile = null;
    logId = 0;
    lastFlushedPosition = 0;
    shouldClose = false;

    // Reset the flushed flag to false
    flushed = false;

    // Recycle the object back to the pool
    forceWriteRequestsRecycler.recycle(this);
}
```
By setting flushed to false during recycling, subsequent reuse of the ForceWriteRequest object will correctly trigger the file flush operation in the flushFileToDisk method when necessary.