### PR TITLE
[improve][tests] Backwards compat tests: added new versions, pulsar upgrade cases, read check from old server

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -326,14 +326,14 @@ jobs:
         run: mvn -B -nsu clean install -Pdocker -DskipTests
 
       - name: Test current server with old clients
-        run: mvn -B -nsu -DbackwardCompatTests -pl :backward-compat-current-server-old-clients test
+        run: mvn -B -nsu -DbackwardCompatTests -DfailIfNoTests -pl :backward-compat-current-server-old-clients test
 
       - name: Test progressive upgrade
-        run: mvn -B -nsu -DbackwardCompatTests -pl :upgrade test
+        run: mvn -B -nsu -DbackwardCompatTests -DfailIfNoTests -pl :upgrade test
 
       - name: Other tests
         run: |
-          mvn -B -nsu -DbackwardCompatTests -pl :bc-non-fips,:hierarchical-ledger-manager,:hostname-bookieid,:old-cookie-new-cluster,:recovery-no-password,:upgrade-direct test
+          mvn -B -nsu -DbackwardCompatTests -DfailIfNoTests -pl :bc-non-fips,:hierarchical-ledger-manager,:hostname-bookieid,:old-cookie-new-cluster,:recovery-no-password,:upgrade-direct test
 
       - name: Upload container logs on failure
         uses: actions/upload-artifact@v4

--- a/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
+++ b/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
@@ -155,51 +155,55 @@ class TestCompatUpgrade {
     }
 
     @Test
-    public void test_006_4130to4147() throws Exception {
-        testUpgrade("4.13.0", "4.14.7")
+    public void test_006_4130to4148() throws Exception {
+        testUpgrade("4.13.0", "4.14.8")
     }
 
     @Test
-    public void test_007_4147to4154() throws Exception {
-        testUpgrade("4.14.7", "4.15.4")
+    public void test_007_4148to4155() throws Exception {
+        testUpgrade("4.14.8", "4.15.5")
     }
 
     @Test
-    public void test_007_4147to4154_crc32c() throws Exception {
-        testUpgrade("4.14.7", "4.15.4", "CRC32C")
+    public void test_007_4148to4155_crc32c() throws Exception {
+        testUpgrade("4.14.8", "4.15.5", "CRC32C")
     }
 
     @Test
-    public void test_008_4154to4161() throws Exception {
-        testUpgrade("4.15.4", "4.16.1")
+    public void test_008_4155to4165() throws Exception {
+        testUpgrade("4.15.5", "4.16.5")
     }
 
     @Test
-    public void test_008_4154to4161_crc32c() throws Exception {
-        testUpgrade("4.15.4", "4.16.1", "CRC32C")
+    public void test_008_4155to4165_crc32c() throws Exception {
+        testUpgrade("4.15.5", "4.16.5", "CRC32C")
     }
 
     @Test
-    public void test_009_4161toCurrentMaster() throws Exception {
-        testUpgrade("4.16.1", BookKeeperClusterUtils.CURRENT_VERSION)
+    public void test_008_4165to4170_crc32c() throws Exception {
+        testUpgrade("4.16.5", "4.17.0", "CRC32C")
     }
 
     @Test
-    public void test_009_4161toCurrentMaster_crc32c() throws Exception {
-        testUpgrade("4.16.1", BookKeeperClusterUtils.CURRENT_VERSION, "CRC32C")
+    public void test_009_4165toCurrentMaster() throws Exception {
+        testUpgrade("4.17.0", BookKeeperClusterUtils.CURRENT_VERSION)
     }
 
-    // old version pulsar upgrade tests
-    // old version pulsar upgrade tests
     @Test
-    public void test_010_4100to4147_crc32c() throws Exception {
-        testUpgrade("4.10.0", "4.14.7", "CRC32C")
+    public void test_009_4165toCurrentMaster_crc32c() throws Exception {
+        testUpgrade("4.17.0", BookKeeperClusterUtils.CURRENT_VERSION, "CRC32C")
     }
 
     // old version pulsar upgrade tests
     @Test
-    public void test_010_4100to4161_crc32c() throws Exception {
-        testUpgrade("4.10.0", "4.16.1", "CRC32C")
+    public void test_010_4100to4148_crc32c() throws Exception {
+        testUpgrade("4.10.0", "4.14.8", "CRC32C")
+    }
+
+    // old version pulsar upgrade tests
+    @Test
+    public void test_010_4100to4170_crc32c() throws Exception {
+        testUpgrade("4.10.0", "4.17.0", "CRC32C")
     }
 
 }

--- a/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
+++ b/tests/backward-compat/upgrade/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgrade.groovy
@@ -55,12 +55,24 @@ class TestCompatUpgrade {
 
         try {
             def ledger0 = currentRunningBK.createLedger(2, 2,
-                                                        currentRunningCL.digestType("CRC32"),
-                                                        PASSWD)
+                    currentRunningCL.digestType("CRC32"),
+                    PASSWD)
             for (int i = 0; i < numEntries; i++) {
                 ledger0.addEntry(("foobar" + i).getBytes())
             }
             ledger0.close()
+
+            // Check whether current client can read from old server
+            def ledger0ro = upgradedBK.openLedger(ledger0.getId(), upgradedCL.digestType("CRC32"), PASSWD)
+            def entries0 = ledger0ro.readEntries(0, numEntries - 1)
+            int jj = 0
+            while (entries0.hasMoreElements()) {
+                def e = entries0.nextElement()
+                Assert.assertEquals(new String(e.getEntry()), "foobar" + jj)
+                jj++
+            }
+            Assert.assertEquals(jj, numEntries)
+            ledger0ro.close()
 
             // Check whether current client can write to old server
             def ledger1 = upgradedBK.createLedger(2, 2, upgradedCL.digestType("CRC32"), PASSWD)
@@ -142,12 +154,35 @@ class TestCompatUpgrade {
     }
 
     @Test
-    public void test_006_4130to4143() throws Exception {
-        testUpgrade("4.13.0", "4.14.4")
+    public void test_006_4130to4147() throws Exception {
+        testUpgrade("4.13.0", "4.14.7")
     }
 
     @Test
-    public void test_007_4143toCurrentMaster() throws Exception {
-        testUpgrade("4.14.4", BookKeeperClusterUtils.CURRENT_VERSION)
+    public void test_007_4147to4154() throws Exception {
+        testUpgrade("4.14.7", "4.15.4")
     }
+
+    @Test
+    public void test_008_4154to4161() throws Exception {
+        testUpgrade("4.15.4", "4.16.1")
+    }
+
+    @Test
+    public void test_009_4161toCurrentMaster() throws Exception {
+        testUpgrade("4.16.1", BookKeeperClusterUtils.CURRENT_VERSION)
+    }
+
+    // old version pulsar upgrade tests
+    @Test
+    public void test_010_4100to4147() throws Exception {
+        testUpgrade("4.10.0", "4.14.7")
+    }
+
+    // old version pulsar upgrade tests
+    @Test
+    public void test_010_4100to4161() throws Exception {
+        testUpgrade("4.10.0", "4.16.1")
+    }
+
 }

--- a/tests/docker-images/all-released-versions-image/Dockerfile
+++ b/tests/docker-images/all-released-versions-image/Dockerfile
@@ -49,9 +49,10 @@ RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.10.0/bookke
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.11.1/bookkeeper-server-4.11.1-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.12.1/bookkeeper-server-4.12.1-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.13.0/bookkeeper-server-4.13.0-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.7/bookkeeper-server-4.14.7-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.15.4/bookkeeper-server-4.15.4-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.1/bookkeeper-server-4.16.1-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.8/bookkeeper-server-4.14.8-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.15.5/bookkeeper-server-4.15.5-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.5/bookkeeper-server-4.16.5-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.17.0/bookkeeper-server-4.17.0-bin.tar.gz{,.sha512,.asc}
 
 RUN wget -nv https://dist.apache.org/repos/dist/release/bookkeeper/KEYS
 RUN wget -nv http://svn.apache.org/repos/asf/zookeeper/bookkeeper/dist/KEYS?p=1620552 -O KEYS.old

--- a/tests/docker-images/all-released-versions-image/Dockerfile
+++ b/tests/docker-images/all-released-versions-image/Dockerfile
@@ -49,7 +49,9 @@ RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.10.0/bookke
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.11.1/bookkeeper-server-4.11.1-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.12.1/bookkeeper-server-4.12.1-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.13.0/bookkeeper-server-4.13.0-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.4/bookkeeper-server-4.14.4-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.7/bookkeeper-server-4.14.7-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.15.4/bookkeeper-server-4.15.4-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.1/bookkeeper-server-4.16.1-bin.tar.gz{,.sha512,.asc}
 
 RUN wget -nv https://dist.apache.org/repos/dist/release/bookkeeper/KEYS
 RUN wget -nv http://svn.apache.org/repos/asf/zookeeper/bookkeeper/dist/KEYS?p=1620552 -O KEYS.old

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
@@ -40,13 +40,13 @@ import org.slf4j.LoggerFactory;
 public class BookKeeperClusterUtils {
     public static final String CURRENT_VERSION = System.getProperty("currentVersion");
     public static final List<String> OLD_CLIENT_VERSIONS =
-            Arrays.asList("4.8.2", "4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.4");
+            Arrays.asList("4.8.2", "4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1");
     private static final List<String> OLD_CLIENT_VERSIONS_WITH_CURRENT_LEDGER_METADATA_FORMAT =
-            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.4");
+            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1");
 
 
     private static final List<String> OLD_CLIENT_VERSIONS_WITH_OLD_BK_BIN_NAME =
-            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.3", "4.3-yahoo");
+            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1", "4.3-yahoo");
 
 
     private static final Logger LOG = LoggerFactory.getLogger(BookKeeperClusterUtils.class);

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
@@ -40,14 +40,11 @@ import org.slf4j.LoggerFactory;
 public class BookKeeperClusterUtils {
     public static final String CURRENT_VERSION = System.getProperty("currentVersion");
     public static final List<String> OLD_CLIENT_VERSIONS =
-            Arrays.asList("4.8.2", "4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1");
+            Arrays.asList("4.8.2", "4.9.2", "4.10.0", "4.11.1", "4.12.1",
+                    "4.13.0", "4.14.8", "4.15.5", "4.16.5", "4.17.0");
     private static final List<String> OLD_CLIENT_VERSIONS_WITH_CURRENT_LEDGER_METADATA_FORMAT =
-            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1");
-
-
-    private static final List<String> OLD_CLIENT_VERSIONS_WITH_OLD_BK_BIN_NAME =
-            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1", "4.13.0", "4.14.7", "4.15.4", "4.16.1", "4.3-yahoo");
-
+            Arrays.asList("4.9.2", "4.10.0", "4.11.1", "4.12.1",
+                    "4.13.0", "4.14.8", "4.15.5", "4.16.5", "4.17.0");
 
     private static final Logger LOG = LoggerFactory.getLogger(BookKeeperClusterUtils.class);
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Expanded backwards-compat tests

### Motivation

On pulsar slack @rdhabalia reported BK-related errors during upgrade.

### Changes

Backwards compat tests: 

* added new BK versions
* pulsar upgrade cases
* read check from old server (new client reads from old server)
* upgrade tests with CRC32C (for select cases)

