### PR TITLE
 AddRequestStats metric is missed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -128,6 +128,13 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
         requestHandler.prepareSendResponseV2(rc, request);
         requestProcessor.onAddRequestFinish();
 
+        if (BookieProtocol.EOK == rc) {
+            requestProcessor.getRequestStats().getAddRequestStats().registerSuccessfulEvent(
+                    MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        } else {
+            requestProcessor.getRequestStats().getAddRequestStats().registerFailedEvent(
+                    MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+        }
         request.recycle();
         recycle();
     }


### PR DESCRIPTION
### Motivation
Before  #3848，Bookie sent response by `org.apache.bookkeeper.proto.PacketProcessorBase#sendResponse`
And we record the add request stat in this method.
```
if (BookieProtocol.EOK == rc) {
            statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
        } else {
            statsLogger.registerFailedEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
        }
```
Now, we implement an new flush strategy, and missed record  add request stat. 
### Changes
Record add request stat in `writeComplete `
