### PR TITLE
[Build] Support property: maven.compiler.release for building BK with higher version JDK

### DIFF
--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -135,11 +135,10 @@
           <sourcepath>${src.dir}</sourcepath>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
           <doclint>none</doclint>
-          <subpackages>org.apache.bookkeeper.common.annotation</subpackages>
           <groups>
             <group>
               <title>Bookkeeper Client</title>
-              <packages>org.apache.bookkeeper.common.annotation*</packages>
+              <packages>org.apache.bookkeeper.common.annotation</packages>
             </group>
           </groups>
         </configuration>

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKey.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKey.java
@@ -19,12 +19,6 @@
 
 package org.apache.bookkeeper.common.conf;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
@@ -36,6 +30,13 @@ import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * A configuration key in a configuration.
  */
@@ -45,6 +46,8 @@ import org.apache.commons.configuration.ConfigurationException;
 @Public
 @Slf4j
 public class ConfigKey {
+
+    public static class ConfigKeyBuilder {}
 
     public static final Comparator<ConfigKey> ORDERING = (o1, o2) -> {
         int ret = Integer.compare(o1.orderInGroup, o2.orderInGroup);

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKey.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKey.java
@@ -19,6 +19,12 @@
 
 package org.apache.bookkeeper.common.conf;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
@@ -29,13 +35,6 @@ import org.apache.bookkeeper.common.conf.validators.NullValidator;
 import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * A configuration key in a configuration.

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKeyGroup.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKeyGroup.java
@@ -19,15 +19,16 @@
 
 package org.apache.bookkeeper.common.conf;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Define a group of configuration settings.
@@ -37,6 +38,8 @@ import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 @Builder(builderMethodName = "internalBuilder")
 @Public
 public class ConfigKeyGroup {
+
+    public static class ConfigKeyGroupBuilder {}
 
     /**
      * Ordering the key groups in a configuration.

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKeyGroup.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/conf/ConfigKeyGroup.java
@@ -19,16 +19,15 @@
 
 package org.apache.bookkeeper.common.conf;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * Define a group of configuration settings.

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -294,11 +294,10 @@
           <sourcepath>${src.dir}</sourcepath>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
           <doclint>none</doclint>
-          <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature</subpackages>
           <groups>
             <group>
               <title>Bookkeeper</title>
-              <packages>org.apache.bookkeeper*</packages>
+              <packages>org.apache.bookkeeper.client:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature</packages>
             </group>
           </groups>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <javac.target>1.8</javac.target>
+    <release.target>8</release.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <testRetryCount>2</testRetryCount>
     <src.dir>src/main/java</src.dir>
@@ -1273,6 +1274,7 @@
         <jdk>[11,)</jdk>
       </activation>
       <properties>
+        <maven.compiler.release>${release.target}</maven.compiler.release>
         <test.additional.args>
           --add-opens java.base/java.io=ALL-UNNAMED
           --add-opens java.base/java.lang=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -964,7 +964,6 @@
           <notimestamp>true</notimestamp>
           <!-- Prevent missing javadoc comments from being marked as errors -->
           <doclint>none</doclint>
-          <subpackages>org.apache.bookkeeper.client:org.apache.bookkeeper.client.api:org.apache.bookkeeper.common.annotation:org.apache.bookkeeper.conf:org.apache.bookkeeper.feature:org.apache.bookkeeper.stats</subpackages>
           <groups>
             <group>
               <title>Bookkeeper Client</title>

--- a/stats/bookkeeper-stats-api/pom.xml
+++ b/stats/bookkeeper-stats-api/pom.xml
@@ -38,7 +38,6 @@
           <sourcepath>${src.dir}</sourcepath>
           <!-- Avoid for missing javadoc comments to be marked as errors -->
           <doclint>none</doclint>
-          <subpackages>org.apache.bookkeeper.stats</subpackages>
           <groups>
             <group>
               <title>Bookkeeper Stats API</title>


### PR DESCRIPTION


### Motivation

With this feature,  the compiler will detect and generate an error when using APIs that don't exist in previous releases of Java SE in advance.

### Changes

Add property: maven.compiler.release

Master Issue: #4089

