### PR TITLE
Close the RegistrationManager in the finally block in AuditorPlacementPolicyCheckTest.

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -463,7 +463,6 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             bookieAddresses.add(bookieAddress);
             regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
-        
 
         LedgerManagerFactory mFactory = driver.getLedgerManagerFactory();
         LedgerManager lm = mFactory.newLedgerManager();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -101,14 +101,13 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfBookies = 5;
         List<BookieId> bookieAddresses = new ArrayList<>();
         BookieSocketAddress bookieAddress;
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            // all the numOfBookies (5) are going to be in different racks
-            for (int i = 0; i < numOfBookies; i++) {
-                bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181);
-                StaticDNSResolver.addNodeToRack(bookieAddress.getHostName(), "/rack" + (i));
-                bookieAddresses.add(bookieAddress.toBookieId());
-                regManager.registerBookie(bookieAddress.toBookieId(), false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        // all the numOfBookies (5) are going to be in different racks
+        for (int i = 0; i < numOfBookies; i++) {
+            bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181);
+            StaticDNSResolver.addNodeToRack(bookieAddress.getHostName(), "/rack" + (i));
+            bookieAddresses.add(bookieAddress.toBookieId());
+            regManager.registerBookie(bookieAddress.toBookieId(), false, BookieServiceInfo.EMPTY);
         }
 
         LedgerManagerFactory mFactory = driver.getLedgerManagerFactory();
@@ -208,6 +207,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -216,12 +216,11 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfBookies = 5;
         int numOfLedgersNotAdheringToPlacementPolicy = 0;
         List<BookieId> bookieAddresses = new ArrayList<>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
-                bookieAddresses.add(bookieAddress);
-                regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
+            bookieAddresses.add(bookieAddress);
+            regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
 
         // only three racks
@@ -291,6 +290,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
     }
 
@@ -300,12 +300,11 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfBookies = 5;
         int numOfLedgersNotAdheringToPlacementPolicy = 0;
         List<BookieId> bookieAddresses = new ArrayList<>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
-                bookieAddresses.add(bookieAddress);
-                regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
+            bookieAddresses.add(bookieAddress);
+            regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
 
         // only three racks
@@ -372,12 +371,11 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfBookies = 5;
         int numOfLedgersNotAdheringToPlacementPolicy = 0;
         List<BookieId> bookieAddresses = new ArrayList<>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
-                bookieAddresses.add(bookieAddress);
-                regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
+            bookieAddresses.add(bookieAddress);
+            regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
 
         // only three racks
@@ -433,6 +431,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
         LedgerUnderreplicationManager underreplicationManager = mFactory.newLedgerUnderreplicationManager();
         long unnderReplicateLedgerId = underreplicationManager.pollLedgerToRereplicate();
@@ -458,13 +457,13 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int underreplicatedLedgerRecoveryGracePeriod = timeElapsed ? 1 : 1000;
         int numOfURLedgersElapsedRecoveryGracePeriod = 0;
         List<BookieId> bookieAddresses = new ArrayList<BookieId>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
-                bookieAddresses.add(bookieAddress);
-                regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
+            bookieAddresses.add(bookieAddress);
+            regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
+        
 
         LedgerManagerFactory mFactory = driver.getLedgerManagerFactory();
         LedgerManager lm = mFactory.newLedgerManager();
@@ -569,6 +568,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
     }
 
@@ -577,12 +577,11 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfBookies = 7;
         int numOfLedgersNotAdheringToPlacementPolicy = 0;
         List<BookieId> bookieAddresses = new ArrayList<>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
-                bookieAddresses.add(bookieAddress);
-                regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieId bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181).toBookieId();
+            bookieAddresses.add(bookieAddress);
+            regManager.registerBookie(bookieAddress, false, BookieServiceInfo.EMPTY);
         }
 
         // only three racks
@@ -673,6 +672,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
     }
 
@@ -682,19 +682,18 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         int numOfLedgersNotAdheringToPlacementPolicy = 0;
         int numOfLedgersSoftlyAdheringToPlacementPolicy = 0;
         List<BookieId> bookieAddresses = new ArrayList<BookieId>();
-        try (RegistrationManager regManager = driver.createRegistrationManager()) {
-            /*
-             * 6 bookies - 3 zones and 2 uds
-             */
-            for (int i = 0; i < numOfBookies; i++) {
-                BookieSocketAddress bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181);
-                bookieAddresses.add(bookieAddress.toBookieId());
-                regManager.registerBookie(bookieAddress.toBookieId(), false, BookieServiceInfo.EMPTY);
-                String zone = "/zone" + (i % 3);
-                String upgradeDomain = "/ud" + (i % 2);
-                String networkLocation = zone + upgradeDomain;
-                StaticDNSResolver.addNodeToRack(bookieAddress.getHostName(), networkLocation);
-            }
+        RegistrationManager regManager = driver.createRegistrationManager();
+        /*
+         * 6 bookies - 3 zones and 2 uds
+         */
+        for (int i = 0; i < numOfBookies; i++) {
+            BookieSocketAddress bookieAddress = new BookieSocketAddress("98.98.98." + i, 2181);
+            bookieAddresses.add(bookieAddress.toBookieId());
+            regManager.registerBookie(bookieAddress.toBookieId(), false, BookieServiceInfo.EMPTY);
+            String zone = "/zone" + (i % 3);
+            String upgradeDomain = "/ud" + (i % 2);
+            String networkLocation = zone + upgradeDomain;
+            StaticDNSResolver.addNodeToRack(bookieAddress.getHostName(), networkLocation);
         }
 
         LedgerManagerFactory mFactory = driver.getLedgerManagerFactory();
@@ -800,6 +799,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
             if (auditor != null) {
                 auditor.close();
             }
+            regManager.close();
         }
     }
 


### PR DESCRIPTION
### Motivation
Some RegistrationManager implements(PulsarRegistrationManager) will delete the bookie's node in the close method, which will lead to the test failure.

