### PR TITLE
Use older protobuf/grpc codegen to support older runtimes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,8 +162,10 @@
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
     <protobuf.version>3.22.3</protobuf.version>
-    <protoc3.version>3.22.3</protoc3.version>
-    <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
+    <!-- set protoc3.version to the oldest version of protobuf to support at runtime -->
+    <protoc3.version>3.19.6</protoc3.version>
+    <!-- set protco-gen-grpc-java.version to the oldest version of grpc to support at runtime -->
+    <protoc-gen-grpc-java.version>1.45.1</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <shrinkwrap.version>3.0.1</shrinkwrap.version>


### PR DESCRIPTION
### Motivation

It seems that protobuf and grpc codegen should be done using a codegen version of the oldest version 
of protobuf and grpc-java to support at runtime. Generated code is designed to be compatible with newer runtimes, 
but not necessarily compatible with older runtimes.

### Changes

Set `protoc3.version` to `3.19.6`.
Set `protoc-gen-grpc-java.version` to `1.45.1`.