### PR TITLE
Fix comment typo in StreamCluster

### DIFF
--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/cluster/StreamCluster.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/cluster/StreamCluster.java
@@ -284,7 +284,7 @@ public class StreamCluster
             // initialize the cluster
             initializeCluster();
 
-            // stop servers
+            // start servers
             startServers();
 
             // create default namespaces


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix comment typo in `StreamCluster`

### Changes

`// stop servers` -> `// start servers`
