### PR TITLE
Return remote cookie  if any address verifies success

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
@@ -178,6 +178,7 @@ public class LegacyCookieValidation implements CookieValidation {
                 } else {
                     masterCookie.verify(rmCookie.getValue());
                 }
+                return rmCookie;
             } catch (BookieException.CookieNotFoundException e) {
                 continue;
             }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

If there are multi possible bookieIds,  we should return the `rmCookie` when any bookIds verifies successfully.

### Changes

Return remote cookie  if any address verifies success
