### PR TITLE
PerChannelBookieClient Enhancement: Self-Recovery Support in Corrupte…

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1043,6 +1043,9 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         if (timedOutOperations > 0) {
             LOG.info("Timed-out {} operations to channel {} for {}",
                      timedOutOperations, channel, bookieId);
+            // In scenarios with message tampering, communication timeout can lead to an unrecoverable state.
+            this.disconnect();
+            this.connect();
         }
     }
 


### PR DESCRIPTION
### Motivation
In the context of popular protocols like LengthBasedFrame, which typically determine total message length based on the first 0-4 bytes (for example, if the initial bytes are 00000014, the message length is 1*16+4 = 20), message tampering can cause serious issues. Specifically, any modification to the higher order bytes can lead to miscalculation of message length and leave the communication end waiting indefinitely without any ability to self-recover.

In summary, in scenarios with message tampering, communication timeout can lead to an unrecoverable link.
I think we can rebuild the client when timeout.

### Changes
rebuild the **PerChannelBookieClient** when timeout.