### PR TITLE
fix AutoCloseableLifecycleComponent close exception log

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AbstractLifecycleComponent.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AbstractLifecycleComponent.java
@@ -122,7 +122,7 @@ public abstract class AbstractLifecycleComponent<ConfT extends ComponentConfigur
         try {
             doClose();
         } catch (IOException e) {
-            log.warn("failed to close {}", getClass().getName(), e);
+            log.warn("failed to close {}", componentName, e);
         }
         listeners.forEach(LifecycleListener::afterClose);
     }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AutoCloseableLifecycleComponent.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/AutoCloseableLifecycleComponent.java
@@ -100,7 +100,7 @@ public class AutoCloseableLifecycleComponent implements LifecycleComponent {
         try {
             closeable.close();
         } catch (Exception e) {
-            LOG.warn("failed to close {}", getClass().getName(), e);
+            LOG.warn("failed to close {}", componentName, e);
         }
         listeners.forEach(LifecycleListener::afterClose);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
@@ -295,7 +295,7 @@ public class EmbeddedServer {
                 StatsProviderService statsProviderService = new StatsProviderService(conf);
                 statsProvider = statsProviderService.getStatsProvider();
                 serverBuilder.addComponent(statsProviderService);
-                log.info("Load lifecycle component : {}", StatsProviderService.class.getName());
+                log.info("Load lifecycle component : {}", statsProviderService.getName());
             }
 
             StatsLogger rootStatsLogger = statsProvider.getStatsLogger("");
@@ -431,7 +431,7 @@ public class EmbeddedServer {
                     new BookieService(conf, bookie, rootStatsLogger, allocatorWithOomHandler, uncleanShutdownDetection);
 
             serverBuilder.addComponent(bookieService);
-            log.info("Load lifecycle component : {}", BookieService.class.getName());
+            log.info("Load lifecycle component : {}", bookieService.getName());
 
             if (conf.getServerConf().isLocalScrubEnabled()) {
                 serverBuilder.addComponent(
@@ -446,7 +446,7 @@ public class EmbeddedServer {
                 autoRecoveryService = new AutoRecoveryService(conf, rootStatsLogger.scope(REPLICATION_SCOPE));
 
                 serverBuilder.addComponent(autoRecoveryService);
-                log.info("Load lifecycle component : {}", AutoRecoveryService.class.getName());
+                log.info("Load lifecycle component : {}", autoRecoveryService.getName());
             }
 
             // 7. build data integrity check service
@@ -456,7 +456,7 @@ public class EmbeddedServer {
                 dataIntegrityService =
                         new DataIntegrityService(conf, rootStatsLogger.scope(REPLICATION_SCOPE), integCheck);
                 serverBuilder.addComponent(dataIntegrityService);
-                log.info("Load lifecycle component : {}", DataIntegrityService.class.getName());
+                log.info("Load lifecycle component : {}", dataIntegrityService.getName());
             }
 
             // 8. build http service
@@ -470,7 +470,7 @@ public class EmbeddedServer {
                         .build();
                 httpService = new HttpService(provider, conf, rootStatsLogger);
                 serverBuilder.addComponent(httpService);
-                log.info("Load lifecycle component : {}", HttpService.class.getName());
+                log.info("Load lifecycle component : {}", httpService.getName());
             }
 
             // 9. build extra services
@@ -483,7 +483,7 @@ public class EmbeddedServer {
                             rootStatsLogger);
                     for (ServerLifecycleComponent component : components) {
                         serverBuilder.addComponent(component);
-                        log.info("Load lifecycle component : {}", component.getClass().getName());
+                        log.info("Load lifecycle component : {}", component.getName());
                     }
                 } catch (Exception e) {
                     if (conf.getServerConf().getIgnoreExtraServerComponentsStartupFailures()) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

If closed with exception, the log will always be `failed to close AutoCloseableLifecycleComponent`.  It will be better to print the `componentName` instead of the class name.

### Changes

Print the `componentName` instead of `AutoCloseableLifecycleComponent` class name if closed with exception
