### PR TITLE
Fix no known bookies after reset racks for all BKs

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/NetworkTopologyImpl.java
@@ -505,6 +505,9 @@ public class NetworkTopologyImpl implements NetworkTopology {
                 if (rack == null) {
                     numOfRacks--;
                 }
+                if (clusterMap.numOfLeaves == 0) {
+                    depthOfAllLeaves = -1;
+                }
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("NetworkTopology became:\n" + this);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/NetworkTopologyImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/NetworkTopologyImplTest.java
@@ -66,6 +66,35 @@ public class NetworkTopologyImplTest {
   }
 
   @Test
+  public void testRestartBKWithNewRackDepth() {
+      NetworkTopologyImpl networkTopology = new NetworkTopologyImpl();
+      String dp1Rack = "/rack-1";
+      String dp2Rack = "/dp/rack-1";
+      BookieId bkId1 = BookieId.parse("bookieIdScopeRack0");
+      BookieId bkId2 = BookieId.parse("bookieIdScopeRack1");
+
+      // Register 2 BKs with depth 1 rack.
+      BookieNode dp1BkNode1 = new BookieNode(bkId1, dp1Rack);
+      BookieNode dp1BkNode2 = new BookieNode(bkId2, dp1Rack);
+      networkTopology.add(dp1BkNode1);
+      networkTopology.add(dp1BkNode2);
+
+      // Update all Bks with depth 2 rack.
+      networkTopology.remove(dp1BkNode1);
+      networkTopology.remove(dp1BkNode2);
+      BookieNode dp2BkNode1 = new BookieNode(bkId1, dp2Rack);
+      BookieNode dp2BkNode2 = new BookieNode(bkId2, dp2Rack);
+      networkTopology.add(dp2BkNode1);
+      networkTopology.add(dp2BkNode2);
+
+      // Verify update success.
+      Set<Node> leaves = networkTopology.getLeaves(dp2Rack);
+      assertTrue(leaves.size() == 2);
+      assertTrue(leaves.contains(dp2BkNode1));
+      assertTrue(leaves.contains(dp2BkNode2));
+  }
+
+  @Test
   public void getLeavesShouldReturnLeavesThatAreNotInExcludedScope() {
       // GIVEN
       // Topology with three racks and 1 bookie in each rack.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/NetworkTopologyImplTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/NetworkTopologyImplTest.java
@@ -79,17 +79,28 @@ public class NetworkTopologyImplTest {
       networkTopology.add(dp1BkNode1);
       networkTopology.add(dp1BkNode2);
 
-      // Update all Bks with depth 2 rack.
+      // Update one BK with depth 2 rack.
+      // Assert it can not be added due to different depth.
       networkTopology.remove(dp1BkNode1);
-      networkTopology.remove(dp1BkNode2);
       BookieNode dp2BkNode1 = new BookieNode(bkId1, dp2Rack);
+      try {
+          networkTopology.add(dp2BkNode1);
+          fail("Expected add node failed caused by different depth of rack");
+      } catch (NetworkTopologyImpl.InvalidTopologyException ex) {
+          // Expected ex.
+      }
+      Set<Node> leaves = networkTopology.getLeaves(dp1Rack);
+      assertEquals(leaves.size(), 1);
+      assertTrue(leaves.contains(dp1BkNode2));
+
+      // Update all Bks with depth 2 rack.
+      // Verify update success.
+      networkTopology.remove(dp1BkNode2);
       BookieNode dp2BkNode2 = new BookieNode(bkId2, dp2Rack);
       networkTopology.add(dp2BkNode1);
       networkTopology.add(dp2BkNode2);
-
-      // Verify update success.
-      Set<Node> leaves = networkTopology.getLeaves(dp2Rack);
-      assertTrue(leaves.size() == 2);
+      leaves = networkTopology.getLeaves(dp2Rack);
+      assertEquals(leaves.size(), 2);
       assertTrue(leaves.contains(dp2BkNode1));
       assertTrue(leaves.contains(dp2BkNode2));
   }


### PR DESCRIPTION
### Motivation

### Background
- `NetworkTopologyImpl` does not allow multi Bks register with different `depthOfAllLeaves.`
- Regarding `NetworkTopologyImpl,` once a node is added, the `depthOfAllLeaves` will be initiated. 
- When a new BK is registering:
  -  `EnsemblePlacementPolicy.networkTopology.add( newBkNode )`
  - `EnsemblePlacementPolicy.knownBookies.add( newBkNode )`
  - Once `network topology.add(newBkNode)` fail, it will not call `knownBookies.add( newBkNode )`

---

### The scenarios that would hit bugs.

#### Scenario 1: Reset racks for all BK nodes, for Example: 
- Register `[BK1,BK2]` with rack `/r_1`
  - `depthOfAllLeaves` is `2` now.
- Restart `[BK1,BK2]` with rack `/region_1/r_1`
  - the depth of  `/region_1/r_1` is `3`, different with `2`
  - Since `depthOfAllLeaves` of `NetworkTopologyImpl` is still `2`, `[BK1, BK2]` could not be added, and get an error `can't add leaf node BK1 at depth 3 to the topology.`

You can reproduce this by the new test `testRestartBKWithNewRackDepth.`

---

#### Scenario 2: A race condition caused `depthOfAllLeaves` to be initialized with a wrong value.

| Time | Event: `BK1 start/shutdown` | thread: `ZK main` | worker thread of `RegistrationClient`|
| --- |  --- | --- | --- |
| 1 | `BK1` start |
| 2 | | Add a node into `bkInfos` of `RegistrationClient` |
| 3 | | | Notice `EnsemblePlacementPolicy`: a node added |
| 4 | `BK1` shutdown |
| 5 | | Remove the node from `bkInfos` of `RegistrationClient,` `bkInfos` is empty now |
| 6 | | | **(Highlight)** `NetworkTopologyImpl` tries to calculate the network location but gets `null,` so use a default value `default-region/default-rack`<sup>[1]</sup> |
| 6 | | | `depthOfAllLeaves` was initialized to `3` |
| 7 | The issue occurs: the node `BK1` could not be added to `NetworkTopologyImpl` anymore |
---

**[1]**: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java#L830

```java
protected String resolveNetworkLocation(BookieId addr) {
  try {
      return NetUtils.resolveNetworkLocation(dnsResolver, bookieAddressResolver.resolve(addr));
  } catch (BookieAddressResolver.BookieIdNotResolvedException err) {
      return NetworkTopology.DEFAULT_REGION_AND_RACK; // "/default-region/default-rack"
  }
}
```

---

The above scenario will cause `EnsemblePlacementPolicy.knownBookies` to be an empty collection, leading to error `Not enough non-faulty bookies available`

### The issue below occurs on the version `4.16.3`

<img width="1424" alt="Screenshot 2023-11-09 at 23 49 17" src="https://github.com/apache/bookkeeper/assets/25195800/3cc9bf3d-bee2-4bfa-ada7-934526377b40">

<img width="1122" alt="Screenshot 2023-11-09 at 23 50 09" src="https://github.com/apache/bookkeeper/assets/25195800/1d59d45b-e14b-4e46-b7da-6a07f8928772">

```
2023-11-03T10:08:03,154+0000 [pulsar-registration-client-34-1] ERROR org.apache.bookkeeper.net.NetworkTopologyImpl - Error: can't add leaf node <Bookie:bk-9:3181> at depth 3 to topology:
2023-11-03T10:08:03,154+0000 [pulsar-registration-client-34-1] ERROR org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy - Unexpected exception while handling joining bookie bk-9:3181
	at java.lang.Thread.run(Thread.java:833) ~[?:?]	
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]	
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]	
	at org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy.handleBookiesThatJoined(TopologyAwareEnsemblePlacementPolicy.java:720) ~[org.apache.bookkeeper-bookkeeper-server-4.16.2.jar:4.16.2]	
	at org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy.onClusterChanged(TopologyAwareEnsemblePlacementPolicy.java:666) ~[org.apache.bookkeeper-bookkeeper-server-4.16.2.jar:4.16.2]	
	at org.apache.bookkeeper.net.NetworkTopologyImpl.add(NetworkTopologyImpl.java:418) ~[org.apache.bookkeeper-bookkeeper-server-4.16.2.jar:4.16.2]	
org.apache.bookkeeper.net.NetworkTopologyImpl$InvalidTopologyException: Invalid network topology. You cannot have a rack and a non-rack node at the same level of the network topology.	
Expected number of leaves:0	
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]	
	at org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy.onClusterChanged(TopologyAwareEnsemblePlacementPolicy.java:666) ~[org.apache.bookkeeper-bookkeeper-server-4.16.2.jar:4.16.2]	
	at org.apache.bookkeeper.client.BookieWatcherImpl.processWritableBookiesChanged(BookieWatcherImpl.java:196) ~[org.apache.bookkeeper-bookkeeper-server-4.16.2.jar:4.16.2]	
```

### Changes

Reset `depthOfAllLeaves` after all BKs have been removed.