### PR TITLE
Make AutoRecovery enable stickyReadS as default.

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -617,7 +617,7 @@ ledgerDirectories=/tmp/bk-data
 gcEntryLogMetadataCacheEnabled=false
 
 # Directory to persist Entrylog metadata if gcPersistentEntrylogMetadataMapEnabled is true
-# [Default: it creates a sub-directory under a first available base ledger directory with 
+# [Default: it creates a sub-directory under a first available base ledger directory with
 # name "entrylogIndexCache"]
 # gcEntryLogMetadataCachePath=
 
@@ -1050,6 +1050,9 @@ zkEnableSecurity=false
 #############################################################################
 ## Replication Worker settings
 #############################################################################
+
+# Enable/disable having read operations for a ledger to be sticky to a single bookie.
+stickyReadSEnabled=true
 
 # The number of entries that a replication will rereplicate in parallel.
 # rereplicationEntryBatchSize=10

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -918,7 +918,7 @@ zkEnableSecurity=false
 # latency stats rollover interval, in seconds
 # prometheusStatsLatencyRolloverSeconds=60
 
-# Expose the default JVM Metrics or not. If you are using the BookKeeper as an embedded service and you want to 
+# Expose the default JVM Metrics or not. If you are using the BookKeeper as an embedded service and you want to
 # expose metrics in your application, you might need to disable this to avoid the JVM metrics register duplicated.
 # exposeDefaultJVMMetrics=true
 
@@ -1051,8 +1051,6 @@ zkEnableSecurity=false
 ## Replication Worker settings
 #############################################################################
 
-# Enable/disable having read operations for a ledger to be sticky to a single bookie.
-stickyReadSEnabled=true
 
 # The number of entries that a replication will rereplicate in parallel.
 # rereplicationEntryBatchSize=10

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -1051,9 +1051,11 @@ zkEnableSecurity=false
 ## Replication Worker settings
 #############################################################################
 
-
 # The number of entries that a replication will rereplicate in parallel.
 # rereplicationEntryBatchSize=10
+
+# Enable/disable having read operations for a ledger to be sticky to a single bookie.
+stickyReadSEnabled=true
 
 # The grace period, in milliseconds, that the replication worker waits before fencing and
 # replicating a ledger fragment that's still being written to upon bookie failure.


### PR DESCRIPTION
### Motivation
The AutoRecovery would move the data to another alive bookie to ensure the data replicas. So it will read data from the alive bookie at the ensemble, then write the data to the new bookie.

When reading data, it will choose the bookie in the ensemble randomly, so it may choose the bookie that may be already shut down, and then print many warm logs.

If we make stickyReadSEnabled=true, it will read the data from the alive bookie continually, and won't print any warm log, and the stickyReadS can improve hit rate of the bookie server read cache, speed the read operation.
