### PR TITLE
Entry read support local node rack awareness

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRackawareEnsemblePlacementPolicy.java
@@ -1644,7 +1644,7 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
     }
 
     @Test
-    public void testReadRequestReorder() throws Exception {
+    public void testReadRequestReorderWithLocalNodeAware() throws Exception {
         BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
         BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
         BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
@@ -1678,18 +1678,177 @@ public class TestRackawareEnsemblePlacementPolicy extends TestCase {
         testEnsemble.add(addr2.toBookieId());
         testEnsemble.add(addr3.toBookieId());
         testEnsemble.add(addr4.toBookieId());
-        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3);
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 0, 1, 2);
+
+        DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
+        DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertNotEquals(reorderSet, origWriteSet);
+        assertEquals(reorderSet.get(0), origWriteSet.get(2));
+    }
+
+    @Test
+    public void testReadRequestReorderWithLocalNodeIgnore() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+
+        repp.uninitalize();
+
+        repp = new RackawareEnsemblePlacementPolicy();
+        ClientConfiguration conf = (ClientConfiguration) this.conf.clone();
+        conf.setReorderReadSequenceEnabled(true);
+        conf.setIgnoreLocalNodeInPlacementPolicy(true);
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+            DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+
+        //update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        List<BookieId> testEnsemble = new ArrayList<>();
+        testEnsemble.add(addr1.toBookieId());
+        testEnsemble.add(addr2.toBookieId());
+        testEnsemble.add(addr3.toBookieId());
+        testEnsemble.add(addr4.toBookieId());
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 0, 1, 2);
+
+        DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
+        DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertTrue(reorderSet.equals(origWriteSet));
+    }
+
+    @Test
+    public void testReadRequestReorderWithLocalAndHealthInfo() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.6", 3181);
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/default-region/r2");
+
+        repp.uninitalize();
+        updateMyRack("/default-region/r2");
+
+        repp = new RackawareEnsemblePlacementPolicy();
+        ClientConfiguration conf = (ClientConfiguration) this.conf.clone();
+        conf.setReorderReadSequenceEnabled(true);
+        conf.setReorderThresholdPendingRequests(10);
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+            DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+
+        //update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        addrs.add(addr5.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        List<BookieId> testEnsemble = new ArrayList<>();
+        testEnsemble.add(addr1.toBookieId());
+        testEnsemble.add(addr2.toBookieId());
+        testEnsemble.add(addr3.toBookieId());
+        testEnsemble.add(addr4.toBookieId());
+        testEnsemble.add(addr5.toBookieId());
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 4, 0, 1);
 
         Map<BookieId, Long> bookiePendingMap = new HashMap<>();
-        bookiePendingMap.put(addr1.toBookieId(), 1L);
-        bookiePendingMap.put(addr2.toBookieId(), 7L);
-        bookiePendingMap.put(addr3.toBookieId(), 1L);
-        bookiePendingMap.put(addr4.toBookieId(), 5L);
+        bookiePendingMap.put(addr1.toBookieId(), 120L);
+        bookiePendingMap.put(addr2.toBookieId(), 70L);
+        bookiePendingMap.put(addr3.toBookieId(), 50L);
+        bookiePendingMap.put(addr4.toBookieId(), 209L);
+        bookiePendingMap.put(addr5.toBookieId(), 15L);
+
         DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
         DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
             testEnsemble, getBookiesHealthInfo(new HashMap<>(), bookiePendingMap), testWriteSet);
         assertNotEquals(reorderSet, origWriteSet);
+        assertEquals(reorderSet.get(0), origWriteSet.get(4));
+        assertEquals(reorderSet.get(1), origWriteSet.get(2));
+    }
+
+    @Test
+    public void testReadRequestReorderWithLocalAndHealthInfoV2() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.6", 3181);
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/default-region/r2");
+
+        repp.uninitalize();
+        updateMyRack("/default-region/r2");
+
+        repp = new RackawareEnsemblePlacementPolicy();
+        ClientConfiguration conf = (ClientConfiguration) this.conf.clone();
+        conf.setReorderReadSequenceEnabled(true);
+        conf.setReorderThresholdPendingRequests(10);
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+            DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+
+        //update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        addrs.add(addr5.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        List<BookieId> testEnsemble = new ArrayList<>();
+        testEnsemble.add(addr1.toBookieId());
+        testEnsemble.add(addr2.toBookieId());
+        testEnsemble.add(addr3.toBookieId());
+        testEnsemble.add(addr4.toBookieId());
+        testEnsemble.add(addr5.toBookieId());
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 4, 0, 1);
+
+        Map<BookieId, Long> bookiePendingMap = new HashMap<>();
+        bookiePendingMap.put(addr1.toBookieId(), 120L);
+        bookiePendingMap.put(addr2.toBookieId(), 70L);
+        bookiePendingMap.put(addr3.toBookieId(), 100L);
+        bookiePendingMap.put(addr4.toBookieId(), 209L);
+        bookiePendingMap.put(addr5.toBookieId(), 90L);
+
+        Map<BookieId, Long> bookieFailureHistory = new HashMap<>();
+        bookieFailureHistory.put(addr1.toBookieId(), 1L);
+        bookieFailureHistory.put(addr2.toBookieId(), 0L);
+        bookieFailureHistory.put(addr3.toBookieId(), 20L);
+        bookieFailureHistory.put(addr4.toBookieId(), 12L);
+        bookieFailureHistory.put(addr5.toBookieId(), 15L);
+
+        DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
+        DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
+            testEnsemble, getBookiesHealthInfo(bookieFailureHistory, bookiePendingMap), testWriteSet);
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(reorderSet.get(0), origWriteSet.get(2));
+        assertEquals(reorderSet.get(1), origWriteSet.get(4));
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1880,4 +1880,98 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         assertEquals("region2", repp.address2Region.get(addr3.toBookieId()));
         assertEquals("region3", repp.address2Region.get(addr4.toBookieId()));
     }
+
+    @Test
+    public void testReadRequestReorderWithLocalNodeIgnore() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+
+        repp.uninitalize();
+
+        repp = new RegionAwareEnsemblePlacementPolicy();
+        ClientConfiguration conf = (ClientConfiguration) this.conf.clone();
+        conf.setReorderReadSequenceEnabled(true);
+        conf.setIgnoreLocalNodeInPlacementPolicy(true);
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+            DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+
+        //update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        List<BookieId> testEnsemble = new ArrayList<>();
+        testEnsemble.add(addr1.toBookieId());
+        testEnsemble.add(addr2.toBookieId());
+        testEnsemble.add(addr3.toBookieId());
+        testEnsemble.add(addr4.toBookieId());
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 0, 1, 2);
+
+        DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
+        DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertTrue(reorderSet.equals(origWriteSet));
+        DistributionSchedule.WriteSet reorderSet1 = repp.reorderReadLACSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertTrue(reorderSet1.equals(origWriteSet));
+    }
+
+    @Test
+    public void testReadRequestReorderWithLocalNodeAware() throws Exception {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.5", 3181);
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/default-region/r1");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/default-region/r2");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/default-region/r3");
+
+        repp.uninitalize();
+        updateMyRack("/default-region/r2");
+
+        repp = new RegionAwareEnsemblePlacementPolicy();
+        ClientConfiguration conf = (ClientConfiguration) this.conf.clone();
+        conf.setReorderReadSequenceEnabled(true);
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+            DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+
+        //update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        List<BookieId> testEnsemble = new ArrayList<>();
+        testEnsemble.add(addr1.toBookieId());
+        testEnsemble.add(addr2.toBookieId());
+        testEnsemble.add(addr3.toBookieId());
+        testEnsemble.add(addr4.toBookieId());
+        DistributionSchedule.WriteSet testWriteSet = writeSetFromValues(0, 1, 2, 3, 0, 1, 2);
+
+        DistributionSchedule.WriteSet origWriteSet = testWriteSet.copy();
+        DistributionSchedule.WriteSet reorderSet = repp.reorderReadSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertTrue(reorderSet.equals(origWriteSet));
+
+        DistributionSchedule.WriteSet reorderSet1 = repp.reorderReadLACSequence(
+            testEnsemble, getBookiesHealthInfo(), testWriteSet);
+        assertTrue(reorderSet1.equals(origWriteSet));
+    }
+
 }


### PR DESCRIPTION
### Motivation
- The entry write supports the local node Rack-Aware placement policy but does not support the local node Region-Aware placement policy
- The entry read supports the local node Region-Aware placement policy but does not support the local node Rack-Aware placement policy

In order to match the local node region/rack awareness both on entry write and read, we need to support the following feature
- Entry write supports local node region awareness placement policy
- Entry read supports local node rack awareness placement policy

### Modification
The PR aims to support entry read local node awareness placement policy.