### PR TITLE
Fix duplicated call zkGetLogSegmentNames in getLogSegmentNames

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogSegmentMetadataStore.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/ZKLogSegmentMetadataStore.java
@@ -427,7 +427,7 @@ public class ZKLogSegmentMetadataStore implements LogSegmentMetadataStore, Watch
         if (null != listener) {
             getLogSegmentNamesResult.whenComplete(new ReadLogSegmentsTask(logSegmentsPath, this));
         }
-        return zkGetLogSegmentNames(logSegmentsPath, zkWatcher);
+        return getLogSegmentNamesResult;
     }
 
     @Override


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix duplicated call `zkGetLogSegmentNames` in `getLogSegmentNames`.

We have called `zkGetLogSegmentNames` at line425 and got the result, so there is no need call `zkGetLogSegmentNames` again at line430.

### Changes

Remove duplicated `zkGetLogSegmentNames` at line430.
