### PR TITLE
Add read failed log for ledger checker.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerChecker.java
@@ -87,6 +87,9 @@ public class LedgerChecker {
                     cb.operationComplete(rc, fragment);
                 }
             } else if (!completed.getAndSet(true)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Read {}:{} from {} failed, the error code: {}", ledgerId, entryId, ctx, rc);
+                }
                 cb.operationComplete(rc, fragment);
             }
         }
@@ -254,7 +257,7 @@ public class LedgerChecker {
             ReadManyEntriesCallback manycb = new ReadManyEntriesCallback(1,
                     fragment, cb);
             bookieClient.readEntry(bookie, fragment.getLedgerId(), firstStored,
-                                   manycb, null, BookieProtocol.FLAG_NONE);
+                                   manycb, bookie, BookieProtocol.FLAG_NONE);
         } else {
             if (lastStored <= firstStored) {
                 cb.operationComplete(Code.IncorrectParameterException, null);
@@ -296,7 +299,7 @@ public class LedgerChecker {
                     fragment, cb);
             for (Long entryID: entriesToBeVerified) {
                 acquirePermit();
-                bookieClient.readEntry(bookie, fragment.getLedgerId(), entryID, manycb, null, BookieProtocol.FLAG_NONE);
+                bookieClient.readEntry(bookie, fragment.getLedgerId(), entryID, manycb, bookie, BookieProtocol.FLAG_NONE);
             }
         }
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:
The ledger checker will try to read entries from the bookie. If the read failed, mark the ledger as under-replicated. 

For users, they didn't know the reason why the ledger mark as under-replicated. Is it because the entry is missing, the ledger does not exist, or because the bookie is under heavy load and the read request times out?

So here we add debug log for ledger checker. If read failed, log the error code.

