### PR TITLE
Fix Journal Sync wrong stats

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -372,8 +372,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         private long logId;
         private boolean flushed;
 
-        public int process(ObjectHashSet<BookieRequestHandler> writeHandlers) {
-            closeFileIfNecessary();
+        public int process(ObjectHashSet<BookieRequestHandler> writeHandlers, JournalStats journalStats) {
+            closeFileIfNecessary(journalStats);
 
             // Notify the waiters that the force write succeeded
             for (int i = 0; i < forceWriteWaiters.size(); i++) {
@@ -390,20 +390,29 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
             return forceWriteWaiters.size();
         }
 
-        private void flushFileToDisk() throws IOException {
+        private void flushFileToDisk(JournalStats journalStats) throws IOException {
             if (!flushed) {
-                logFile.forceWrite(false);
-                flushed = true;
+                long fsyncStartTime = MathUtils.nowInNano();
+                try {
+                    logFile.forceWrite(false);
+                    flushed = true;
+                    journalStats.getJournalSyncStats().registerSuccessfulEvent(MathUtils.elapsedNanos(fsyncStartTime),
+                            TimeUnit.NANOSECONDS);
+                } catch (IOException ioe) {
+                    journalStats.getJournalSyncStats()
+                            .registerFailedEvent(MathUtils.elapsedNanos(fsyncStartTime), TimeUnit.NANOSECONDS);
+                    throw ioe;
+                }
             }
         }
 
-        public void closeFileIfNecessary() {
+        public void closeFileIfNecessary(JournalStats journalStats) {
             // Close if shouldClose is set
             if (shouldClose) {
                 // We should guard against exceptions so its
                 // safe to call in catch blocks
                 try {
-                    flushFileToDisk();
+                    flushFileToDisk(journalStats);
                     logFile.close();
                     // Call close only once
                     shouldClose = false;
@@ -507,7 +516,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                     // responses
                     for (int i = 0; i < requestsCount; i++) {
                         ForceWriteRequest req = localRequests[i];
-                        numEntriesInLastForceWrite += req.process(writeHandlers);
+                        numEntriesInLastForceWrite += req.process(writeHandlers, journalStats);
                         localRequests[i] = null;
                         req.recycle();
                     }
@@ -534,17 +543,8 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
         }
 
         private void syncJournal(ForceWriteRequest lastRequest) throws IOException {
-            long fsyncStartTime = MathUtils.nowInNano();
-            try {
-                lastRequest.flushFileToDisk();
-                journalStats.getJournalSyncStats().registerSuccessfulEvent(MathUtils.elapsedNanos(fsyncStartTime),
-                        TimeUnit.NANOSECONDS);
-                lastLogMark.setCurLogMark(lastRequest.logId, lastRequest.lastFlushedPosition);
-            } catch (IOException ioe) {
-                journalStats.getJournalSyncStats()
-                        .registerFailedEvent(MathUtils.elapsedNanos(fsyncStartTime), TimeUnit.NANOSECONDS);
-                throw ioe;
-            }
+            lastRequest.flushFileToDisk(journalStats);
+            lastLogMark.setCurLogMark(lastRequest.logId, lastRequest.lastFlushedPosition);
         }
 
         // shutdown sync thread


### PR DESCRIPTION
### Motivation

In Journal, we process `ForceWriteRequest` with batch as the smallest unit. When we rotate a Journal File, in the forceWriteRequests queue, we may contain a ForceWriteRequest of an old file, and shouldClose is true, and the last ForceWriteRequest in the queue is created by the new Jouranl file. When we batch process fwr, we only sync the last ForceWriteRequest to the disk, so that we can flash the previous fwr data of the file to the disk together. But for old files, when we process the fwr response, we will still process `closeFileIfNecessary`. Here we also sync the Journal files that are waiting for close, but here, we do not update `JournalSyncStats`.
