### PR TITLE
Upgrade snappy-java to address multiple CVEs

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -317,7 +317,7 @@ Apache Software License, Version 2.
 - lib/io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar [47]
 - lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
-- lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
+- lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/org.hdrhistogram-HdrHistogram-2.1.10.jar [52]
 - lib/com.carrotsearch-hppc-0.9.1.jar [53]
@@ -395,7 +395,7 @@ Apache Software License, Version 2.
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
-[50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
+[50] Source available at https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/HdrHistogram/HdrHistogram/tree/HdrHistogram-2.1.10
 [53] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -289,7 +289,7 @@ Apache Software License, Version 2.
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
 - lib/io.perfmark-perfmark-api-0.25.0.jar [47]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
-- lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
+- lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 
@@ -330,7 +330,7 @@ Apache Software License, Version 2.
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
-[50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
+[50] Source available at https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -314,7 +314,7 @@ Apache Software License, Version 2.
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
 - lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar [49]
-- lib/org.xerial.snappy-snappy-java-1.1.7.7.jar [50]
+- lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 - lib/com.squareup.okhttp3-okhttp-4.11.0.jar [53]
@@ -391,7 +391,7 @@ Apache Software License, Version 2.
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.25.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.1
-[50] Source available at https://github.com/google/snappy/releases/tag/1.1.7.7
+[50] Source available at https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/square/okio/releases/tag/parent-3.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <testcontainers.version>1.17.6</testcontainers.version>
     <vertx.version>4.3.8</vertx.version>
     <zookeeper.version>3.8.1</zookeeper.version>
-    <snappy.version>1.1.7.7</snappy.version>
+    <snappy.version>1.1.10.1</snappy.version>
     <jctools.version>2.1.2</jctools.version>
     <hppc.version>0.9.1</hppc.version>
     <!-- plugin dependencies -->


### PR DESCRIPTION
Address multiple CVEs:
CVE-2023-34453
CVE-2023-34454
CVE-2023-34455

See https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1