### PR TITLE
Fix verifyDirsForNewEnvironment

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LegacyCookieValidation.java
@@ -94,7 +94,7 @@ public class LegacyCookieValidation implements CookieValidation {
             if (!missedCookieDirs.isEmpty()) {
                 if (rmCookie == null) {
                     // 5.1 new environment: all directories should be empty
-                    verifyDirsForNewEnvironment(missedCookieDirs);
+                    verifyDirsForNewEnvironment(directories);
                     stampNewCookie(conf, masterCookie, registrationManager,
                             Version.NEW, directories);
                 } else if (allowExpansion) {


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

When verify dires for new environment,  we should make sure that all directories should be empty, instead of `missedCookieDirs`

### Changes

`verifyDirsForNewEnvironment(missedCookieDirs)` -> `verifyDirsForNewEnvironment(directories)`

