### PR TITLE
Improve auto-recovery noise log when some bookie down.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -507,13 +507,27 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         try {
             excludeBookies = addDefaultRackBookiesIfMinNumRacksIsEnforced(excludeBookies);
             excludeBookies.addAll(currentEnsemble);
+    
+            Set<Node> ensembleNodes = new HashSet<>();
+            Set<Node> excludeNodes = new HashSet<>();
             BookieNode bn = knownBookies.get(bookieToReplace);
             if (null == bn) {
                 bn = createBookieNode(bookieToReplace);
             }
-
-            Set<Node> ensembleNodes = convertBookiesToNodes(currentEnsemble);
-            Set<Node> excludeNodes = convertBookiesToNodes(excludeBookies);
+            for (BookieId bookieId : currentEnsemble) {
+                if (bookieId.equals(bookieToReplace)) {
+                    ensembleNodes.add(bn);
+                    continue;
+                }
+                ensembleNodes.add(convertBookieToNode(bookieId));
+            }
+            for (BookieId bookieId : excludeBookies) {
+                if (bookieId.equals(bookieToReplace)) {
+                    excludeNodes.add(bn);
+                    continue;
+                }
+                excludeNodes.add(convertBookieToNode(bookieId));
+            }
 
             excludeNodes.addAll(ensembleNodes);
             excludeNodes.add(bn);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -507,7 +507,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
         try {
             excludeBookies = addDefaultRackBookiesIfMinNumRacksIsEnforced(excludeBookies);
             excludeBookies.addAll(currentEnsemble);
-    
+
             Set<Node> ensembleNodes = new HashSet<>();
             Set<Node> excludeNodes = new HashSet<>();
             BookieNode bn = knownBookies.get(bookieToReplace);
@@ -516,7 +516,6 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             }
             for (BookieId bookieId : currentEnsemble) {
                 if (bookieId.equals(bookieToReplace)) {
-                    ensembleNodes.add(bn);
                     continue;
                 }
                 ensembleNodes.add(convertBookieToNode(bookieId));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -824,9 +824,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
             if (null != historyBookie) {
                 return historyBookie.getNetworkLocation();
             }
-
-            LOG.error("Cannot resolve bookieId {} to a network address, resolving as {}", addr,
-                      NetworkTopology.DEFAULT_REGION_AND_RACK, err);
+            LOG.error("Cannot resolve bookieId {} to a network address, resolving as {}. {}", addr,
+                      NetworkTopology.DEFAULT_REGION_AND_RACK, err.getMessage());
             return NetworkTopology.DEFAULT_REGION_AND_RACK;
         }
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:
When some bookie is down, the resolver will resolve failed, it will print many logs. 

1. In RackawareEnsemblePlacementPolicyImpl#replaceBookie, reduce the repeat resolve operation.
2. In TopologyAwareEnsemblePlacementPolicy#resolveNetworkLocation, avoid to print the stack info.


