### PR TITLE
Add diskUnderWarnThreshold check event to prevent gcThread suspended forever

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -209,6 +209,15 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
             }
 
             @Override
+            public void diskUnderWarnThreshold(File disk) {
+                if (gcThread.isForceGCAllowWhenNoSpace()) {
+                    gcThread.disableForceGC();
+                } else {
+                    gcThread.resumeMajorGC();
+                }
+            }
+
+            @Override
             public void diskFull(File disk) {
                 if (gcThread.isForceGCAllowWhenNoSpace) {
                     gcThread.enableForceGC();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -1155,6 +1155,15 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             }
 
             @Override
+            public void diskUnderWarnThreshold(File disk) {
+                if (gcThread.isForceGCAllowWhenNoSpace()) {
+                    gcThread.disableForceGC();
+                } else {
+                    gcThread.resumeMajorGC();
+                }
+            }
+
+            @Override
             public void diskFull(File disk) {
                 if (gcThread.isForceGCAllowWhenNoSpace()) {
                     gcThread.enableForceGC();


### PR DESCRIPTION
### Motivation
This  code snippet  implements disk check event trigger if disk usage is above warnThreshold, either marjor is suspend or forcegc is enabled. 

There exists a case that if usgae descends to warn threshold, the gc thread is suspend forever.  until it goes to full and becomes writable again.
```
@Override
            public void diskAlmostFull(File disk) {
                if (gcThread.isForceGCAllowWhenNoSpace) {
                    gcThread.enableForceGC();
                } else {
                    gcThread.suspendMajorGC();
                }
            }
```

### Changes

Add diskUnderWarnThreshold check event to prevent gcThread  supended forever


