### PR TITLE
Speed the Auditor test end time.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -68,6 +68,8 @@ import org.slf4j.LoggerFactory;
  * <p>TODO: eliminate the direct usage of zookeeper here {@link https://github.com/apache/bookkeeper/issues/1332}
  */
 public class Auditor implements AutoCloseable {
+    public static final String AUDITOR_AWAIT_TERMINATION = "auditor.awaitTermination";
+    private final int awaitTermination = Integer.getInteger(AUDITOR_AWAIT_TERMINATION , 30);
     private static final Logger LOG = LoggerFactory.getLogger(Auditor.class);
     private final ServerConfiguration conf;
     private final BookKeeper bkc;
@@ -620,7 +622,7 @@ public class Auditor implements AutoCloseable {
         LOG.info("Shutting down auditor");
         executor.shutdown();
         try {
-            while (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+            while (!executor.awaitTermination(awaitTermination, TimeUnit.SECONDS)) {
                 LOG.warn("Executor not shutting down, interrupting");
                 executor.shutdownNow();
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -92,6 +92,10 @@ import org.slf4j.LoggerFactory;
  * A class runs several bookie servers for testing.
  */
 public abstract class BookKeeperClusterTestCase {
+    
+    static {
+        System.setProperty(Auditor.AUDITOR_AWAIT_TERMINATION, "1");
+    }
 
     static final Logger LOG = LoggerFactory.getLogger(BookKeeperClusterTestCase.class);
 


### PR DESCRIPTION
### Motivation
In some tests, the execution time can be quite long, even though the test methods have already finished running. For example, in the AuditorRollingRestartTest#testAuditingDuringRollingRestart() test. 

I printed out the stack trace and found that it is stuck at executor.awaitTermination(30, TimeUnit.SECONDS) i
n the Auditor. In some tests, the executor in the Auditor is getting stuck, causing the test to wait for an additional 30 seconds.

```
"Time-limited test" #18 daemon prio=5 os_prio=31 cpu=762.48ms elapsed=69.85s tid=0x000000011fb87200 nid=0x871b waiting on condition  [0x0000000173b39000]
   java.lang.Thread.State: TIMED_WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.3.1/Native Method)
	- parking to wait for  <0x00002000063a18d0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@17.0.3.1/LockSupport.java:252)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@17.0.3.1/AbstractQueuedSynchronizer.java:1672)
	at java.util.concurrent.ThreadPoolExecutor.awaitTermination(java.base@17.0.3.1/ThreadPoolExecutor.java:1464)
	at java.util.concurrent.Executors$DelegatedExecutorService.awaitTermination(java.base@17.0.3.1/Executors.java:743)
	at org.apache.bookkeeper.replication.Auditor.shutdown(Auditor.java:623)
	at org.apache.bookkeeper.replication.AuditorElector.shutdown(AuditorElector.java:246)
	at org.apache.bookkeeper.replication.AutoRecoveryMain.shutdown(AutoRecoveryMain.java:157)
	at org.apache.bookkeeper.replication.AutoRecoveryMain.shutdown(AutoRecoveryMain.java:143)
	at org.apache.bookkeeper.test.BookKeeperClusterTestCase$ServerTester.stopAutoRecovery(BookKeeperClusterTestCase.java:916)
	at org.apache.bookkeeper.test.BookKeeperClusterTestCase.stopReplicationService(BookKeeperClusterTestCase.java:766)
	at org.apache.bookkeeper.test.BookKeeperClusterTestCase.stopBKCluster(BookKeeperClusterTestCase.java:278)
	at org.apache.bookkeeper.test.BookKeeperClusterTestCase.tearDown(BookKeeperClusterTestCase.java:203)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.3.1/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.3.1/NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.3.1/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@17.0.3.1/Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunAfters.invokeMethod(RunAfters.java:46)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(java.base@17.0.3.1/FutureTask.java:264)
	at java.lang.Thread.run(java.base@17.0.3.1/Thread.java:833)

"AuditorBookie-127.0.0.1:59740" #306 daemon prio=5 os_prio=31 cpu=0.24ms elapsed=50.97s tid=0x000000011f1a1400 nid=0x13407 waiting on condition  [0x00000004e8a36000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.3.1/Native Method)
	- parking to wait for  <0x00002000050dcff0> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.3.1/LockSupport.java:211)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.3.1/AbstractQueuedSynchronizer.java:715)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@17.0.3.1/AbstractQueuedSynchronizer.java:1047)
	at java.util.concurrent.CountDownLatch.await(java.base@17.0.3.1/CountDownLatch.java:230)
	at org.apache.bookkeeper.replication.ReplicationEnableCb.await(ReplicationEnableCb.java:56)
	at org.apache.bookkeeper.replication.AuditorBookieCheckTask.waitIfLedgerReplicationDisabled(AuditorBookieCheckTask.java:181)
	at org.apache.bookkeeper.replication.AuditorBookieCheckTask.auditBookies(AuditorBookieCheckTask.java:104)
	at org.apache.bookkeeper.replication.AuditorBookieCheckTask.startAudit(AuditorBookieCheckTask.java:86)
	at org.apache.bookkeeper.replication.AuditorBookieCheckTask.runTask(AuditorBookieCheckTask.java:64)
	at org.apache.bookkeeper.replication.AuditorTask.run(AuditorTask.java:72)
	at org.apache.bookkeeper.replication.AuditorBookieCheckTask.run(AuditorBookieCheckTask.java:40)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@17.0.3.1/Executors.java:539)
	at java.util.concurrent.FutureTask.runAndReset(java.base@17.0.3.1/FutureTask.java:305)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@17.0.3.1/ScheduledThreadPoolExecutor.java:305)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.3.1/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.3.1/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.3.1/Thread.java:833)
```


Therefore, we can modify the behavior of awaitTermination using a system variable, so that it doesn't wait for 30 seconds when running in a single-sided mode.

