### PR TITLE
Make compatible between DefaultEntryLogger and DirectEntryLogger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -69,6 +69,7 @@ import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.LedgerDirUtil;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap.BiConsumerLong;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -575,8 +576,8 @@ public class DefaultEntryLogger implements EntryLogger {
         if (currentIds.isEmpty()) {
             return -1;
         }
-        Collections.sort(currentIds);
-        return currentIds.get(currentIds.size() - 1);
+        Pair<Integer, Integer> largestGap = LedgerDirUtil.findLargestGap(currentIds);
+        return largestGap.getLeft() - 1;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -24,6 +24,7 @@ package org.apache.bookkeeper.bookie;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.bookie.TransactionalEntryLogCompactor.COMPACTING_SUFFIX;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -202,7 +203,8 @@ class EntryLoggerAllocator {
     /**
      * writes the given id to the "lastId" file in the given directory.
      */
-    private void setLastLogId(File dir, long logId) throws IOException {
+    @VisibleForTesting
+    void setLastLogId(File dir, long logId) throws IOException {
         FileOutputStream fos;
         fos = new FileOutputStream(new File(dir, "lastId"));
         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos, UTF_8));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -58,6 +58,7 @@ import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.common.util.nativeio.NativeIO;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.util.LedgerDirUtil;
 
 /**
  * DirectEntryLogger.
@@ -365,7 +366,7 @@ public class DirectEntryLogger implements EntryLogger {
 
     @Override
     public Collection<Long> getFlushedLogIds() {
-        return EntryLogIdsImpl.logIdsInDirectory(ledgerDir).stream()
+        return LedgerDirUtil.logIdsInDirectory(ledgerDir).stream()
             .filter(logId -> !unflushedLogs.contains(logId))
             .map(i -> Long.valueOf(i))
             .collect(Collectors.toList());
@@ -492,7 +493,7 @@ public class DirectEntryLogger implements EntryLogger {
                         }
                     }
 
-                    Matcher m = EntryLogIdsImpl.COMPACTED_FILE_PATTERN.matcher(f.getName());
+                    Matcher m = LedgerDirUtil.COMPACTED_FILE_PATTERN.matcher(f.getName());
                     if (m.matches()) {
                         int dstLogId = Integer.parseUnsignedInt(m.group(1), 16);
                         int srcLogId = Integer.parseUnsignedInt(m.group(2), 16);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/EntryLogIdsImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/EntryLogIdsImpl.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.bookie.storage.directentrylogger;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
@@ -1,0 +1,68 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.util;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LedgerDirUtil {
+
+    public static final Pattern FILE_PATTERN = Pattern.compile("^([0-9a-fA-F]+)\\.log$");
+    public static final Pattern COMPACTED_FILE_PATTERN =
+            Pattern.compile("^([0-9a-fA-F]+)\\.log\\.([0-9a-fA-F]+)\\.compacted$");
+
+    public static List<Integer> logIdsInDirectory(File directory) {
+        List<Integer> ids = new ArrayList<>();
+        if (directory.exists() && directory.isDirectory()) {
+            File[] files = directory.listFiles();
+            if (files != null && files.length > 0) {
+                for (File f : files) {
+                    Matcher m = FILE_PATTERN.matcher(f.getName());
+                    if (m.matches()) {
+                        int logId = Integer.parseUnsignedInt(m.group(1), 16);
+                        ids.add(logId);
+                    }
+                }
+            }
+        }
+        return ids;
+    }
+
+    public static List<Integer> compactedLogIdsInDirectory(File directory) {
+        List<Integer> ids = new ArrayList<>();
+        if (directory.exists() && directory.isDirectory()) {
+            File[] files = directory.listFiles();
+            if (files != null && files.length > 0) {
+                for (File f : files) {
+                    Matcher m = COMPACTED_FILE_PATTERN.matcher(f.getName());
+                    if (m.matches()) {
+                        int logId = Integer.parseUnsignedInt(m.group(1), 16);
+                        ids.add(logId);
+                    }
+                }
+            }
+        }
+        return ids;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
@@ -79,9 +79,9 @@ public class LedgerDirUtil {
         if (currentIds.isEmpty()) {
             return Pair.of(0, Integer.MAX_VALUE);
         }
-        
+
         Collections.sort(currentIds);
-        
+
         int nextIdCandidate = 0;
         int maxIdCandidate = currentIds.get(0);
         int maxGap = maxIdCandidate - nextIdCandidate;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LedgerDirUtil.java
@@ -20,11 +20,14 @@
  */
 package org.apache.bookkeeper.util;
 
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class LedgerDirUtil {
 
@@ -64,5 +67,38 @@ public class LedgerDirUtil {
             }
         }
         return ids;
+    }
+
+    /**
+     * O(nlogn) algorithm to find largest contiguous gap between
+     * integers in a passed list. n should be relatively small.
+     * Entry logs should be about 1GB in size, so even if the node
+     * stores a PB, there should be only 1000000 entry logs.
+     */
+    public static Pair<Integer, Integer> findLargestGap(List<Integer> currentIds) {
+        if (currentIds.isEmpty()) {
+            return Pair.of(0, Integer.MAX_VALUE);
+        }
+        
+        Collections.sort(currentIds);
+        
+        int nextIdCandidate = 0;
+        int maxIdCandidate = currentIds.get(0);
+        int maxGap = maxIdCandidate - nextIdCandidate;
+        for (int i = 0; i < currentIds.size(); i++) {
+            int gapStart = currentIds.get(i) + 1;
+            int j = i + 1;
+            int gapEnd = Integer.MAX_VALUE;
+            if (j < currentIds.size()) {
+                gapEnd = currentIds.get(j);
+            }
+            int gapSize = gapEnd - gapStart;
+            if (gapSize > maxGap) {
+                maxGap = gapSize;
+                nextIdCandidate = gapStart;
+                maxIdCandidate = gapEnd;
+            }
+        }
+        return Pair.of(nextIdCandidate, maxIdCandidate);
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -525,6 +525,46 @@ public class CreateNewLogTest {
                 el.getPreviousAllocatedEntryLogId());
     }
 
+    @Test
+    public void testLastIdCompatibleBetweenDefaultAndDirectEntryLogger() throws Exception {
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+
+        // Creating a new configuration with a number of
+        // ledger directories.
+        conf.setLedgerDirNames(ledgerDirs);
+        conf.setEntryLogFilePreAllocationEnabled(false);
+        LedgerDirsManager ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
+
+        DefaultEntryLogger el = new DefaultEntryLogger(conf, ledgerDirsManager);
+        EntryLogManagerBase entryLogManagerBase = (EntryLogManagerBase) el.getEntryLogManager();
+        for (int i = 0; i < 10; i++) {
+            entryLogManagerBase.createNewLog(i);
+        }
+
+        Assert.assertEquals(9, el.getPreviousAllocatedEntryLogId());
+
+        //Mock half ledgerDirs lastId is 3.
+        for (int i = 0; i < ledgerDirs.length / 2; i++) {
+            File dir = ledgerDirsManager.pickRandomWritableDir();
+            LOG.info("Picked this directory: {}", dir);
+            el.getEntryLoggerAllocator().setLastLogId(dir, 3);
+        }
+
+        el = new DefaultEntryLogger(conf, ledgerDirsManager);
+        Assert.assertEquals(9, el.getPreviousAllocatedEntryLogId());
+    
+        //Mock all ledgerDirs lastId is 3.
+        for (int i = 0; i < ledgerDirs.length / 2; i++) {
+            File dir = ledgerDirsManager.pickRandomWritableDir();
+            LOG.info("Picked this directory: {}", dir);
+            el.getEntryLoggerAllocator().setLastLogId(dir, 3);
+        }
+
+        el = new DefaultEntryLogger(conf, ledgerDirsManager);
+        Assert.assertEquals(9, el.getPreviousAllocatedEntryLogId());
+    }
+
     /*
      * In this testcase entrylogs for ledgers are tried to create concurrently.
      */

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CreateNewLogTest.java
@@ -545,18 +545,18 @@ public class CreateNewLogTest {
         Assert.assertEquals(9, el.getPreviousAllocatedEntryLogId());
 
         //Mock half ledgerDirs lastId is 3.
-        for (int i = 0; i < ledgerDirs.length / 2; i++) {
-            File dir = ledgerDirsManager.pickRandomWritableDir();
+        for (int i = 0; i < ledgerDirsManager.getAllLedgerDirs().size() / 2; i++) {
+            File dir = ledgerDirsManager.getAllLedgerDirs().get(i);
             LOG.info("Picked this directory: {}", dir);
             el.getEntryLoggerAllocator().setLastLogId(dir, 3);
         }
 
         el = new DefaultEntryLogger(conf, ledgerDirsManager);
         Assert.assertEquals(9, el.getPreviousAllocatedEntryLogId());
-    
+
         //Mock all ledgerDirs lastId is 3.
-        for (int i = 0; i < ledgerDirs.length / 2; i++) {
-            File dir = ledgerDirsManager.pickRandomWritableDir();
+        for (int i = 0; i < ledgerDirsManager.getAllLedgerDirs().size(); i++) {
+            File dir = ledgerDirsManager.getAllLedgerDirs().get(i);
             LOG.info("Picked this directory: {}", dir);
             el.getEntryLoggerAllocator().setLastLogId(dir, 3);
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestEntryLogIds.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestEntryLogIds.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.bookie.storage.EntryLogIds;
 import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.test.TmpDirs;
+import org.apache.bookkeeper.util.LedgerDirUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Test;
@@ -259,16 +260,16 @@ public class TestEntryLogIds {
 
     @Test
     public void testGapSelection() throws Exception {
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList()), Pair.of(0, Integer.MAX_VALUE));
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList(0)),
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList()), Pair.of(0, Integer.MAX_VALUE));
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList(0)),
             Pair.of(1, Integer.MAX_VALUE));
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList(1, 2, 3, 4, 5, 6)),
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList(1, 2, 3, 4, 5, 6)),
             Pair.of(7, Integer.MAX_VALUE));
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE)),
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE)),
             Pair.of(0, Integer.MAX_VALUE));
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE / 2)),
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE / 2)),
             Pair.of(0, Integer.MAX_VALUE / 2));
-        assertEquals(EntryLogIdsImpl.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE / 2 - 1)),
+        assertEquals(LedgerDirUtil.findLargestGap(Lists.newArrayList(Integer.MAX_VALUE / 2 - 1)),
             Pair.of(Integer.MAX_VALUE / 2, Integer.MAX_VALUE));
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fixes #4040 

Upgrade guide:
If the user already uses the DirectEntryLogger in production, can not disable DirectEntryLogger directly. 

There are two ways:
1. Upgrade to the version with this PR, and disable DirectEntryLogger. Then restart, and the data won't be lost.
2. If you don't want to upgrade to the bookie version, you should stop the bookie first, then find the entry log which has the biggest log id.  Modify the `lastLogId` file content using the biggest log id. (Not recommend)
