### PR TITLE
[Branch-4.16] Downgrade grpc and protobuf to avoid introducing breaking change

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -275,26 +275,26 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [28]
-- lib/com.google.code.gson-gson-2.10.1.jar [29]
+- lib/com.google.api.grpc-proto-google-common-protos-2.9.0.jar [28]
+- lib/com.google.code.gson-gson-2.9.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.56.0.jar [33]
-- lib/io.grpc-grpc-alts-1.56.0.jar [33]
-- lib/io.grpc-grpc-api-1.56.0.jar [33]
-- lib/io.grpc-grpc-auth-1.56.0.jar [33]
-- lib/io.grpc-grpc-context-1.56.0.jar [33]
-- lib/io.grpc-grpc-core-1.56.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [33]
-- lib/io.grpc-grpc-netty-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [33]
-- lib/io.grpc-grpc-services-1.56.0.jar [33]
-- lib/io.grpc-grpc-stub-1.56.0.jar [33]
-- lib/io.grpc-grpc-testing-1.56.0.jar [33]
-- lib/io.grpc-grpc-xds-1.56.0.jar [33]
-- lib/io.grpc-grpc-rls-1.56.0.jar[33]
+- lib/io.grpc-grpc-all-1.54.1.jar [33]
+- lib/io.grpc-grpc-alts-1.54.1.jar [33]
+- lib/io.grpc-grpc-api-1.54.1.jar [33]
+- lib/io.grpc-grpc-auth-1.54.1.jar [33]
+- lib/io.grpc-grpc-context-1.54.1.jar [33]
+- lib/io.grpc-grpc-core-1.54.1.jar [33]
+- lib/io.grpc-grpc-grpclb-1.54.1.jar [33]
+- lib/io.grpc-grpc-netty-1.54.1.jar [33]
+- lib/io.grpc-grpc-protobuf-1.54.1.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar [33]
+- lib/io.grpc-grpc-services-1.54.1.jar [33]
+- lib/io.grpc-grpc-stub-1.54.1.jar [33]
+- lib/io.grpc-grpc-testing-1.54.1.jar [33]
+- lib/io.grpc-grpc-xds-1.54.1.jar [33]
+- lib/io.grpc-grpc-rls-1.54.1.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -308,14 +308,14 @@ Apache Software License, Version 2.
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.41.0.jar [43]
 - lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [44]
+- lib/com.google.auto.value-auto-value-annotations-1.9.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [45]
-- lib/com.google.re2j-re2j-1.7.jar [46]
+- lib/com.google.re2j-re2j-1.6.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-jmx-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar [47]
-- lib/io.perfmark-perfmark-api-0.26.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -641,13 +641,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -641,13 +641,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
-Source available at https://github.com/google/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-3.21.9.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-util-3.21.9.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -566,13 +566,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
-Source available at https://github.com/google/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-3.21.9.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-util-3.21.9.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -250,26 +250,26 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.8.1-tests.jar [20]
 - lib/com.beust-jcommander-1.82.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [27]
-- lib/com.google.code.gson-gson-2.10.1.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.9.0.jar [27]
+- lib/com.google.code.gson-gson-2.9.0.jar [28]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/io.grpc-grpc-all-1.56.0.jar [32]
-- lib/io.grpc-grpc-alts-1.56.0.jar [32]
-- lib/io.grpc-grpc-api-1.56.0.jar [32]
-- lib/io.grpc-grpc-auth-1.56.0.jar [32]
-- lib/io.grpc-grpc-context-1.56.0.jar [32]
-- lib/io.grpc-grpc-core-1.56.0.jar [32]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [32]
-- lib/io.grpc-grpc-netty-1.56.0.jar [32]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [32]
-- lib/io.grpc-grpc-services-1.56.0.jar [32]
-- lib/io.grpc-grpc-stub-1.56.0.jar [32]
-- lib/io.grpc-grpc-testing-1.56.0.jar [32]
-- lib/io.grpc-grpc-xds-1.56.0.jar [32]
-- lib/io.grpc-grpc-rls-1.56.0.jar[32]
+- lib/io.grpc-grpc-all-1.54.1.jar [32]
+- lib/io.grpc-grpc-alts-1.54.1.jar [32]
+- lib/io.grpc-grpc-api-1.54.1.jar [32]
+- lib/io.grpc-grpc-auth-1.54.1.jar [32]
+- lib/io.grpc-grpc-context-1.54.1.jar [32]
+- lib/io.grpc-grpc-core-1.54.1.jar [32]
+- lib/io.grpc-grpc-grpclb-1.54.1.jar [32]
+- lib/io.grpc-grpc-netty-1.54.1.jar [32]
+- lib/io.grpc-grpc-protobuf-1.54.1.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar [32]
+- lib/io.grpc-grpc-services-1.54.1.jar [32]
+- lib/io.grpc-grpc-stub-1.54.1.jar [32]
+- lib/io.grpc-grpc-testing-1.54.1.jar [32]
+- lib/io.grpc-grpc-xds-1.54.1.jar [32]
+- lib/io.grpc-grpc-rls-1.54.1.jar[32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
@@ -281,13 +281,13 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [39]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [40]
 - lib/com.google.android-annotations-4.1.1.4.jar [41]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [42]
+- lib/com.google.auto.value-auto-value-annotations-1.9.jar [42]
 - lib/com.google.http-client-google-http-client-1.41.0.jar [43]
 - lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [44]
-- lib/com.google.re2j-re2j-1.7.jar [45]
+- lib/com.google.re2j-re2j-1.6.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
-- lib/io.perfmark-perfmark-api-0.26.0.jar [47]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [47]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -566,13 +566,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -630,13 +630,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
-Source available at https://github.com/google/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-3.21.9.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
+  - lib/com.google.protobuf-protobuf-java-util-3.21.9.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.9
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -275,26 +275,26 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [28]
-- lib/com.google.code.gson-gson-2.10.1.jar [29]
+- lib/com.google.api.grpc-proto-google-common-protos-2.9.0.jar [28]
+- lib/com.google.code.gson-gson-2.9.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.56.0.jar [33]
-- lib/io.grpc-grpc-alts-1.56.0.jar [33]
-- lib/io.grpc-grpc-api-1.56.0.jar [33]
-- lib/io.grpc-grpc-auth-1.56.0.jar [33]
-- lib/io.grpc-grpc-context-1.56.0.jar [33]
-- lib/io.grpc-grpc-core-1.56.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [33]
-- lib/io.grpc-grpc-netty-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [33]
-- lib/io.grpc-grpc-services-1.56.0.jar [33]
-- lib/io.grpc-grpc-stub-1.56.0.jar [33]
-- lib/io.grpc-grpc-testing-1.56.0.jar [33]
-- lib/io.grpc-grpc-xds-1.56.0.jar [33]
-- lib/io.grpc-grpc-rls-1.56.0.jar[33]
+- lib/io.grpc-grpc-all-1.54.1.jar [33]
+- lib/io.grpc-grpc-alts-1.54.1.jar [33]
+- lib/io.grpc-grpc-api-1.54.1.jar [33]
+- lib/io.grpc-grpc-auth-1.54.1.jar [33]
+- lib/io.grpc-grpc-context-1.54.1.jar [33]
+- lib/io.grpc-grpc-core-1.54.1.jar [33]
+- lib/io.grpc-grpc-grpclb-1.54.1.jar [33]
+- lib/io.grpc-grpc-netty-1.54.1.jar [33]
+- lib/io.grpc-grpc-protobuf-1.54.1.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar [33]
+- lib/io.grpc-grpc-services-1.54.1.jar [33]
+- lib/io.grpc-grpc-stub-1.54.1.jar [33]
+- lib/io.grpc-grpc-testing-1.54.1.jar [33]
+- lib/io.grpc-grpc-xds-1.54.1.jar [33]
+- lib/io.grpc-grpc-rls-1.54.1.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -308,11 +308,11 @@ Apache Software License, Version 2.
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.http-client-google-http-client-1.41.0.jar [43]
 - lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [44]
+- lib/com.google.auto.value-auto-value-annotations-1.9.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-1.3.jar [45]
-- lib/com.google.re2j-re2j-1.7.jar [46]
+- lib/com.google.re2j-re2j-1.6.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
-- lib/io.perfmark-perfmark-api-0.26.0.jar [48]
+- lib/io.perfmark-perfmark-api-0.25.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar [49]
 - lib/org.xerial.snappy-snappy-java-1.1.10.1.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
@@ -630,13 +630,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.21.12.jar
+Source available at https://github.com/google/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.21.12.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.21.12
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -134,15 +134,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.54.1.jar
+- lib/io.grpc-grpc-auth-1.54.1.jar
+- lib/io.grpc-grpc-context-1.54.1.jar
+- lib/io.grpc-grpc-core-1.54.1.jar
+- lib/io.grpc-grpc-netty-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar
+- lib/io.grpc-grpc-stub-1.54.1.jar
+- lib/io.grpc-grpc-testing-1.54.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -56,15 +56,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.54.1.jar
+- lib/io.grpc-grpc-auth-1.54.1.jar
+- lib/io.grpc-grpc-context-1.54.1.jar
+- lib/io.grpc-grpc-core-1.54.1.jar
+- lib/io.grpc-grpc-netty-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar
+- lib/io.grpc-grpc-stub-1.54.1.jar
+- lib/io.grpc-grpc-testing-1.54.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -116,15 +116,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.54.1.jar
+- lib/io.grpc-grpc-auth-1.54.1.jar
+- lib/io.grpc-grpc-context-1.54.1.jar
+- lib/io.grpc-grpc-core-1.54.1.jar
+- lib/io.grpc-grpc-netty-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-1.54.1.jar
+- lib/io.grpc-grpc-protobuf-lite-1.54.1.jar
+- lib/io.grpc-grpc-stub-1.54.1.jar
+- lib/io.grpc-grpc-testing-1.54.1.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <freebuilder.version>2.7.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>
-    <grpc.version>1.56.0</grpc.version>
+    <grpc.version>1.54.1</grpc.version>
     <guava.version>31.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>3.3.5</hadoop.version>
@@ -161,8 +161,8 @@
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <protobuf.version>3.22.3</protobuf.version>
-    <protoc3.version>3.22.3</protoc3.version>
+    <protobuf.version>3.21.12</protobuf.version>
+    <protoc3.version>3.21.12</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>7.9.2</rocksdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <protobuf.version>3.21.12</protobuf.version>
-    <protoc3.version>3.21.12</protoc3.version>
+    <protobuf.version>3.21.9</protobuf.version>
+    <protoc3.version>3.21.9</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>7.9.2</rocksdb.version>


### PR DESCRIPTION
---

### Motivation

We upgrade grpc and protobuf to address CVE-2023-32732. But it requires the protobuf 3.22+. In protobuf 3.22.0, it introduces a breaking change. It requires all the sub-project, which depend on the bookkeeper to upgrade protobuf to 3.22.0+. It should not be acceptable in a minor release.

So we use a lower version of grpc and protobuf to address the CVE issue.

See more context: https://github.com/apache/bookkeeper/pull/3997

