### PR TITLE
Fix memory leak of direct memory in direct memory entry logger.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectReader.java
@@ -56,8 +56,6 @@ class DirectReader implements LogReader {
         this.filename = filename;
         this.maxSaneEntrySize = maxSaneEntrySize;
         this.readBlockStats = readBlockStats;
-
-        nativeBuffer = new Buffer(nativeIO, bufferSize);
         closed = false;
 
         try {
@@ -71,6 +69,7 @@ class DirectReader implements LogReader {
                                   .kv("errno", ne.getErrno()).toString());
         }
         refreshMaxOffset();
+        nativeBuffer = new Buffer(nativeIO, bufferSize);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectWriter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectWriter.java
@@ -233,10 +233,11 @@ class DirectWriter implements LogWriter {
             throw new IOException(exMsg(ne.getMessage())
                                   .kv("file", filename)
                                   .kv("errno", ne.getErrno()).toString());
-        }
-        synchronized (bufferLock) {
-            bufferPool.release(nativeBuffer);
-            nativeBuffer = null;
+        } finally {
+            synchronized (bufferLock) {
+                bufferPool.release(nativeBuffer);
+                nativeBuffer = null;
+            }
         }
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation
When open a non-exist file for DirectReader, it will throw an exception. The ByteBuf won't release.
When close DirectWriter, if the close failed, the ByteBuf also won't release.