### PR TITLE
Optimize getActiveLedgersInRange

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -160,6 +160,9 @@ public class LedgerMetadataIndex implements Closeable {
 
     public Iterable<Long> getActiveLedgersInRange(final long firstLedgerId, final long lastLedgerId)
             throws IOException {
+        if (firstLedgerId <=0 && lastLedgerId == Long.MAX_VALUE) {
+            return ledgers.keys();
+        }
         return Iterables.filter(ledgers.keys(), new Predicate<Long>() {
             @Override
             public boolean apply(Long ledgerId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -160,7 +160,7 @@ public class LedgerMetadataIndex implements Closeable {
 
     public Iterable<Long> getActiveLedgersInRange(final long firstLedgerId, final long lastLedgerId)
             throws IOException {
-        if (firstLedgerId <=0 && lastLedgerId == Long.MAX_VALUE) {
+        if (firstLedgerId <= 0 && lastLedgerId == Long.MAX_VALUE) {
             return ledgers.keys();
         }
         return Iterables.filter(ledgers.keys(), new Predicate<Long>() {


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Optimize `Iterable<Long>  getActiveLedgersInRange(0, Long.MAX_VALUE)` by  avoid applying the filter predicate when traverse the `Iterable<Long>`.


There are many places call `getActiveLedgersInRange(0, Long.MAX_VALUE)`  to get the `Iterable` of all the `ledgerId`,  for example:
1. https://github.com/apache/bookkeeper/blob/147b5bf846189584d6a9b4e20ac9a73e6e617255/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java#L124-L125
2. https://github.com/apache/bookkeeper/blob/147b5bf846189584d6a9b4e20ac9a73e6e617255/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ConvertToDBStorageCommand.java#L88
3. https://github.com/apache/bookkeeper/blob/147b5bf846189584d6a9b4e20ac9a73e6e617255/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildOp.java#L160

We could return the keys of `ledgers` directly to avoid applying the filter predicate when traverse the `Iterable<Long>`


### Changes

Return the keys of `ledgers` directly if `firstLedgerId <=0 && lastLedgerId == Long.MAX_VALUE`
