### PR TITLE
Fix replace result adhere result wrong problem.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeperAdmin.java
@@ -1084,17 +1084,17 @@ public class BookKeeperAdmin implements AutoCloseable {
             BookieId bookie = ensemble.get(bookieIndex);
             bookiesToExclude.add(bookie);
         }
-
+        List<BookieId> newEnsemble = new ArrayList<>(ensemble) ;
         // allocate bookies
         for (Integer bookieIndex : bookieIndexesToRereplicate) {
-            BookieId oldBookie = ensemble.get(bookieIndex);
+            BookieId oldBookie = newEnsemble.get(bookieIndex);
             EnsemblePlacementPolicy.PlacementResult<BookieId> replaceBookieResponse =
                     bkc.getPlacementPolicy().replaceBookie(
                             lh.getLedgerMetadata().getEnsembleSize(),
                             lh.getLedgerMetadata().getWriteQuorumSize(),
                             lh.getLedgerMetadata().getAckQuorumSize(),
                             lh.getLedgerMetadata().getCustomMetadata(),
-                            ensemble,
+                            newEnsemble,
                             oldBookie,
                             bookiesToExclude);
             BookieId newBookie = replaceBookieResponse.getResult();
@@ -1103,10 +1103,11 @@ public class BookKeeperAdmin implements AutoCloseable {
                 LOG.debug(
                         "replaceBookie for bookie: {} in ensemble: {} "
                                 + "is not adhering to placement policy and chose {}",
-                        oldBookie, ensemble, newBookie);
+                        oldBookie, newEnsemble, newBookie);
             }
             targetBookieAddresses.put(bookieIndex, newBookie);
             bookiesToExclude.add(newBookie);
+            newEnsemble.set(bookieIndex, newBookie);
         }
 
         return targetBookieAddresses;


### PR DESCRIPTION
Descriptions of the changes in this PR:

When replacing a bookie, if there are two or more bookies that need to be replaced, our logic is to replace them one by one. However, after the replacement, we do not use the new bookies to replace the old ones in the ensemble. Therefore, the return result of isEnsembleAdheringToPlacementPolicy may be incorrect.

The code:
```
        for (Integer bookieIndex : bookieIndexesToRereplicate) {
            BookieId oldBookie = newEnsemble.get(bookieIndex);
            EnsemblePlacementPolicy.PlacementResult<BookieId> replaceBookieResponse =
                    bkc.getPlacementPolicy().replaceBookie(
                            lh.getLedgerMetadata().getEnsembleSize(),
                            lh.getLedgerMetadata().getWriteQuorumSize(),
                            lh.getLedgerMetadata().getAckQuorumSize(),
                            lh.getLedgerMetadata().getCustomMetadata(),
                            ensemble,
                            oldBookie,
                            bookiesToExclude);
            BookieId newBookie = replaceBookieResponse.getResult();
                LOG.debug(
                        "replaceBookie for bookie: {} in ensemble: {} "
                                + "is not adhering to placement policy and chose {}",
                        oldBookie, newEnsemble, newBookie);
            }
            targetBookieAddresses.put(bookieIndex, newBookie);
            bookiesToExclude.add(newBookie);
            newEnsemble.set(bookieIndex, newBookie);
        }
```

The 5th param `ensemble` in EnsemblePlacementPolicy#replaceBookie should be updated after replace.

Example:
The ensemble [0,1,2], we want to replace [1,2].

Step1. replace 1 by 3, after replace, the 5th param ensemble should be [0,3,2], instead still [0,1,2].
 






