### PR TITLE
Fix RegionAwarePolicy can not update rackInfo between bookie left and join

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -134,7 +134,8 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
             topology.add(node);
             knownBookies.put(addr, node);
             historyBookies.put(addr, node);
-            String region = getLocalRegion(node);
+            String region = parseBookieRegion(addr);
+            address2Region.put(addr, region);
             if (null == perRegionPlacement.get(region)) {
                 perRegionPlacement.put(region, new RackawareEnsemblePlacementPolicy()
                         .initialize(dnsResolver, timer, this.reorderReadsRandom, this.stabilizePeriodSeconds,


### PR DESCRIPTION
### Motivation

When using regionAwarePolicy in pulsar, we encounter a case as following:
1. bookie shutdown, trigger handleBookiesThatLeft()
2. change bookie's rackInfo, trigger onBookieRackChange()
3. bookie start, trigger handleBookiesThatJoined()

However, the rackInfo is not updated actually, broker still write ensemble with old rackInfo. 

### Changes

1. The Hashmap "address2Region" is local variable. It should be updated in handleBookiesThatJoined()
2. add a test to verify