### PR TITLE
Add explanatory messages to the asserts

### DIFF
--- a/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/impl/container/TestStorageContainerInfo.java
+++ b/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/impl/container/TestStorageContainerInfo.java
@@ -42,10 +42,10 @@ public class TestStorageContainerInfo {
             revision,
             endpoint,
             Lists.newArrayList(endpoint));
-        assertEquals(groupId, sc.getGroupId(), "Group ID mismatch");
-        assertEquals(revision, sc.getRevision(), "Revision mismatch");
-        assertEquals(endpoint, sc.getWriteEndpoint(), "Write Endpoint mismatch");
-        assertEquals(Lists.newArrayList(endpoint), sc.getReadEndpoints(), "Read Endpoint mismatch");
+        assertEquals("Group ID mismatch", groupId, sc.getGroupId());
+        assertEquals("Revision mismatch", revision, sc.getRevision());
+        assertEquals("Write Endpoint mismatch", endpoint, sc.getWriteEndpoint());
+        assertEquals("Read Endpoint mismatch", Lists.newArrayList(endpoint), sc.getReadEndpoints());
     }
 
 }

--- a/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/impl/container/TestStorageContainerInfo.java
+++ b/stream/clients/java/base/src/test/java/org/apache/bookkeeper/clients/impl/container/TestStorageContainerInfo.java
@@ -42,10 +42,10 @@ public class TestStorageContainerInfo {
             revision,
             endpoint,
             Lists.newArrayList(endpoint));
-        assertEquals(groupId, sc.getGroupId());
-        assertEquals(revision, sc.getRevision());
-        assertEquals(endpoint, sc.getWriteEndpoint());
-        assertEquals(Lists.newArrayList(endpoint), sc.getReadEndpoints());
+        assertEquals(groupId, sc.getGroupId(), "Group ID mismatch");
+        assertEquals(revision, sc.getRevision(), "Revision mismatch");
+        assertEquals(endpoint, sc.getWriteEndpoint(), "Write Endpoint mismatch");
+        assertEquals(Lists.newArrayList(endpoint), sc.getReadEndpoints(), "Read Endpoint mismatch");
     }
 
 }


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice. This smell is known as _Assertion Roulette_, where a test method has multiple asserts without explanatory messages, which can sometimes make it difficult to identify which assert has failed. We would like to get your feedback on this particular test refactoring. Thanks in advance for your input.