### PR TITLE
Issue 4126: Fix a slow gc thread shutdown when compacting

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -679,6 +679,7 @@ public class GarbageCollectorThread implements Runnable {
         if (!this.running) {
             return;
         }
+        this.running = false;
         LOG.info("Shutting down GarbageCollectorThread");
 
         throttler.cancelledAcquire();
@@ -688,7 +689,6 @@ public class GarbageCollectorThread implements Runnable {
             Thread.sleep(100);
         }
 
-        this.running = false;
         // Interrupt GC executor thread
         gcExecutor.shutdownNow();
         try {


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Fix a slow gc thread shutdown when compacting.

The problem here is that the stop flag `running` has been moved after `compacting.compareAndSet`. When `running` is not set to false, entry log continues to compact one after one and the shutdown thread is hard to set the `compacting`.

### Changes

Set `running` to false first and then check `compacting`.

Master Issue: #4126