### PR TITLE
Add force readonly param to RESTful API

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
@@ -62,6 +62,10 @@ public class BookieStateReadOnlyService implements HttpEndpointService {
             } else if (!stateManager.isReadOnly() && inState.isReadOnly()) {
                 stateManager.transitionToReadOnlyMode().get();
             }
+            boolean isForce = request.getParams().getOrDefault("force", "false").equals("true");
+            if (stateManager.isReadOnly() && isForce) {
+                stateManager.forceToReadOnly();
+            }
         } else if (!HttpServer.Method.GET.equals(request.getMethod())) {
             response.setCode(HttpServer.StatusCode.NOT_FOUND);
             response.setBody("Unsupported method. Should be GET or PUT method");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -1022,6 +1022,17 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         readOnlyState = JsonUtil.fromJson(response.getBody(), ReadOnlyState.class);
         assertFalse(readOnlyState.isReadOnly());
 
+        // force=true force the bookie to readonly
+        Map<String, String> params = new HashMap<>();
+        params.put("force", "true");
+        request = new HttpServiceRequest(JsonUtil.toJson(new ReadOnlyState(true)), HttpServer.Method.PUT, params);
+        response = bookieReadOnlyService.handle(request);
+        readOnlyState = JsonUtil.fromJson(response.getBody(), ReadOnlyState.class);
+        assertTrue(readOnlyState.isReadOnly());
+        request = new HttpServiceRequest(JsonUtil.toJson(new ReadOnlyState(false)), HttpServer.Method.PUT, null);
+        response = bookieReadOnlyService.handle(request);
+        assertEquals(400, response.getStatusCode());
+
         //forceReadonly to writable
         baseConf.setForceReadOnlyBookie(true);
         baseConf.setReadOnlyModeEnabled(true);


### PR DESCRIPTION

### Motivation

Allow readonly API to force bookie readonly.


> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
