### PR TITLE
Remove the unused logs in the CleanupLedgerManager.recordPromise

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
@@ -115,9 +115,6 @@ public class CleanupLedgerManager implements LedgerManager {
         futures.add(promise);
         promise.whenComplete((result, exception) -> {
             futures.remove(promise);
-            if (exception != null) {
-                log.error("Failed on operating ledger metadata: {}", BKException.getExceptionCode(exception));
-            }
         });
     }
 


### PR DESCRIPTION
---

### Motivation

In the cleanup ledger manager, we just record every future and remove them when the future complete. Seems we don't need to print the logs

