### PR TITLE
Fix issue with binary compatibility with older grpc versions at runtime in the client

### DIFF
--- a/stream/common/src/main/java/org/apache/bookkeeper/common/resolver/ServiceNameResolverProvider.java
+++ b/stream/common/src/main/java/org/apache/bookkeeper/common/resolver/ServiceNameResolverProvider.java
@@ -40,7 +40,7 @@ import org.apache.bookkeeper.common.util.SharedResourceManager.Resource;
 @Slf4j
 public final class ServiceNameResolverProvider extends NameResolverFactoryProvider {
 
-    private final DnsNameResolverProvider dnsProvider;
+    private final NameResolverProvider dnsProvider;
     private final Resource<ExecutorService> executorResource;
 
     public ServiceNameResolverProvider() {


### PR DESCRIPTION
### Motivation

- grpc version was upgraded to 1.56.0 in #3992
- that breaks binary compatibility for DnsNameResolverProvider class
  - see https://github.com/grpc/grpc-java/commit/fcb5c54e4b82d354f42ced0121928fabce9ef53f#diff-b04e884de51ed12ff79482f600a2d4ec18e405ee189a4952ae35f4d2742b7160L50

### Changes

- make the field type NameResolverProvider instead of DnsNameResolverProvider
  - this prevents possible NoSuchMethodError errors about DnsNameResolverProvider.newNameResolver method 