### PR TITLE
Optimize shell log print

### DIFF
--- a/conf/log4j2.shell.xml
+++ b/conf/log4j2.shell.xml
@@ -21,23 +21,38 @@
 -->
 <Configuration status="warn" monitorInterval="10">
     <Properties>
-        <Property name="bookkeeper.log.root.level">INFO</Property>
-        <Property name="bookkeeper.log.root.appender">CONSOLE</Property>
+        <Property name="bookkeeper.shell.log.dir">.</Property>
+        <Property name="bookkeeper.shell.log.file">bookkeeper-shell.log</Property>
+        <Property name="bookkeeper.shell.root.level">INFO</Property>
+        <Property name="bookkeeper.shell.root.appender">ROLLINGFILE</Property>
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %-5p %m%n"/>
         </Console>
+        <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}" filePattern="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}%d{.yyyy-MM-dd}">
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy modulate="true"/>
+            </Policies>
+            <DefaultRolloverStrategy max="100"/>
+        </RollingFile>
     </Appenders>
     <Loggers>
-        <Root level="${sys:bookkeeper.log.root.level}">
-            <AppenderRef ref="${sys:bookkeeper.log.root.appender}"/>
+        <Root level="${sys:bookkeeper.shell.root.level}">
+            <AppenderRef ref="${sys:bookkeeper.shell.root.appender}"/>
         </Root>
-        <Logger name="org.apache.zookeeper" level="INFO"/>
-        <Logger name="org.apache.bookkeeper.bookie.BookieShell" level="INFO"/>
-        <Logger name="org.apache.bookkeeper.bookie.InterleavedStorageRegenerateIndexOp" level="INFO"/>
-        <Logger name="org.apache.bookkeeper.client.BookKeeperAdmin" level="INFO"/>
-        <Logger name="org.apache.bookkeeper.tools.cli.commands.bookies.InstanceIdCommand" level="INFO"/>
-        <Logger name="org.apache.bookkeeper" level="INFO"/>
+        <Logger name="org.apache.bookkeeper.bookie.BookieShell" level="INFO">
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+        <Logger name="org.apache.bookkeeper.bookie.InterleavedStorageRegenerateIndexOp" level="INFO">
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+        <Logger name="org.apache.bookkeeper.client.BookKeeperAdmin" level="INFO">
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
+        <Logger name="org.apache.bookkeeper.tools.cli.commands" level="INFO">
+            <AppenderRef ref="CONSOLE"/>
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Optimize shell log print.


When we execute the bookkeeper shell , e.g., `bin/bookkeeper shell listbookies -a`, it will print a lot of redundant logs. And the key infomation is hard to find:
<img width="1146" alt="image" src="https://github.com/apache/bookkeeper/assets/10233437/fe97c299-900b-4f71-babf-444000f60432">



### Changes

Changing the `log4j2.shell.xml` to only print the key infomation, other logs will be printed to the `bookkeeper-shell.log` file

After changing:
<img width="764" alt="image" src="https://github.com/apache/bookkeeper/assets/10233437/62f0acc9-15dd-4745-b43b-72cba97ccd8c">


