### PR TITLE
Fix bugs in hash bucket algorithm implementation in collection classes

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -710,8 +710,14 @@ public class ConcurrentLongHashMap<V> {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) n & (max - 1);
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashSet.java
@@ -562,8 +562,14 @@ public class ConcurrentLongHashSet {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) (n & (max - 1));
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongHashMap.java
@@ -896,8 +896,14 @@ public class ConcurrentLongLongHashMap {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) (n & (max - 1)) << 1;
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -663,8 +663,14 @@ public class ConcurrentLongLongPairHashMap {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) (n & (max - 1)) << 2;
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongLongPairHashMap.java
@@ -311,6 +311,8 @@ public class ConcurrentLongLongPairHashMap {
     private static final class Section extends StampedLock {
         // Keys and values are stored interleaved in the table array
         private volatile long[] table;
+        // each item takes 4 elements of the table
+        private static final int ITEM_SIZE = 4;
 
         private volatile int capacity;
         private final int initCapacity;
@@ -328,7 +330,7 @@ public class ConcurrentLongLongPairHashMap {
                 float expandFactor, float shrinkFactor) {
             this.capacity = alignToPowerOfTwo(capacity);
             this.initCapacity = this.capacity;
-            this.table = new long[4 * this.capacity];
+            this.table = new long[ITEM_SIZE * this.capacity];
             this.size = 0;
             this.usedBuckets = 0;
             this.autoShrink = autoShrink;
@@ -344,15 +346,15 @@ public class ConcurrentLongLongPairHashMap {
         LongPair get(long key1, long key2, int keyHash) {
             long stamp = tryOptimisticRead();
             boolean acquiredLock = false;
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             try {
                 while (true) {
                     // First try optimistic locking
-                    long storedKey1 = table[bucket];
-                    long storedKey2 = table[bucket + 1];
-                    long storedValue1 = table[bucket + 2];
-                    long storedValue2 = table[bucket + 3];
+                    long storedKey1 = table[bucketIndex];
+                    long storedKey2 = table[bucketIndex + 1];
+                    long storedValue1 = table[bucketIndex + 2];
+                    long storedValue2 = table[bucketIndex + 3];
 
                     if (!acquiredLock && validate(stamp)) {
                         // The values we have read are consistent
@@ -368,11 +370,11 @@ public class ConcurrentLongLongPairHashMap {
                             stamp = readLock();
                             acquiredLock = true;
 
-                            bucket = signSafeMod(keyHash, capacity);
-                            storedKey1 = table[bucket];
-                            storedKey2 = table[bucket + 1];
-                            storedValue1 = table[bucket + 2];
-                            storedValue2 = table[bucket + 3];
+                            bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
+                            storedKey1 = table[bucketIndex];
+                            storedKey2 = table[bucketIndex + 1];
+                            storedValue1 = table[bucketIndex + 2];
+                            storedValue2 = table[bucketIndex + 3];
                         }
 
                         if (key1 == storedKey1 && key2 == storedKey2) {
@@ -383,7 +385,7 @@ public class ConcurrentLongLongPairHashMap {
                         }
                     }
 
-                    bucket = (bucket + 4) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
             } finally {
                 if (acquiredLock) {
@@ -394,21 +396,21 @@ public class ConcurrentLongLongPairHashMap {
 
         boolean put(long key1, long key2, long value1, long value2, int keyHash, boolean onlyIfAbsent) {
             long stamp = writeLock();
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             // Remember where we find the first available spot
             int firstDeletedKey = -1;
 
             try {
                 while (true) {
-                    long storedKey1 = table[bucket];
-                    long storedKey2 = table[bucket + 1];
+                    long storedKey1 = table[bucketIndex];
+                    long storedKey2 = table[bucketIndex + 1];
 
                     if (key1 == storedKey1 && key2 == storedKey2) {
                         if (!onlyIfAbsent) {
                             // Over written an old value for same key
-                            table[bucket + 2] = value1;
-                            table[bucket + 3] = value2;
+                            table[bucketIndex + 2] = value1;
+                            table[bucketIndex + 3] = value2;
                             return true;
                         } else {
                             return false;
@@ -417,25 +419,25 @@ public class ConcurrentLongLongPairHashMap {
                         // Found an empty bucket. This means the key is not in the map. If we've already seen a deleted
                         // key, we should write at that position
                         if (firstDeletedKey != -1) {
-                            bucket = firstDeletedKey;
+                            bucketIndex = firstDeletedKey;
                         } else {
                             ++usedBuckets;
                         }
 
-                        table[bucket] = key1;
-                        table[bucket + 1] = key2;
-                        table[bucket + 2] = value1;
-                        table[bucket + 3] = value2;
+                        table[bucketIndex] = key1;
+                        table[bucketIndex + 1] = key2;
+                        table[bucketIndex + 2] = value1;
+                        table[bucketIndex + 3] = value2;
                         ++size;
                         return true;
                     } else if (storedKey1 == DeletedKey) {
                         // The bucket contained a different deleted key
                         if (firstDeletedKey == -1) {
-                            firstDeletedKey = bucket;
+                            firstDeletedKey = bucketIndex;
                         }
                     }
 
-                    bucket = (bucket + 4) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
             } finally {
                 if (usedBuckets > resizeThresholdUp) {
@@ -454,19 +456,19 @@ public class ConcurrentLongLongPairHashMap {
 
         private boolean remove(long key1, long key2, long value1, long value2, int keyHash) {
             long stamp = writeLock();
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             try {
                 while (true) {
-                    long storedKey1 = table[bucket];
-                    long storedKey2 = table[bucket + 1];
-                    long storedValue1 = table[bucket + 2];
-                    long storedValue2 = table[bucket + 3];
+                    long storedKey1 = table[bucketIndex];
+                    long storedKey2 = table[bucketIndex + 1];
+                    long storedValue1 = table[bucketIndex + 2];
+                    long storedValue2 = table[bucketIndex + 3];
                     if (key1 == storedKey1 && key2 == storedKey2) {
                         if (value1 == ValueNotFound || (value1 == storedValue1 && value2 == storedValue2)) {
                             --size;
 
-                            cleanBucket(bucket);
+                            cleanBucketIndex(bucketIndex);
                             return true;
                         } else {
                             return false;
@@ -476,7 +478,7 @@ public class ConcurrentLongLongPairHashMap {
                         return false;
                     }
 
-                    bucket = (bucket + 4) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
 
             } finally {
@@ -501,32 +503,32 @@ public class ConcurrentLongLongPairHashMap {
             }
         }
 
-        private void cleanBucket(int bucket) {
-            int nextInArray = (bucket + 4) & (table.length - 1);
+        private void cleanBucketIndex(int bucketIndex) {
+            int nextInArray = (bucketIndex + ITEM_SIZE) & (table.length - 1);
             if (table[nextInArray] == EmptyKey) {
-                table[bucket] = EmptyKey;
-                table[bucket + 1] = EmptyKey;
-                table[bucket + 2] = ValueNotFound;
-                table[bucket + 3] = ValueNotFound;
+                table[bucketIndex] = EmptyKey;
+                table[bucketIndex + 1] = EmptyKey;
+                table[bucketIndex + 2] = ValueNotFound;
+                table[bucketIndex + 3] = ValueNotFound;
                 --usedBuckets;
 
                 // Cleanup all the buckets that were in `DeletedKey` state,
                 // so that we can reduce unnecessary expansions
-                bucket = (bucket - 4) & (table.length - 1);
-                while (table[bucket] == DeletedKey) {
-                    table[bucket] = EmptyKey;
-                    table[bucket + 1] = EmptyKey;
-                    table[bucket + 2] = ValueNotFound;
-                    table[bucket + 3] = ValueNotFound;
+                bucketIndex = (bucketIndex - ITEM_SIZE) & (table.length - 1);
+                while (table[bucketIndex] == DeletedKey) {
+                    table[bucketIndex] = EmptyKey;
+                    table[bucketIndex + 1] = EmptyKey;
+                    table[bucketIndex + 2] = ValueNotFound;
+                    table[bucketIndex + 3] = ValueNotFound;
                     --usedBuckets;
 
-                    bucket = (bucket - 4) & (table.length - 1);
+                    bucketIndex = (bucketIndex - ITEM_SIZE) & (table.length - 1);
                 }
             } else {
-                table[bucket] = DeletedKey;
-                table[bucket + 1] = DeletedKey;
-                table[bucket + 2] = ValueNotFound;
-                table[bucket + 3] = ValueNotFound;
+                table[bucketIndex] = DeletedKey;
+                table[bucketIndex + 1] = DeletedKey;
+                table[bucketIndex + 2] = ValueNotFound;
+                table[bucketIndex + 3] = ValueNotFound;
             }
         }
 
@@ -563,21 +565,21 @@ public class ConcurrentLongLongPairHashMap {
                 }
 
                 // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 4) {
-                    long storedKey1 = table[bucket];
-                    long storedKey2 = table[bucket + 1];
-                    long storedValue1 = table[bucket + 2];
-                    long storedValue2 = table[bucket + 3];
+                for (int bucketIndex = 0; bucketIndex < table.length; bucketIndex += ITEM_SIZE) {
+                    long storedKey1 = table[bucketIndex];
+                    long storedKey2 = table[bucketIndex + 1];
+                    long storedValue1 = table[bucketIndex + 2];
+                    long storedValue2 = table[bucketIndex + 3];
 
                     if (!acquiredReadLock && !validate(stamp)) {
                         // Fallback to acquiring read lock
                         stamp = readLock();
                         acquiredReadLock = true;
 
-                        storedKey1 = table[bucket];
-                        storedKey2 = table[bucket + 1];
-                        storedValue1 = table[bucket + 2];
-                        storedValue2 = table[bucket + 3];
+                        storedKey1 = table[bucketIndex];
+                        storedKey2 = table[bucketIndex + 1];
+                        storedValue1 = table[bucketIndex + 2];
+                        storedValue2 = table[bucketIndex + 3];
                     }
 
                     if (storedKey1 != DeletedKey && storedKey1 != EmptyKey) {
@@ -592,11 +594,11 @@ public class ConcurrentLongLongPairHashMap {
         }
 
         private void rehash(int newCapacity) {
-            long[] newTable = new long[4 * newCapacity];
+            long[] newTable = new long[ITEM_SIZE * newCapacity];
             Arrays.fill(newTable, EmptyKey);
 
             // Re-hash table
-            for (int i = 0; i < table.length; i += 4) {
+            for (int i = 0; i < table.length; i += ITEM_SIZE) {
                 long storedKey1 = table[i];
                 long storedKey2 = table[i + 1];
                 long storedValue1 = table[i + 2];
@@ -616,7 +618,7 @@ public class ConcurrentLongLongPairHashMap {
         }
 
         private void shrinkToInitCapacity() {
-            long[] newTable = new long[4 * initCapacity];
+            long[] newTable = new long[ITEM_SIZE * initCapacity];
             Arrays.fill(newTable, EmptyKey);
 
             table = newTable;
@@ -631,21 +633,21 @@ public class ConcurrentLongLongPairHashMap {
 
         private static void insertKeyValueNoLock(long[] table, int capacity, long key1, long key2, long value1,
                 long value2) {
-            int bucket = signSafeMod(hash(key1, key2), capacity);
+            int bucketIndex = signSafeMod(hash(key1, key2), capacity) * ITEM_SIZE;
 
             while (true) {
-                long storedKey1 = table[bucket];
+                long storedKey1 = table[bucketIndex];
 
                 if (storedKey1 == EmptyKey) {
                     // The bucket is empty, so we can use it
-                    table[bucket] = key1;
-                    table[bucket + 1] = key2;
-                    table[bucket + 2] = value1;
-                    table[bucket + 3] = value2;
+                    table[bucketIndex] = key1;
+                    table[bucketIndex + 1] = key2;
+                    table[bucketIndex + 2] = value1;
+                    table[bucketIndex + 3] = value2;
                     return;
                 }
 
-                bucket = (bucket + 4) & (table.length - 1);
+                bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -649,8 +649,14 @@ public class ConcurrentOpenHashMap<K, V> {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) (n & (max - 1)) << 1;
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashMap.java
@@ -280,6 +280,8 @@ public class ConcurrentOpenHashMap<K, V> {
     private static final class Section<K, V> extends StampedLock {
         // Keys and values are stored interleaved in the table array
         private volatile Object[] table;
+        // each item takes 2 elements of the table
+        public static final int ITEM_SIZE = 2;
 
         private volatile int capacity;
         private final int initCapacity;
@@ -297,7 +299,7 @@ public class ConcurrentOpenHashMap<K, V> {
                 float expandFactor, float shrinkFactor) {
             this.capacity = alignToPowerOfTwo(capacity);
             this.initCapacity = this.capacity;
-            this.table = new Object[2 * this.capacity];
+            this.table = new Object[ITEM_SIZE * this.capacity];
             this.size = 0;
             this.usedBuckets = 0;
             this.autoShrink = autoShrink;
@@ -312,13 +314,13 @@ public class ConcurrentOpenHashMap<K, V> {
         V get(K key, int keyHash) {
             long stamp = tryOptimisticRead();
             boolean acquiredLock = false;
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             try {
                 while (true) {
                     // First try optimistic locking
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
+                    K storedKey = (K) table[bucketIndex];
+                    V storedValue = (V) table[bucketIndex + 1];
 
                     if (!acquiredLock && validate(stamp)) {
                         // The values we have read are consistent
@@ -334,9 +336,9 @@ public class ConcurrentOpenHashMap<K, V> {
                             stamp = readLock();
                             acquiredLock = true;
 
-                            bucket = signSafeMod(keyHash, capacity);
-                            storedKey = (K) table[bucket];
-                            storedValue = (V) table[bucket + 1];
+                            bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
+                            storedKey = (K) table[bucketIndex];
+                            storedValue = (V) table[bucketIndex + 1];
                         }
 
                         if (key.equals(storedKey)) {
@@ -347,7 +349,7 @@ public class ConcurrentOpenHashMap<K, V> {
                         }
                     }
 
-                    bucket = (bucket + 2) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
             } finally {
                 if (acquiredLock) {
@@ -358,20 +360,20 @@ public class ConcurrentOpenHashMap<K, V> {
 
         V put(K key, V value, int keyHash, boolean onlyIfAbsent, Function<K, V> valueProvider) {
             long stamp = writeLock();
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             // Remember where we find the first available spot
             int firstDeletedKey = -1;
 
             try {
                 while (true) {
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
+                    K storedKey = (K) table[bucketIndex];
+                    V storedValue = (V) table[bucketIndex + 1];
 
                     if (key.equals(storedKey)) {
                         if (!onlyIfAbsent) {
                             // Over written an old value for same key
-                            table[bucket + 1] = value;
+                            table[bucketIndex + 1] = value;
                             return storedValue;
                         } else {
                             return storedValue;
@@ -380,7 +382,7 @@ public class ConcurrentOpenHashMap<K, V> {
                         // Found an empty bucket. This means the key is not in the map. If we've already seen a deleted
                         // key, we should write at that position
                         if (firstDeletedKey != -1) {
-                            bucket = firstDeletedKey;
+                            bucketIndex = firstDeletedKey;
                         } else {
                             ++usedBuckets;
                         }
@@ -389,18 +391,18 @@ public class ConcurrentOpenHashMap<K, V> {
                             value = valueProvider.apply(key);
                         }
 
-                        table[bucket] = key;
-                        table[bucket + 1] = value;
+                        table[bucketIndex] = key;
+                        table[bucketIndex + 1] = value;
                         ++size;
                         return valueProvider != null ? value : null;
                     } else if (storedKey == DeletedKey) {
                         // The bucket contained a different deleted key
                         if (firstDeletedKey == -1) {
-                            firstDeletedKey = bucket;
+                            firstDeletedKey = bucketIndex;
                         }
                     }
 
-                    bucket = (bucket + 2) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
             } finally {
                 if (usedBuckets > resizeThresholdUp) {
@@ -419,16 +421,16 @@ public class ConcurrentOpenHashMap<K, V> {
 
         private V remove(K key, Object value, int keyHash) {
             long stamp = writeLock();
-            int bucket = signSafeMod(keyHash, capacity);
+            int bucketIndex = signSafeMod(keyHash, capacity) * ITEM_SIZE;
 
             try {
                 while (true) {
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
+                    K storedKey = (K) table[bucketIndex];
+                    V storedValue = (V) table[bucketIndex + 1];
                     if (key.equals(storedKey)) {
                         if (value == null || value.equals(storedValue)) {
                             --size;
-                            cleanBucket(bucket);
+                            cleanBucketIndex(bucketIndex);
                             return storedValue;
                         } else {
                             return null;
@@ -438,7 +440,7 @@ public class ConcurrentOpenHashMap<K, V> {
                         return null;
                     }
 
-                    bucket = (bucket + 2) & (table.length - 1);
+                    bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
                 }
 
             } finally {
@@ -496,17 +498,17 @@ public class ConcurrentOpenHashMap<K, V> {
                 }
 
                 // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 2) {
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
+                for (int bucketIndex = 0; bucketIndex < table.length; bucketIndex += ITEM_SIZE) {
+                    K storedKey = (K) table[bucketIndex];
+                    V storedValue = (V) table[bucketIndex + 1];
 
                     if (!acquiredReadLock && !validate(stamp)) {
                         // Fallback to acquiring read lock
                         stamp = readLock();
                         acquiredReadLock = true;
 
-                        storedKey = (K) table[bucket];
-                        storedValue = (V) table[bucket + 1];
+                        storedKey = (K) table[bucketIndex];
+                        storedValue = (V) table[bucketIndex + 1];
                     }
 
                     if (storedKey != DeletedKey && storedKey != EmptyKey) {
@@ -526,16 +528,16 @@ public class ConcurrentOpenHashMap<K, V> {
             int removedCount = 0;
             try {
                 // Go through all the buckets for this section
-                for (int bucket = 0; size > 0 && bucket < table.length; bucket += 2) {
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
+                for (int bucketIndex = 0; size > 0 && bucketIndex < table.length; bucketIndex += ITEM_SIZE) {
+                    K storedKey = (K) table[bucketIndex];
+                    V storedValue = (V) table[bucketIndex + 1];
 
                     if (storedKey != DeletedKey && storedKey != EmptyKey) {
                         if (filter.test(storedKey, storedValue)) {
                             // Removing item
                             --size;
                             ++removedCount;
-                            cleanBucket(bucket);
+                            cleanBucketIndex(bucketIndex);
                         }
                     }
                 }
@@ -563,35 +565,35 @@ public class ConcurrentOpenHashMap<K, V> {
             }
         }
 
-        private void cleanBucket(int bucket) {
-            int nextInArray = (bucket + 2) & (table.length - 1);
+        private void cleanBucketIndex(int bucketIndex) {
+            int nextInArray = (bucketIndex + ITEM_SIZE) & (table.length - 1);
             if (table[nextInArray] == EmptyKey) {
-                table[bucket] = EmptyKey;
-                table[bucket + 1] = null;
+                table[bucketIndex] = EmptyKey;
+                table[bucketIndex + 1] = null;
                 --usedBuckets;
 
                 // Cleanup all the buckets that were in `DeletedKey` state,
                 // so that we can reduce unnecessary expansions
-                bucket = (bucket - 2) & (table.length - 1);
-                while (table[bucket] == DeletedKey) {
-                    table[bucket] = EmptyKey;
-                    table[bucket + 1] = null;
+                bucketIndex = (bucketIndex - ITEM_SIZE) & (table.length - 1);
+                while (table[bucketIndex] == DeletedKey) {
+                    table[bucketIndex] = EmptyKey;
+                    table[bucketIndex + 1] = null;
                     --usedBuckets;
 
-                    bucket = (bucket - 2) & (table.length - 1);
+                    bucketIndex = (bucketIndex - ITEM_SIZE) & (table.length - 1);
                 }
             } else {
-                table[bucket] = DeletedKey;
-                table[bucket + 1] = null;
+                table[bucketIndex] = DeletedKey;
+                table[bucketIndex + 1] = null;
             }
         }
 
         private void rehash(int newCapacity) {
             // Expand the hashmap
-            Object[] newTable = new Object[2 * newCapacity];
+            Object[] newTable = new Object[ITEM_SIZE * newCapacity];
 
             // Re-hash table
-            for (int i = 0; i < table.length; i += 2) {
+            for (int i = 0; i < table.length; i += ITEM_SIZE) {
                 K storedKey = (K) table[i];
                 V storedValue = (V) table[i + 1];
                 if (storedKey != EmptyKey && storedKey != DeletedKey) {
@@ -609,7 +611,7 @@ public class ConcurrentOpenHashMap<K, V> {
         }
 
         private void shrinkToInitCapacity() {
-            Object[] newTable = new Object[2 * initCapacity];
+            Object[] newTable = new Object[ITEM_SIZE * initCapacity];
 
             table = newTable;
             size = 0;
@@ -622,19 +624,19 @@ public class ConcurrentOpenHashMap<K, V> {
         }
 
         private static <K, V> void insertKeyValueNoLock(Object[] table, int capacity, K key, V value) {
-            int bucket = signSafeMod(hash(key), capacity);
+            int bucketIndex = signSafeMod(hash(key), capacity) * ITEM_SIZE;
 
             while (true) {
-                K storedKey = (K) table[bucket];
+                K storedKey = (K) table[bucketIndex];
 
                 if (storedKey == EmptyKey) {
                     // The bucket is empty, so we can use it
-                    table[bucket] = key;
-                    table[bucket + 1] = value;
+                    table[bucketIndex] = key;
+                    table[bucketIndex + 1] = value;
                     return;
                 }
 
-                bucket = (bucket + 2) & (table.length - 1);
+                bucketIndex = (bucketIndex + ITEM_SIZE) & (table.length - 1);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentOpenHashSet.java
@@ -555,8 +555,14 @@ public class ConcurrentOpenHashSet<V> {
         return hash;
     }
 
-    static final int signSafeMod(long n, int max) {
-        return (int) n & (max - 1);
+    static final int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
     }
 
     private static int alignToPowerOfTwo(int n) {


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

- Fix a bug in ConcurrentLongLongPairHashMap, ConcurrentLongPairSet and ConcurrentOpenHashMap where the hash bucket's storage index was incorrectly calculated.
  - the impact of the bug has been that the implementations have been rather unoptimal because of of frequent collisions in storing the item to the underlying array. Essentially the hash bucket algorithm hasn't been properly used.
- Fix a bug in `signSafeMod` function which is duplicated in all classes. The buggy implementation didn't return correct results for negative input values.

### Changes

- rename `bucket` to `bucketIndex` to indicate that it's the bucket index in the storage array that needs to be calculated.
- calculate bucketIndex by multiplying the hash bucket by the item size (4 or 2).
- fix the `signSafeMod` function which wasn't sign safe at all. Negative input values produced invalid results. Currently the logic is duplicated in all classes.

### Additional context

See Pulsar bugs https://github.com/apache/pulsar/issues/21106 and https://github.com/apache/pulsar/issues/21108 in similar classes that are duplicated in the Pulsar code base and the fix PR https://github.com/apache/pulsar/issues/21107.