### PR TITLE
Fix headerBuffer not released in `DefaultEntryLogger.scanEntryLog`

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1027,6 +1027,7 @@ public class DefaultEntryLogger implements EntryLogger {
                 pos += entrySize;
             }
         } finally {
+            ReferenceCountUtil.release(headerBuffer);
             ReferenceCountUtil.release(data);
         }
     }


### PR DESCRIPTION
it should be released