### PR TITLE
Fix the bookkeeper-server-shaded version in ledger-api doc

### DIFF
--- a/site3/website/docs/api/ledger-api.md
+++ b/site3/website/docs/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.10.0/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.10.0/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.11.1/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.11.1/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.12.1/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.12.1/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.13.0/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.13.0/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.14.8/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.14.8/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.15.5/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.15.5/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.16.5/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.16.5/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.17.0/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.17.0/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.6.2/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.6.2/api/ledger-api.md
@@ -96,7 +96,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the shaded artifact of `bookkeeper-server` jar
 dependencies {
-    compile ('org.apache.bookkeeper:bookkeeper-server:{{ site.latest-version }}:shaded') {
+    compile ('org.apache.bookkeeper:bookkeeper-server:{{ site.latest_release }}:shaded') {
         exclude group: 'org.apache.bookkeeper', module: "bookkeeper-common'
         exclude group: 'org.apache.bookkeeper', module: 'bookkeeper-proto'
     }
@@ -105,7 +105,7 @@ dependencies {
 
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.7.3/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.7.3/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.8.2/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.8.2/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.9.2/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.9.2/api/ledger-api.md
@@ -67,7 +67,7 @@ Similarly as using maven, you can also configure to use the shaded jars.
 ```groovy
 // use the `bookkeeper-server-shaded` jar
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest-version }}'
+    compile 'org.apache.bookkeeper:bookkeeper-server-shaded:{{ site.latest_release }}'
 }
 ```
 


### PR DESCRIPTION
### Motivation
![image](https://github.com/apache/bookkeeper/assets/231353/eccea413-b2b8-4fd2-8f30-7115d854b931)

![image](https://github.com/apache/bookkeeper/assets/231353/e4965460-1427-4ecd-a327-1eb448e531de)


### Changes

1. fix the bookkeeper-server-shaded version by  `site.latest_release`
2. fix the overview title version.

