### PR TITLE
fix the stats/bookkeeper-stats-providers hype-link

### DIFF
--- a/site3/website/docs/getting-started/installation.md
+++ b/site3/website/docs/getting-started/installation.md
@@ -66,5 +66,5 @@ The BookKeeper project contains several subfolders that you should be aware of:
 |:----------------------------------------------------------------------------------------------|:----------------------------------------------------------|
 | [`bookkeeper-server`]({{ site.github_repo }}/tree/master/bookkeeper-server)                   | The BookKeeper server and client                          |
 | [`bookkeeper-benchmark`]({{ site.github_repo }}/tree/master/bookkeeper-benchmark)             | A benchmarking suite for measuring BookKeeper performance |
-| [`bookkeeper-stats`]({{ site.github_repo }}/tree/master/bookkeeper-stats)                     | A BookKeeper stats library                                |
-| [`bookkeeper-stats-providers`]({{ site.github_repo }}/tree/master/bookkeeper-stats-providers) | BookKeeper stats providers                                |
+| [`bookkeeper-stats`]({{ site.github_repo }}/tree/master/stats)                     | A BookKeeper stats library                                           |
+| [`bookkeeper-stats-providers`]({{ site.github_repo }}/tree/master/stats/bookkeeper-stats-providers) | BookKeeper stats providers                          |


### PR DESCRIPTION
fix the stats/bookkeeper-stats-providers hype-link

Descriptions of the changes in this PR:
https://bookkeeper.apache.org/docs/getting-started/installation/#package-directory
[bookkeeper-stats](https://github.com/apache/bookkeeper/tree/master/bookkeeper-stats)
[bookkeeper-stats-providers](https://github.com/apache/bookkeeper/tree/master/bookkeeper-stats-providers)

- File Not Found
![image](https://github.com/apache/bookkeeper/assets/18533252/01f2478a-cb43-4f16-b9e4-e2e976dc0dff)
### Motivation
fix
