### PR TITLE
Recycle LongWrapper finally to avoid memory leak

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -299,38 +299,44 @@ public class LedgerMetadataIndex implements Closeable {
     public void flush() throws IOException {
         LongWrapper key = LongWrapper.get();
 
-        int updatedLedgers = 0;
-        Entry<Long, LedgerData> entry;
-        while ((entry = pendingLedgersUpdates.poll()) != null) {
-            key.set(entry.getKey());
-            byte[] value = entry.getValue().toByteArray();
-            ledgersDb.put(key.array, value);
-            ++updatedLedgers;
-        }
+        try {
+            int updatedLedgers = 0;
+            Entry<Long, LedgerData> entry;
+            while ((entry = pendingLedgersUpdates.poll()) != null) {
+                key.set(entry.getKey());
+                byte[] value = entry.getValue().toByteArray();
+                ledgersDb.put(key.array, value);
+                ++updatedLedgers;
+            }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Persisting updates to {} ledgers", updatedLedgers);
-        }
+            if (log.isDebugEnabled()) {
+                log.debug("Persisting updates to {} ledgers", updatedLedgers);
+            }
 
-        ledgersDb.sync();
-        key.recycle();
+            ledgersDb.sync();
+        } finally {
+            key.recycle();
+        }
     }
 
     public void removeDeletedLedgers() throws IOException {
         LongWrapper key = LongWrapper.get();
 
-        int deletedLedgers = 0;
-        for (Long ledgerId : pendingDeletedLedgers) {
-            key.set(ledgerId);
-            ledgersDb.delete(key.array);
-        }
+        try {
+            int deletedLedgers = 0;
+            for (Long ledgerId : pendingDeletedLedgers) {
+                key.set(ledgerId);
+                ledgersDb.delete(key.array);
+            }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Persisting deletes of ledgers {}", deletedLedgers);
-        }
+            if (log.isDebugEnabled()) {
+                log.debug("Persisting deletes of ledgers {}", deletedLedgers);
+            }
 
-        ledgersDb.sync();
-        key.recycle();
+            ledgersDb.sync();
+        } finally {
+            key.recycle();
+        }
     }
 
     private ReentrantLock lockForLedger(long ledgerId) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

We should recycle `LongWrapper` in  `finally` block to avoid memory leak. Beacuase `flush()` and `removeDeletedLedgers()` could throw Exception.

### Changes
Recycle `LongWrapper` in  `finally` block



