### PR TITLE
[fix] Fix script to resolve target/cached_classpath.txt not found error

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -196,13 +196,13 @@ find_module_jar() {
     BUILT_JAR=$(find_module_jar_at ${BK_HOME}/${MODULE_PATH}/target ${MODULE_NAME})
     if [ -z "${BUILT_JAR}" ]; then
       echo "Couldn't find module '${MODULE_NAME}' jar." >&2
-      read -p "Do you want me to run \`mvn package -DskipTests\` for you ? (y|n) " answer
+      read -p "Do you want me to run \`mvn install -DskipTests\` for you ? (y|n) " answer
       case "${answer:0:1}" in
         y|Y )
           mkdir -p ${BK_HOME}/logs
           output="${BK_HOME}/logs/build.out"
           echo "see output at ${output} for the progress ..." >&2
-          mvn package -DskipTests &> ${output}
+          mvn install -DskipTests &> ${output}
           ;;
         * )
           exit 1


### PR DESCRIPTION

### Motivation

If we run bin/bookkeeper or bin/bkctl, if there's no jar package, it will build it. But there's a a command

`${MVN} -f "${BK_HOME}/${MODULE_PATH}/pom.xml" dependency:build-classpath -Dmdep.outputFile="target/cached_classpath.txt" &> ${output}` and raised the following error:

<img width="1632" alt="image" src="https://github.com/apache/bookkeeper/assets/10069311/dcbfb80c-7be5-40a1-b580-f0a325dca36e">


This needs the jars in classpath, so we need to run `mvn install` instead of `mvn package`.
