### PR TITLE
[Bug] LedgerManagerFactory Info storing in LAYOUT znode is not correct

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -62,9 +62,11 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
 
         Class<? extends LedgerManagerFactory> factoryClass;
         try {
-            factoryClass = conf.getLedgerManagerFactoryClass();
-        } catch (ConfigurationException e) {
-            throw new IOException("Failed to get ledger manager factory class from configuration : ", e);
+            factoryClass = (Class<? extends LedgerManagerFactory>)
+                    Class.forName(layoutManager.readLedgerLayout().getManagerFactoryClass());
+        } catch (ClassNotFoundException e) {
+            // should not reach here, as LayoutManager was successfully inited
+            throw new IOException("Failed to read ledger manager factory class from LAYOUT : ", e);
         }
 
         layoutManager.deleteLedgerLayout();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -27,44 +27,25 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.BOOKIE_STATUS_FILENAME;
 import static org.apache.bookkeeper.util.TestUtils.countNumOfFiles;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.bookkeeper.bookie.BookieException.DiskPartitionDuplicationException;
 import org.apache.bookkeeper.bookie.BookieException.MetadataStoreException;
 import org.apache.bookkeeper.bookie.Journal.LastLogMark;
@@ -1770,4 +1751,19 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             fail();
         }
     }
+
+    @Test
+    public void testFormatTwiceWithNonDefaultHierarchicalType() throws Exception {
+        File tmpDir = tmpDirs.createNew("bookie", "test");
+        final String zkRoot = "/ledgers3";
+
+        final ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+                .setJournalDirName(tmpDir.getPath())
+                .setLedgerDirNames(new String[] { tmpDir.getPath() })
+                .setMetadataServiceUri(zkUtil.getMetadataServiceUri(zkRoot, "longhierarchical"))
+                .setZkTimeout(5000);
+        BookKeeperAdmin.format(conf, false, false);
+        BookKeeperAdmin.format(conf, false, true);
+    }
+
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix a bug described in #<4094>

### Changes

When executing `format` method, as `layoutManager` is inited already as user configured, the `LedgerManagerFactory` info should be read from znode, instead of configuration.
