### PR TITLE
Support config to control the Bookie handle not available log level.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -493,9 +493,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             this.ownTimer = false;
         }
 
-        BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
-                ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
-                : new BookieAddressResolverDisabled();
+        BookieAddressResolver bookieAddressResolver =
+                conf.getBookieAddressResolverEnabled() ? new DefaultBookieAddressResolver(
+                        metadataDriver.getRegistrationClient(), conf.isDebugBookieHandleNotAvailableLog())
+                        : new BookieAddressResolverDisabled();
         if (dnsResolver != null) {
             dnsResolver.setBookieAddressResolver(bookieAddressResolver);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ClientInternalConf.java
@@ -48,6 +48,7 @@ class ClientInternalConf {
     final boolean enableBookieFailureTracking;
     final boolean useV2WireProtocol;
     final boolean enforceMinNumFaultDomainsForWrite;
+    final boolean debugBookieHandleNotAvailableLog;
 
     static ClientInternalConf defaultValues() {
         return fromConfig(new ClientConfiguration());
@@ -82,6 +83,7 @@ class ClientInternalConf {
         this.useV2WireProtocol = conf.getUseV2WireProtocol();
         this.enableStickyReads = conf.isStickyReadsEnabled();
         this.enforceMinNumFaultDomainsForWrite = conf.getEnforceMinNumFaultDomainsForWrite();
+        this.debugBookieHandleNotAvailableLog = conf.isDebugBookieHandleNotAvailableLog();
 
         if (conf.getFirstSpeculativeReadTimeout() > 0) {
             this.readSpeculativeRequestPolicy =

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -32,7 +32,7 @@ import org.apache.bookkeeper.proto.BookieAddressResolver;
 public class DefaultBookieAddressResolver implements BookieAddressResolver {
 
     private final RegistrationClient registrationClient;
-    
+
     private final boolean isDebugBookieHandleNotAvailableLog;
 
     public DefaultBookieAddressResolver(RegistrationClient registrationClient,
@@ -40,7 +40,7 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
         this.registrationClient = registrationClient;
         this.isDebugBookieHandleNotAvailableLog = isDebugBookieHandleNotAvailableLog;
     }
-    
+
     public RegistrationClient getRegistrationClient() {
         return registrationClient;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -32,11 +32,19 @@ import org.apache.bookkeeper.proto.BookieAddressResolver;
 public class DefaultBookieAddressResolver implements BookieAddressResolver {
 
     private final RegistrationClient registrationClient;
+    
+    private final boolean isDebugBookieHandleNotAvailableLog;
 
     public DefaultBookieAddressResolver(RegistrationClient registrationClient) {
-        this.registrationClient = registrationClient;
+        this(registrationClient, false);
     }
-
+    
+    public DefaultBookieAddressResolver(RegistrationClient registrationClient,
+            boolean isDebugBookieHandleNotAvailableLog) {
+        this.registrationClient = registrationClient;
+        this.isDebugBookieHandleNotAvailableLog = isDebugBookieHandleNotAvailableLog;
+    }
+    
     public RegistrationClient getRegistrationClient() {
         return registrationClient;
     }
@@ -65,7 +73,13 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
                 }
                 return BookieSocketAddress.resolveLegacyBookieId(bookieId);
             }
-            log.info("Cannot resolve {}, bookie is unknown {}", bookieId, ex.toString());
+            if (isDebugBookieHandleNotAvailableLog) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Cannot resolve {}, bookie is unknown {}", bookieId, ex.toString());
+                }
+            } else {
+                log.info("Cannot resolve {}, bookie is unknown {}", bookieId, ex.toString());
+            }
             throw new BookieIdNotResolvedException(bookieId, ex);
         } catch (Exception ex) {
             if (ex instanceof InterruptedException) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/DefaultBookieAddressResolver.java
@@ -35,10 +35,6 @@ public class DefaultBookieAddressResolver implements BookieAddressResolver {
     
     private final boolean isDebugBookieHandleNotAvailableLog;
 
-    public DefaultBookieAddressResolver(RegistrationClient registrationClient) {
-        this(registrationClient, false);
-    }
-    
     public DefaultBookieAddressResolver(RegistrationClient registrationClient,
             boolean isDebugBookieHandleNotAvailableLog) {
         this.registrationClient = registrationClient;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -212,9 +212,17 @@ class PendingReadOp implements ReadEntryCallback, Runnable {
                             lh.ledgerId, eId, host);
                 }
             } else {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("{} while reading L{} E{} from bookie: {}",
-                            errMsg, lh.ledgerId, eId, host);
+                if (clientCtx.getConf().debugBookieHandleNotAvailableLog
+                        && BKException.Code.BookieHandleNotAvailableException == rc) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} while reading L{} E{} from bookie: {}",
+                                errMsg, lh.ledgerId, eId, host);
+                    }
+                } else {
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("{} while reading L{} E{} from bookie: {}",
+                                errMsg, lh.ledgerId, eId, host);
+                    }
                 }
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -201,6 +201,8 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     // Logs
     protected static final String CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING =
             "clientConnectBookieUnavailableLogThrottling";
+    
+    protected static final String DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG = "debugBookieHandleNotAvailableLog";
 
     /**
      * Construct a default client-side configuration.
@@ -2080,5 +2082,14 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     @Override
     protected ClientConfiguration getThis() {
         return this;
+    }
+    
+    public ClientConfiguration setDebugBookieHandleNotAvailableLog(boolean isDebug) {
+        setProperty(DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG, isDebug);
+        return this;
+    }
+    
+    public boolean isDebugBookieHandleNotAvailableLog() {
+        return getBoolean(DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG, false);
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -201,7 +201,7 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     // Logs
     protected static final String CLIENT_CONNECT_BOOKIE_UNAVAILABLE_LOG_THROTTLING =
             "clientConnectBookieUnavailableLogThrottling";
-    
+
     protected static final String DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG = "debugBookieHandleNotAvailableLog";
 
     /**
@@ -2083,12 +2083,12 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     protected ClientConfiguration getThis() {
         return this;
     }
-    
+
     public ClientConfiguration setDebugBookieHandleNotAvailableLog(boolean isDebug) {
         setProperty(DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG, isDebug);
         return this;
     }
-    
+
     public boolean isDebugBookieHandleNotAvailableLog() {
         return getBoolean(DEBUG_BOOKIE_HANDLE_NOT_AVAILABLE_LOG, false);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -538,8 +538,15 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         try {
             addr = bookieAddressResolver.resolve(bookieId);
         } catch (BookieAddressResolver.BookieIdNotResolvedException err) {
-            LOG.error("Cannot connect to {} as endpoint resolution failed (probably bookie is down) err {}",
-                    bookieId, err.toString());
+            if (conf.isDebugBookieHandleNotAvailableLog()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Cannot connect to {} as endpoint resolution failed (probably bookie is down) err {}",
+                            bookieId, err.toString());
+                }
+            } else {
+                LOG.error("Cannot connect to {} as endpoint resolution failed (probably bookie is down) err {}",
+                        bookieId, err.toString());
+            }
             return processBookieNotResolvedError(startTime, err);
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookies/ListBookiesCommand.java
@@ -86,7 +86,7 @@ public class ListBookiesCommand extends DiscoveryCommand<Flags> {
         }
 
         BookieAddressResolver bookieAddressResolver = bookieAddressResolverEnabled
-                ? new DefaultBookieAddressResolver(regClient)
+                ? new DefaultBookieAddressResolver(regClient, false)
                 : new BookieAddressResolverDisabled();
 
         boolean hasBookies = false;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockClientContext.java
@@ -61,7 +61,7 @@ public class MockClientContext implements ClientContext {
         EnsemblePlacementPolicy placementPolicy = new DefaultEnsemblePlacementPolicy();
         BookieWatcherImpl bookieWatcherImpl = new BookieWatcherImpl(conf, placementPolicy,
                                                                     regClient,
-                                                                    new DefaultBookieAddressResolver(regClient),
+                                                                    new DefaultBookieAddressResolver(regClient, false),
                                                                     NullStatsLogger.INSTANCE);
         bookieWatcherImpl.initialBlockingBookieRead();
 

--- a/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolver.java
+++ b/stream/bk-grpc-name-resolver/src/main/java/org/apache/bookkeeper/grpc/resolver/BKRegistrationNameResolver.java
@@ -83,8 +83,8 @@ class BKRegistrationNameResolver extends NameResolver {
         } catch (MetadataException e) {
             throw new RuntimeException("Failed to initialize registration client driver at " + serviceURI, e);
         }
-        this.bookieAddressResolver = conf.getBookieAddressResolverEnabled()
-                ? new DefaultBookieAddressResolver(clientDriver.getRegistrationClient())
+        this.bookieAddressResolver = conf.getBookieAddressResolverEnabled() ? new DefaultBookieAddressResolver(
+                clientDriver.getRegistrationClient(), conf.isDebugBookieHandleNotAvailableLog())
                 : new BookieAddressResolverDisabled();
 
         resolve();

--- a/tests/integration/cluster/src/test/java/org/apache/bookkeeper/tests/integration/cluster/BookKeeperClusterTestBase.java
+++ b/tests/integration/cluster/src/test/java/org/apache/bookkeeper/tests/integration/cluster/BookKeeperClusterTestBase.java
@@ -99,7 +99,7 @@ public abstract class BookKeeperClusterTestBase {
 
     private static boolean findIfBookieRegistered(String bookieName) throws Exception {
         DefaultBookieAddressResolver resolver =
-                new DefaultBookieAddressResolver(metadataClientDriver.getRegistrationClient());
+                new DefaultBookieAddressResolver(metadataClientDriver.getRegistrationClient(), false);
         Set<BookieId> bookies =
             FutureUtils.result(metadataClientDriver
                     .getRegistrationClient().getWritableBookies()).getValue();


### PR DESCRIPTION
When AutoRecovery working, it will replicate the data from the shutdown bookie to another living bookie. So there are lots of logs about the shutdown bookie.

Like: 
```
2023-10-19T18:33:52,042 - ERROR - [BookKeeperClientWorker-OrderedExecutor-3-0:PerChannelBookieClient@563] - Cannot connect to 192.168.31.216:3181 as endpoint resolution failed (probably bookie is down) err org.apache.bookkeeper.proto.BookieAddressResolver$BookieIdNotResolvedException: Cannot resolve bookieId 192.168.31.216:3181, bookie does not exist or it is not running
```

```
2023-10-19T18:33:52,042 - INFO  - [BookKeeperClientWorker-OrderedExecutor-3-0:DefaultBookieAddressResolver@77] - Cannot resolve 192.168.31.216:3181, bookie is unknown org.apache.bookkeeper.client.BKException$BKBookieHandleNotAvailableException: Bookie handle is not available

```

```
2023-10-19T18:33:52,042 - INFO  - [BookKeeperClientWorker-OrderedExecutor-3-0:PendingReadOp$LedgerEntryRequest@223] - Error: Bookie handle is not available while reading L6 E40 from bookie: 192.168.31.216:3181

```

So we can add a flag to control the Bookie handle not available log level.

I have test the change at my local.

Before:
[before.txt](https://github.com/apache/bookkeeper/files/13041394/before.txt)


After:
[atfer.txt](https://github.com/apache/bookkeeper/files/13041395/atfer.txt)

