### PR TITLE
Fix NoSuchElementException when rereplicate empty ledgers

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -293,7 +293,8 @@ public class LedgerFragmentReplicator {
             assert false;
         }
 
-        long numberOfEntriesToReplicate = (lastEntryId - firstEntryId) + 1;
+        long numberOfEntriesToReplicate = firstEntryId == INVALID_ENTRY_ID && lastEntryId == INVALID_ENTRY_ID ? 0 :
+                (lastEntryId - firstEntryId) + 1;
         long splitsWithFullEntries = numberOfEntriesToReplicate
                 / rereplicationEntryBatchSize;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -293,8 +293,7 @@ public class LedgerFragmentReplicator {
             assert false;
         }
 
-        long numberOfEntriesToReplicate = firstEntryId == INVALID_ENTRY_ID && lastEntryId == INVALID_ENTRY_ID ? 0 :
-                (lastEntryId - firstEntryId) + 1;
+        long numberOfEntriesToReplicate = firstEntryId == INVALID_ENTRY_ID ? 0 : (lastEntryId - firstEntryId) + 1;
         long splitsWithFullEntries = numberOfEntriesToReplicate
                 / rereplicationEntryBatchSize;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestLedgerFragmentReplication.java
@@ -263,6 +263,8 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
         testSplitIntoSubFragments(22, 103, 11, 8, lh);
         testSplitIntoSubFragments(49, 51, 1, 3, lh);
         testSplitIntoSubFragments(11, 101, 3, 31, lh);
+        testSplitIntoSubFragments(0, -1, 1, 1, lh);
+        testSplitIntoSubFragments(0, -1, 10, 1, lh);
     }
 
     /**
@@ -272,17 +274,7 @@ public class TestLedgerFragmentReplication extends BookKeeperClusterTestCase {
             final long oriFragmentLastEntry, long entriesPerSubFragment,
             long expectedSubFragments, LedgerHandle lh) {
         LedgerFragment fr = new LedgerFragment(lh, oriFragmentFirstEntry,
-                oriFragmentLastEntry, Sets.newHashSet(0)) {
-            @Override
-            public long getLastStoredEntryId() {
-                return oriFragmentLastEntry;
-            }
-
-            @Override
-            public long getFirstStoredEntryId() {
-                return oriFragmentFirstEntry;
-            }
-        };
+                oriFragmentLastEntry, Sets.newHashSet(0));
         Set<LedgerFragment> subFragments = LedgerFragmentReplicator
                 .splitIntoSubFragments(lh, fr, entriesPerSubFragment);
         assertEquals(expectedSubFragments, subFragments.size());


### PR DESCRIPTION
### Motivation
Master issue: #4036 

### Changes
Set the `numberOfEntriesToReplicate` to 0 when ledger is empty
