### PR TITLE
Improve only one region need localNode in regionAwarePolicy

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -33,6 +33,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.util.HashedWheelTimer;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +54,7 @@ import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.StaticDNSResolver;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1879,5 +1881,66 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         assertEquals("region3", repp.address2Region.get(addr2.toBookieId()));
         assertEquals("region2", repp.address2Region.get(addr3.toBookieId()));
         assertEquals("region3", repp.address2Region.get(addr4.toBookieId()));
+    }
+
+    public void testOnlyOneRegionHasLocalnode() {
+        BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.1", 3181);
+        BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.2", 3181);
+        BookieSocketAddress addr3 = new BookieSocketAddress("127.0.0.3", 3181);
+        BookieSocketAddress addr4 = new BookieSocketAddress("127.0.0.4", 3181);
+        BookieSocketAddress addr5 = new BookieSocketAddress("127.0.0.5", 3181);
+        BookieSocketAddress addr6 = new BookieSocketAddress("127.0.0.6", 3181);
+
+        // update dns mapping
+        StaticDNSResolver.addNodeToRack(addr1.getHostName(), "/region1/r1");
+        StaticDNSResolver.addNodeToRack(addr2.getHostName(), "/region1/r2");
+        StaticDNSResolver.addNodeToRack(addr3.getHostName(), "/region2/r3");
+        StaticDNSResolver.addNodeToRack(addr4.getHostName(), "/region2/r4");
+        StaticDNSResolver.addNodeToRack(addr5.getHostName(), "/region3/r5");
+        StaticDNSResolver.addNodeToRack(addr6.getHostName(), "/region3/r6");
+
+        repp.initialize(conf, Optional.<DNSToSwitchMapping>empty(), timer,
+                DISABLE_ALL, NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
+        repp.withDefaultRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
+        // Update cluster
+        Set<BookieId> addrs = new HashSet<BookieId>();
+        addrs.add(addr1.toBookieId());
+        addrs.add(addr2.toBookieId());
+        addrs.add(addr3.toBookieId());
+        addrs.add(addr4.toBookieId());
+        addrs.add(addr5.toBookieId());
+        addrs.add(addr6.toBookieId());
+        repp.onClusterChanged(addrs, new HashSet<BookieId>());
+
+        for (Map.Entry<String, TopologyAwareEnsemblePlacementPolicy> entry : repp.perRegionPlacement.entrySet()) {
+            String region = entry.getKey();
+            RackawareEnsemblePlacementPolicy rackawareEnsemblePlacementPolicy =
+                    (RackawareEnsemblePlacementPolicy) entry.getValue();
+            if (region.equals("region1")) {
+                Assert.assertEquals("/region1/r1", rackawareEnsemblePlacementPolicy.localNode.getNetworkLocation());
+            }
+            if (region.equals("region2") || region.equals("region3")) {
+                Assert.assertNull(rackawareEnsemblePlacementPolicy.localNode);
+            }
+        }
+
+        // change rackInfo of addr1 and localNode
+        System.out.println("change rackInfo of addr1 and localNode");
+        StaticDNSResolver.changeRack(Collections.singletonList(addr1),
+                Collections.singletonList("/region2/r7"));
+
+        for (Map.Entry<String, TopologyAwareEnsemblePlacementPolicy> entry : repp.perRegionPlacement.entrySet()) {
+            String region = entry.getKey();
+            RackawareEnsemblePlacementPolicy rackawareEnsemblePlacementPolicy =
+                    (RackawareEnsemblePlacementPolicy) entry.getValue();
+
+            if (region.equals("region2")) {
+                Assert.assertEquals("/region2/r7",
+                        rackawareEnsemblePlacementPolicy.localNode.getNetworkLocation());
+            }
+            if (region.equals("region1") || region.equals("region3")) {
+                Assert.assertNull(rackawareEnsemblePlacementPolicy.localNode);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Now in regionAwarePolicy, each region has the same localNode. Such as:

- region1  -  localNode is /region1/rack1
- region2  -  localNode is /region1/rack1
- region3  -  localNode is /region1/rack1

This is not correct and would generate more confusing warn log in newEnsemble()
![企业微信截图_f12217d6-af21-41d6-b2de-c1c484a0d788](https://github.com/apache/bookkeeper/assets/13505225/d693c196-100a-4ea3-8dfb-6ad8ef4accce)

This pr is a supplement of https://github.com/apache/bookkeeper/pull/4091. We should fix the localNode not update first. 

### Changes
1. only one region need localNode. So reset the localNode in other region
2. add test

