### PR TITLE
issue 4109: Fix Flaky-test: HandleFailuresTest.testHandleFailureBookieNotInWriteSet

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
@@ -31,11 +31,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClientImpl;
+import org.apache.bookkeeper.proto.MockBookieClient;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.junit.Assert;
 import org.junit.Test;
@@ -480,14 +484,20 @@ public class HandleFailuresTest {
         b1Delay.completeExceptionally(new BKException.BKWriteException());
 
         log.info("write second entry, should have enough bookies, but blocks completion on failure handling");
-        CompletableFuture<?> e2 = lh.appendAsync("entry2".getBytes());
+        AtomicReference<CompletableFuture<?>> e2 = new AtomicReference<>();
+
+        // Execute appendAsync at the same thread of preWriteHook exception thread. So that the `delayedWriteFailedBookies` could update before
+        // appendAsync invoke.
+        ((MockBookieClient) clientCtx.getBookieClient()).executor
+                .chooseThread(lh.ledgerId)
+                .execute(() -> e2.set(lh.appendAsync("entry2".getBytes())));
         changeInProgress.get();
         assertEventuallyTrue("e2 should eventually complete", () -> lh.pendingAddOps.peek().completed);
-        Assert.assertFalse("e2 shouldn't be completed to client", e2.isDone());
+        Assert.assertFalse("e2 shouldn't be completed to client", e2.get().isDone());
         blockEnsembleChange.complete(null); // allow ensemble change to continue
 
         log.info("e2 should complete");
-        e2.get(10, TimeUnit.SECONDS);
+        e2.get().get(10, TimeUnit.SECONDS);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
@@ -26,12 +26,12 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.Lists;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -43,8 +43,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 /**
  * Ledger recovery tests using mocks rather than a real cluster.
@@ -486,8 +484,8 @@ public class HandleFailuresTest {
         log.info("write second entry, should have enough bookies, but blocks completion on failure handling");
         AtomicReference<CompletableFuture<?>> e2 = new AtomicReference<>();
 
-        // Execute appendAsync at the same thread of preWriteHook exception thread. So that the `delayedWriteFailedBookies` could update before
-        // appendAsync invoke.
+        // Execute appendAsync at the same thread of preWriteHook exception thread. So that the
+        // `delayedWriteFailedBookies` could update before appendAsync invoke.
         ((MockBookieClient) clientCtx.getBookieClient()).getExecutor()
                 .chooseThread(lh.ledgerId)
                 .execute(() -> e2.set(lh.appendAsync("entry2".getBytes())));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.Lists;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -38,13 +37,14 @@ import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.bookkeeper.proto.BookieClientImpl;
 import org.apache.bookkeeper.proto.MockBookieClient;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
 
 /**
  * Ledger recovery tests using mocks rather than a real cluster.
@@ -488,7 +488,7 @@ public class HandleFailuresTest {
 
         // Execute appendAsync at the same thread of preWriteHook exception thread. So that the `delayedWriteFailedBookies` could update before
         // appendAsync invoke.
-        ((MockBookieClient) clientCtx.getBookieClient()).executor
+        ((MockBookieClient) clientCtx.getBookieClient()).getExecutor()
                 .chooseThread(lh.ledgerId)
                 .execute(() -> e2.set(lh.appendAsync("entry2".getBytes())));
         changeInProgress.get();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
 public class MockBookieClient implements BookieClient {
     static final Logger LOG = LoggerFactory.getLogger(MockBookieClient.class);
 
-    final OrderedExecutor executor;
+    public final OrderedExecutor executor;
     final MockBookies mockBookies;
     final Set<BookieId> errorBookies =
             Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
@@ -25,6 +25,8 @@ import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCounted;
+import lombok.Getter;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -56,7 +58,8 @@ import org.slf4j.LoggerFactory;
 public class MockBookieClient implements BookieClient {
     static final Logger LOG = LoggerFactory.getLogger(MockBookieClient.class);
 
-    public final OrderedExecutor executor;
+    @Getter
+    final OrderedExecutor executor;
     final MockBookies mockBookies;
     final Set<BookieId> errorBookies =
             Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java
@@ -25,8 +25,6 @@ import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_RECOVERY_ADD;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCounted;
-import lombok.Getter;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -34,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;


### PR DESCRIPTION
Descriptions of the changes in this PR:


Master Issue: https://github.com/apache/bookkeeper/issues/4109
### Motivation

Fix Flaky-test: HandleFailuresTest.testHandleFailureBookieNotInWriteSet

When we call `b1Delay.completeExceptionally(new BKException.BKWriteException())` at line480(code1),  the `preWriteHook` will complete with exception  and then do some actions in the choosen thread(code2), e.g., put the failure bookie to `delayedWriteFailedBookies`(code3).  So the `delayedWriteFailedBookies` update is async.

However, `lh.appendAsync("entry2".getBytes()))`(Line483 in Code4) is invoked in main thread. So when `appendAsync` execute,  the `delayedWriteFailedBookies` could be not updated yet, and `changeInProgress.complete(null)`(code5) will never be invoked.

We can reproduce this flasy-test if we put `Thread.sleep(5000)` just before line289 at code6.

code1:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java#L480

code2:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/MockBookieClient.java#L179-L186

code3:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L1848-L1852

code4:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java#L480-L483

code5:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/HandleFailuresTest.java#L469-L472

code6:
https://github.com/apache/bookkeeper/blob/907c273431a7d4bae7a7ee22bc03f366328a5dd5/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java#L282-L290

### Changes

(Describe: what changes you have made)



