### PR TITLE
Disable annoying logs when segments is empty

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/ReadAheadEntryReader.java
@@ -1014,6 +1014,9 @@ class ReadAheadEntryReader implements
         if (!started.get()) {
             return;
         }
+        if (segments == null || segments.isEmpty()) {
+            return;
+        }
         logger.info("segments is updated with {}", segments);
         processLogSegments(segments);
     }


### PR DESCRIPTION
### Motivation

I saw some logs print repeatedly.

```
2023-08-12T03:52:59,027+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,065+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,129+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,175+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,208+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,225+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,278+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,337+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,340+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,412+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,433+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,646+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,871+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,894+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,942+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:52:59,976+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:53:00,012+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:53:00,070+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:53:00,237+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:53:00,270+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
2023-08-12T03:53:00,287+0000 [main-EventThread] INFO  org.apache.distributedlog.ReadAheadEntryReader - segments is updated with []
```

### Changes

Return directly when segments are empty.
