### PR TITLE
Added a sync function to run flush without commit  #4033

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/AppendOnlyStreamWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/AppendOnlyStreamWriter.java
@@ -68,6 +68,20 @@ public class AppendOnlyStreamWriter implements Closeable {
         }
     }
 
+    public void sync(boolean isForced) throws IOException {
+      if (isForced) {
+        force(false);
+      } else {
+        try {
+          FutureUtils.result(logWriter.flush());
+        } catch (IOException ioe) {
+          throw ioe;
+        } catch (Exception ex) {
+          throw new UnexpectedException("unexpected exception in AppendOnlyStreamWriter.force", ex);
+        }
+      }
+    }
+
     public long position() {
         synchronized (syncPos) {
             return syncPos[0];


### PR DESCRIPTION
Descriptions of the changes in this PR:

Added a sync method for AppendOnlyWriter

### Motivation

(Explain: why you're making that change, what is the problem you're trying to solve)

### Changes

The method has a parameter isforced. If true, the sync just works as force. If false, the sync method just invoke a flush method.

Master Issue: #<master-issue-number>

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
