### PR TITLE
[release] Force to use linux/amd64 to build release

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -48,7 +48,7 @@ else # boot2docker uid and gid
 fi
 
 docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
-FROM ${IMAGE_NAME}
+FROM --platform=linux/amd64 ${IMAGE_NAME}
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
   useradd -l -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
 ENV  HOME /home/${USER_NAME}

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM maven:3.9.0-eclipse-temurin-8
+FROM --platform=linux/amd64 maven:3.9.0-eclipse-temurin-8
 
 RUN apt-get update
 RUN apt-get install -y g++ cmake gnupg2 vim subversion


### PR DESCRIPTION
---


### Motivation

Because we have a Native IO that needs to be built from cpp code. The build platform will impact the target library. People are using different laptop to execute the release process with docker, we need to force the image to use linux/amd64 platform to ensure the .so lib build out the correct platform lib.
Since most of time we are using amd64 to run the bookie, making the dev docker image build from amd64.

### Changes

Update the dev Dockerfile to use the specified platform.
