### PR TITLE
Update the document of diskUsageWarnThreshold

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -638,17 +638,17 @@ gcEntryLogMetadataCacheEnabled=false
 # Default is 0.95f. i.e. 95% of disk can be used at most after which nothing will
 # be written to that partition. If all ledger dir partions are full, then bookie
 # will turn to readonly mode if 'readOnlyModeEnabled=true' is set, else it will
-# shutdown.
-# Valid values should be in between 0 and 1 (exclusive).
+# shutdown. Bookie will also suspend the minor and major compaction when usage threshold is exceed
+# if `isForceGCAllowWhenNoSpace` is disabled. When the usage becomes lower than the threshold, the major and minor
+# compaction will be resumed.
+# Valid values should be in between 0 and 1 (exclusive). The default value is 0.95.
 # diskUsageThreshold=0.95
 
-# The disk free space low water mark threshold.
-# Disk is considered full when usage threshold is exceeded.
-# Disk returns back to non-full state when usage is below low water mark threshold.
-# This prevents it from going back and forth between these states frequently
-# when concurrent writes and compaction are happening. This also prevent bookie from
-# switching frequently between read-only and read-writes states in the same cases.
-# diskUsageWarnThreshold=0.95
+# The disk free space warn threshold.
+# Disk is considered almost full when usage threshold is exceeded. Bookie will suspend the major
+# compaction when usage threshold is exceed if `isForceGCAllowWhenNoSpace` is disabled. When the usage becomes lower
+# than the threshold, the major compaction will be resumed. The default value is 0.90.
+# diskUsageWarnThreshold=0.90
 
 # Set the disk free space low water mark threshold. Disk is considered full when
 # usage threshold is exceeded. Disk returns back to non-full state when usage is
@@ -656,7 +656,10 @@ gcEntryLogMetadataCacheEnabled=false
 # between these states frequently when concurrent writes and compaction are
 # happening. This also prevent bookie from switching frequently between
 # read-only and read-writes states in the same cases.
-# diskUsageLwmThreshold=0.90
+# If the bookie already runs into read-only mode and the disk usage becomes lower than this threshold, the bookie
+# will change from read-only to read-write mode. At the same time, the major and minor compaction will be resumed
+# if `isForceGCAllowWhenNoSpace` is disabled. The default value is the same with `diskUsageThreshold`.
+# diskUsageLwmThreshold=0.95
 
 # Disk check interval in milli seconds, interval to check the ledger dirs usage.
 # Default is 10000


### PR DESCRIPTION
### Motivation

In `conf/bk_server.conf`, the document and default value of `diskUsageWarnThreshold` and `diskUsageLwmThreshold` is not synced with the code.


### Changes
- Update the document and default value of `diskUsageWarnThreshold` and `diskUsageLwmThreshold`