### PR TITLE
Cleanup layoutManager null-check when AbstractZkLedgerManagerFactory#newLedgerManagerFactory

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerFactory.java
@@ -164,12 +164,6 @@ public abstract class AbstractZkLedgerManagerFactory implements LedgerManagerFac
             throw new IOException("Empty Ledger Root Path.");
         }
 
-        // if layoutManager is null, return the default ledger manager
-        if (layoutManager == null) {
-            return new FlatLedgerManagerFactory()
-                   .initialize(conf, null, FlatLedgerManagerFactory.CUR_VERSION);
-        }
-
         LedgerManagerFactory lmFactory;
 
         // check that the configured ledger manager is

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/FlatLedgerManagerFactory.java
@@ -52,7 +52,7 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
                                            final LayoutManager layoutManager,
                                            final int factoryVersion)
     throws IOException {
-        checkArgument(layoutManager == null || layoutManager instanceof ZkLayoutManager);
+        checkArgument(layoutManager instanceof ZkLayoutManager);
 
         if (CUR_VERSION != factoryVersion) {
             throw new IOException("Incompatible layout version found : "
@@ -60,7 +60,7 @@ public class FlatLedgerManagerFactory extends AbstractZkLedgerManagerFactory {
         }
         this.conf = conf;
 
-        this.zk = layoutManager == null ? null : ((ZkLayoutManager) layoutManager).getZk();
+        this.zk = ((ZkLayoutManager) layoutManager).getZk();
         return this;
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Remove the null-check from `AbstractZkLedgerManagerFactory#newLedgerManagerFactory`. The reason is that:
1. the parameter `layoutManager` in `newLedgerManagerFactory()` method can never be null. So this check is unnecessory
2. If the `layoutManager` is null and we return  `new FlatLedgerManagerFactory().initialize(conf, null, FlatLedgerManagerFactory.CUR_VERSION)`,  the 'zk' in `FlatLedgerManagerFactory` is null and could throw NPE when invoke the methods in the `FlatLedgerManagerFactory`.


### Changes

1. Cleanup layoutManager null-check when `newLedgerManagerFactory()`
2. Let `layoutManager` could never be null in `FlatLedgerManagerFactory`

