### PR TITLE
Fix getLedgerDirsListener

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -121,6 +121,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     private OpStatsLogger getEntryStats;
     private OpStatsLogger pageScanStats;
     private Counter retryCounter;
+    protected LedgerDirsManager ledgerDirsManager;
 
     public InterleavedLedgerStorage() {
         activeLedgers = new SnapshotMap<>();
@@ -184,6 +185,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         checkNotNull(checkpointer, "invalid null checkpointer");
         this.entryLogger = (DefaultEntryLogger) entryLogger;
         this.entryLogger.addListener(this);
+        this.ledgerDirsManager = ledgerDirsManager;
         ledgerCache = new LedgerCacheImpl(conf, activeLedgers,
                 null == indexDirsManager ? ledgerDirsManager : indexDirsManager, statsLogger);
         gcThread = new GarbageCollectorThread(conf, ledgerManager, ledgerDirsManager,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -203,21 +203,26 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
 
             @Override
             public void diskAlmostFull(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace) {
-                    gcThread.enableForceGC();
-                } else {
-                    gcThread.suspendMajorGC();
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace) {
+                        gcThread.enableForceGC();
+                    } else {
+                        gcThread.suspendMajorGC();
+                    }
                 }
             }
 
             @Override
             public void diskFull(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace) {
-                    gcThread.enableForceGC();
-                } else {
-                    gcThread.suspendMajorGC();
-                    gcThread.suspendMinorGC();
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace) {
+                        gcThread.enableForceGC();
+                    } else {
+                        gcThread.suspendMajorGC();
+                        gcThread.suspendMinorGC();
+                    }
                 }
+
             }
 
             @Override
@@ -232,25 +237,30 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
 
             @Override
             public void diskWritable(File disk) {
-                // we have enough space now
-                if (gcThread.isForceGCAllowWhenNoSpace) {
-                    // disable force gc.
-                    gcThread.disableForceGC();
-                } else {
-                    // resume compaction to normal.
-                    gcThread.resumeMajorGC();
-                    gcThread.resumeMinorGC();
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)) {
+                    // we have enough space now
+                    if (gcThread.isForceGCAllowWhenNoSpace) {
+                        // disable force gc.
+                        gcThread.disableForceGC();
+                    } else {
+                        // resume compaction to normal.
+                        gcThread.resumeMajorGC();
+                        gcThread.resumeMinorGC();
+                    }
                 }
+
             }
 
             @Override
             public void diskJustWritable(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace) {
-                    // if a disk is just writable, we still need force gc.
-                    gcThread.enableForceGC();
-                } else {
-                    // still under warn threshold, only resume minor compaction.
-                    gcThread.resumeMinorGC();
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace) {
+                        // if a disk is just writable, we still need force gc.
+                        gcThread.enableForceGC();
+                    } else {
+                        // still under warn threshold, only resume minor compaction.
+                        gcThread.resumeMinorGC();
+                    }
                 }
             }
         };

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -144,8 +144,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private final Counter flushExecutorTime;
     private final boolean singleLedgerDirs;
-
-    private final String ledgerBaseDir;
+    private final LedgerDirsManager ledgerDirsManager;
+    private final LedgerDirsManager indexDirsManager;
 
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
                                           LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
@@ -157,7 +157,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 "Db implementation only allows for one storage dir");
 
         String ledgerBaseDir = ledgerDirsManager.getAllLedgerDirs().get(0).getPath();
-        this.ledgerBaseDir = ledgerBaseDir;
         // indexBaseDir default use ledgerBaseDir
         String indexBaseDir = ledgerBaseDir;
         if (CollectionUtils.isEmpty(indexDirsManager.getAllLedgerDirs())
@@ -231,6 +230,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         if (!ledgerBaseDir.equals(indexBaseDir)) {
             indexDirsManager.addLedgerDirsListener(getLedgerDirsListener());
         }
+        this.ledgerDirsManager = ledgerDirsManager;
+        this.indexDirsManager = indexDirsManager;
     }
 
     @Override
@@ -1150,7 +1151,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskAlmostFull(File disk) {
-                if (disk.getPath().equals(ledgerBaseDir)) {
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)
+                        || indexDirsManager.getAllLedgerDirs().contains(disk)) {
                     if (gcThread.isForceGCAllowWhenNoSpace()) {
                         gcThread.enableForceGC();
                     } else {
@@ -1161,7 +1163,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskFull(File disk) {
-                if (disk.getPath().equals(ledgerBaseDir)) {
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)
+                        || indexDirsManager.getAllLedgerDirs().contains(disk)) {
                     if (gcThread.isForceGCAllowWhenNoSpace()) {
                         gcThread.enableForceGC();
                     } else {
@@ -1184,7 +1187,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskWritable(File disk) {
-                if (disk.getPath().equals(ledgerBaseDir)) {
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)
+                        || indexDirsManager.getAllLedgerDirs().contains(disk)) {
                     // we have enough space now
                     if (gcThread.isForceGCAllowWhenNoSpace()) {
                         // disable force gc.
@@ -1199,7 +1203,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskJustWritable(File disk) {
-                if (disk.getPath().equals(ledgerBaseDir)) {
+                if (ledgerDirsManager.getAllLedgerDirs().contains(disk)
+                        || indexDirsManager.getAllLedgerDirs().contains(disk)) {
                     if (gcThread.isForceGCAllowWhenNoSpace()) {
                         // if a disk is just writable, we still need force gc.
                         gcThread.enableForceGC();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -145,6 +145,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     private final Counter flushExecutorTime;
     private final boolean singleLedgerDirs;
 
+    private final String ledgerBaseDir;
+
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
                                           LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                                           EntryLogger entryLogger, StatsLogger statsLogger, ByteBufAllocator allocator,
@@ -155,6 +157,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 "Db implementation only allows for one storage dir");
 
         String ledgerBaseDir = ledgerDirsManager.getAllLedgerDirs().get(0).getPath();
+        this.ledgerBaseDir = ledgerBaseDir;
         // indexBaseDir default use ledgerBaseDir
         String indexBaseDir = ledgerBaseDir;
         if (CollectionUtils.isEmpty(indexDirsManager.getAllLedgerDirs())
@@ -1147,21 +1150,26 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskAlmostFull(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace()) {
-                    gcThread.enableForceGC();
-                } else {
-                    gcThread.suspendMajorGC();
+                if (disk.getPath().equals(ledgerBaseDir)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace()) {
+                        gcThread.enableForceGC();
+                    } else {
+                        gcThread.suspendMajorGC();
+                    }
                 }
             }
 
             @Override
             public void diskFull(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace()) {
-                    gcThread.enableForceGC();
-                } else {
-                    gcThread.suspendMajorGC();
-                    gcThread.suspendMinorGC();
+                if (disk.getPath().equals(ledgerBaseDir)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace()) {
+                        gcThread.enableForceGC();
+                    } else {
+                        gcThread.suspendMajorGC();
+                        gcThread.suspendMinorGC();
+                    }
                 }
+
             }
 
             @Override
@@ -1176,25 +1184,29 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
             @Override
             public void diskWritable(File disk) {
-                // we have enough space now
-                if (gcThread.isForceGCAllowWhenNoSpace()) {
-                    // disable force gc.
-                    gcThread.disableForceGC();
-                } else {
-                    // resume compaction to normal.
-                    gcThread.resumeMajorGC();
-                    gcThread.resumeMinorGC();
+                if (disk.getPath().equals(ledgerBaseDir)) {
+                    // we have enough space now
+                    if (gcThread.isForceGCAllowWhenNoSpace()) {
+                        // disable force gc.
+                        gcThread.disableForceGC();
+                    } else {
+                        // resume compaction to normal.
+                        gcThread.resumeMajorGC();
+                        gcThread.resumeMinorGC();
+                    }
                 }
             }
 
             @Override
             public void diskJustWritable(File disk) {
-                if (gcThread.isForceGCAllowWhenNoSpace()) {
-                    // if a disk is just writable, we still need force gc.
-                    gcThread.enableForceGC();
-                } else {
-                    // still under warn threshold, only resume minor compaction.
-                    gcThread.resumeMinorGC();
+                if (disk.getPath().equals(ledgerBaseDir)) {
+                    if (gcThread.isForceGCAllowWhenNoSpace()) {
+                        // if a disk is just writable, we still need force gc.
+                        gcThread.enableForceGC();
+                    } else {
+                        // still under warn threshold, only resume minor compaction.
+                        gcThread.resumeMinorGC();
+                    }
                 }
             }
         };


### PR DESCRIPTION
### Motivation
The ledgerDirsListener in SingleDirectoryDbLedgerStorage is currently triggered by a ledger directory that does not belong to this storage.

### Changes

To address this issue, we can introduce a comparison step to verify the ownership of the ledger directory before triggering the listeners. This way, the ledgerDirsListener will only be triggered for the directories that are associated with the storage.