### PR TITLE
fix latest_release to 4.16.2

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -7,7 +7,7 @@ const baseUrl = process.env.BASE_URL || "/"
 const deployUrl = process.env.DEPLOY_URL || "https://bookkeeper.apache.org";
 const variables = {
   /** They are used in .md files*/
-  latest_release: "4.16.1",
+  latest_release: "4.16.2",
   stable_release: "4.14.7",
   github_repo: "https://github.com/apache/bookkeeper",
   github_master: "https://github.com/apache/bookkeeper/tree/master",


### PR DESCRIPTION
### Motivation

The PR #4002 generated the website doc of 4.16.2, but missed updating the `latest_release` variable, and the official document still shows 4.16.1

https://bookkeeper.apache.org/releases

![image](https://github.com/apache/bookkeeper/assets/35599757/eff75d2e-0480-4646-890e-a8d9b127fbbb)
