### PR TITLE
Increase journal thread priority

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -471,6 +471,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
                                 boolean enableGroupForceWrites,
                                 StatsLogger statsLogger) {
             super("ForceWriteThread");
+            this.setPriority(Thread.MAX_PRIORITY);
             this.threadToNotifyOnEx = threadToNotifyOnEx;
             this.enableGroupForceWrites = enableGroupForceWrites;
             this.forceWriteThreadTime = statsLogger.getThreadScopedCounter("force-write-thread-time");
@@ -650,6 +651,7 @@ public class Journal extends BookieCriticalThread implements CheckpointSource {
     public Journal(int journalIndex, File journalDirectory, ServerConfiguration conf,
             LedgerDirsManager ledgerDirsManager, StatsLogger statsLogger, ByteBufAllocator allocator) {
         super(journalThreadName + "-" + conf.getBookiePort());
+        this.setPriority(Thread.MAX_PRIORITY);
         this.allocator = allocator;
 
         StatsLogger journalStatsLogger = statsLogger.scopeLabel("journalIndex", String.valueOf(journalIndex));


### PR DESCRIPTION
### Motivation
When deploying Bookie on K8s with limited CPU resources, once the CPU is throttled, the journal write latency will increase.
One case of causing CPU throttle is garbage collection triggered.
![image](https://github.com/apache/bookkeeper/assets/5436568/35e4f518-7edf-4a7c-b582-586854c96171)

<img width="1711" alt="image" src="https://github.com/apache/bookkeeper/assets/5436568/26bdd6d8-a52d-4e42-a157-9cac3684e9f7">


The journal write latency is sensitive with the journal CPU, especially when the CPU is throttled.

### Modifications
Increase the JournalThread and ForceWriteThread priority to reduce the latency impaction when the CPU is being throttled.