### PR TITLE
Fix trigger GC not work

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -292,12 +292,11 @@ public class GarbageCollectorThread implements Runnable {
         }
     }
 
-    public void enableForceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void enableForceGC(boolean forceMajor, boolean forceMinor) {
         if (forceGarbageCollection.compareAndSet(false, true)) {
             LOG.info("Forced garbage collection triggered by thread: {}, forceMajor: {}, forceMinor: {}",
                 Thread.currentThread().getName(), forceMajor, forceMinor);
-            triggerGC(true, forceMajor == null ? suspendMajorCompaction.get() : !forceMajor,
-                forceMinor == null ? suspendMinorCompaction.get() : !forceMinor);
+            triggerGC(true, !forceMajor, !forceMinor);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -260,7 +260,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     @Override
-    public void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void forceGC(boolean forceMajor, boolean forceMinor) {
         gcThread.enableForceGC(forceMajor, forceMinor);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -232,7 +232,7 @@ public interface LedgerStorage {
     /**
      * Force trigger Garbage Collection with forceMajor or forceMinor parameter.
      */
-    default void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    default void forceGC(boolean forceMajor, boolean forceMinor) {
         return;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -367,7 +367,7 @@ public class SortedLedgerStorage
     }
 
     @Override
-    public void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void forceGC(boolean forceMajor, boolean forceMinor) {
         interleavedLedgerStorage.forceGC(forceMajor, forceMinor);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -511,7 +511,7 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
-    public void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void forceGC(boolean forceMajor, boolean forceMinor) {
         ledgerStorageList.stream().forEach(s -> s.forceGC(forceMajor, forceMinor));
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -270,7 +270,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     }
 
     @Override
-    public void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void forceGC(boolean forceMajor, boolean forceMinor) {
         gcThread.enableForceGC(forceMajor, forceMinor);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.http.HttpServer;
@@ -70,9 +71,13 @@ public class TriggerGCService implements HttpEndpointService {
                 } else {
                     @SuppressWarnings("unchecked")
                     Map<String, Object> configMap = JsonUtil.fromJson(requestBody, HashMap.class);
-                    Boolean forceMajor = (Boolean) configMap.getOrDefault("forceMajor", null);
-                    Boolean forceMinor = (Boolean) configMap.getOrDefault("forceMinor", null);
-                    bookieServer.getBookie().getLedgerStorage().forceGC(forceMajor, forceMinor);
+                    LedgerStorage ledgerStorage = bookieServer.getBookie().getLedgerStorage();
+                    boolean forceMajor = !ledgerStorage.isMajorGcSuspended();
+                    boolean forceMinor = !ledgerStorage.isMinorGcSuspended();
+
+                    forceMajor = Boolean.parseBoolean(configMap.getOrDefault("forceMajor", forceMajor).toString());
+                    forceMinor = Boolean.parseBoolean(configMap.getOrDefault("forceMinor", forceMinor).toString());
+                    ledgerStorage.forceGC(forceMajor, forceMinor);
                 }
 
                 String output = "Triggered GC on BookieServer: " + bookieServer.getBookieId();
@@ -94,13 +99,13 @@ public class TriggerGCService implements HttpEndpointService {
                 response.setCode(HttpServer.StatusCode.OK);
                 return response;
             } else {
-                response.setCode(HttpServer.StatusCode.NOT_FOUND);
-                response.setBody("Not found method. Should be PUT to trigger GC, Or GET to get Force GC state.");
+                response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
+                response.setBody("Not allowed method. Should be PUT to trigger GC, Or GET to get Force GC state.");
                 return response;
             }
         } catch (Exception e) {
             LOG.error("Failed to handle the request, method: {}, body: {} ", request.getMethod(), request.getBody(), e);
-            response.setCode(HttpServer.StatusCode.INTERNAL_ERROR);
+            response.setCode(HttpServer.StatusCode.BAD_REQUEST);
             response.setBody("Failed to handle the request, exception: " + e.getMessage());
             return response;
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/MockLedgerStorage.java
@@ -271,7 +271,7 @@ public class MockLedgerStorage implements CompactableLedgerStorage {
     }
 
     @Override
-    public void forceGC(Boolean forceMajor, Boolean forceMinor) {
+    public void forceGC(boolean forceMajor, boolean forceMinor) {
         CompactableLedgerStorage.super.forceGC(forceMajor, forceMinor);
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerGCServiceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/service/TriggerGCServiceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.LedgerStorage;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Unit test for {@link TriggerGCService}.
+ */
+@Slf4j
+public class TriggerGCServiceTest {
+    private TriggerGCService service;
+    private BookieServer mockBookieServer;
+    private LedgerStorage mockLedgerStorage;
+
+    @Before
+    public void setup() {
+        this.mockBookieServer = mock(BookieServer.class, RETURNS_DEEP_STUBS);
+        this.mockLedgerStorage = mock(DbLedgerStorage.class);
+        when(mockBookieServer.getBookie().getLedgerStorage()).thenReturn(mockLedgerStorage);
+        when(mockLedgerStorage.isInForceGC()).thenReturn(false);
+        this.service = new TriggerGCService(new ServerConfiguration(), mockBookieServer);
+    }
+
+    @Test
+    public void testHandleRequest() throws Exception {
+
+        // test empty put body
+        HttpServiceRequest request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        HttpServiceResponse resp = service.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("\"Triggered GC on BookieServer: " + mockBookieServer.getBookieId() + "\"",
+            resp.getBody());
+
+        // test invalid put json body
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("test");
+        resp = service.handle(request);
+        assertEquals(HttpServer.StatusCode.INTERNAL_ERROR.getValue(), resp.getStatusCode());
+        assertEquals("Failed to handle the request, exception: Failed to deserialize Object from Json string",
+            resp.getBody());
+
+        // test forceMajor and forceMinor not set
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("{\"test\":1}");
+        resp = service.handle(request);
+        verify(mockLedgerStorage, times(1)).forceGC(null, null);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("\"Triggered GC on BookieServer: " + mockBookieServer.getBookieId() + "\"",
+            resp.getBody());
+
+        // test forceMajor set, but forceMinor not set
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("{\"test\":1,\"forceMajor\":true}");
+        resp = service.handle(request);
+        verify(mockLedgerStorage, times(1)).forceGC(eq(true), eq(null));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("\"Triggered GC on BookieServer: " + mockBookieServer.getBookieId() + "\"",
+            resp.getBody());
+
+        // test forceMajor set, but forceMinor not set
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("{\"test\":1,\"forceMajor\":\"true\"}");
+        resp = service.handle(request);
+        //verify(mockLedgerStorage, times(1)).forceGC(true, null);
+        assertEquals(HttpServer.StatusCode.INTERNAL_ERROR.getValue(), resp.getStatusCode());
+        assertEquals("Failed to handle the request, exception: class java.lang.String cannot be cast to "
+                + "class java.lang.Boolean (java.lang.String and java.lang.Boolean "
+                + "are in module java.base of loader 'bootstrap')",
+            resp.getBody());
+
+        // test forceMajor set to false, and forMinor not set
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("{\"test\":1,\"forceMajor\":false}");
+        resp = service.handle(request);
+        verify(mockLedgerStorage, times(1)).forceGC(eq(false), eq(null));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("\"Triggered GC on BookieServer: " + mockBookieServer.getBookieId() + "\"",
+            resp.getBody());
+
+        // test forceMajor not set and forMinor set
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.PUT);
+        request.setBody("{\"test\":1,\"forceMinor\":true}");
+        resp = service.handle(request);
+        verify(mockLedgerStorage, times(1)).forceGC(eq(null), eq(true));
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("\"Triggered GC on BookieServer: " + mockBookieServer.getBookieId() + "\"",
+            resp.getBody());
+
+        // test get gc
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.GET);
+        resp = service.handle(request);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), resp.getStatusCode());
+        assertEquals("{\n  \"is_in_force_gc\" : \"false\"\n}", resp.getBody());
+
+        // test invalid method type
+        request = new HttpServiceRequest();
+        request.setMethod(HttpServer.Method.POST);
+        resp = service.handle(request);
+        assertEquals(HttpServer.StatusCode.NOT_FOUND.getValue(), resp.getStatusCode());
+        assertEquals("Not found method. Should be PUT to trigger GC, Or GET to get Force GC state.",
+            resp.getBody());
+    }
+
+}


### PR DESCRIPTION
### Motivation
When I use `curl -XPUT http://<ip>:<port>/api/v1/bookie/gc` command to trigger garbage compaction, the bookie server returns `Internal Server Error`. Then I checked the bookie server's log, and nothing was found.

After a deep debugging of the server, I found the following exception.
```
    org.apache.bookkeeper.common.util.JsonUtil$ParseJsonException: Failed to deserialize Object from Json string
	at org.apache.bookkeeper.common.util.JsonUtil.fromJson(JsonUtil.java:41)
	at org.apache.bookkeeper.server.http.service.TriggerGCService.handle(TriggerGCService.java:71)
	at org.apache.bookkeeper.http.vertx.VertxAbstractHandler.processRequest(VertxAbstractHandler.java:55)
	at org.apache.bookkeeper.http.vertx.VertxHttpHandlerFactory$1.handle(VertxHttpHandlerFactory.java:47)
	at org.apache.bookkeeper.http.vertx.VertxHttpHandlerFactory$1.handle(VertxHttpHandlerFactory.java:43)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1038)
	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:137)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:132)
	at io.vertx.ext.web.handler.impl.BodyHandlerImpl$BHandler.doEnd(BodyHandlerImpl.java:296)
	at io.vertx.ext.web.handler.impl.BodyHandlerImpl$BHandler.end(BodyHandlerImpl.java:276)
	at io.vertx.ext.web.handler.impl.BodyHandlerImpl.lambda$handle$0(BodyHandlerImpl.java:87)
	at io.vertx.core.http.impl.HttpServerRequestImpl.onEnd(HttpServerRequestImpl.java:525)
	at io.vertx.core.http.impl.HttpServerRequestImpl.handleEnd(HttpServerRequestImpl.java:511)
	at io.vertx.core.http.impl.Http1xServerConnection.handleEnd(Http1xServerConnection.java:176)
	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:138)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
```

This bug is introduced by https://github.com/apache/bookkeeper/pull/3205. When we use `curl -XPUT http://<ip>:<port>/api/v1/bookie/gc` command to trigger gc, the request body is empty string, but not `null`. 
https://github.com/apache/bookkeeper/blob/ffc8e8bec19e54dc76710c3de133401248f243d6/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerGCService.java#L67-L75

It will enter Line#68 but goes into Line#71. It uses `JsonUtil.fromJson` to parse an empty string will throw the above exception and will return `500` to the client but no logs in the server side.

### Changes
- Fix the request body check bug
- Add a unit test to cover this logic

