### PR TITLE
Readledger command did not read data when specifying the bookie address

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
@@ -188,8 +188,11 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
                 BookieClient bookieClient = new BookieClientImpl(conf, eventLoopGroup, UnpooledByteBufAllocator.DEFAULT,
                                                                  executor, scheduler, NullStatsLogger.INSTANCE,
                                                                  bk.getBookieAddressResolver());
-
-                LongStream.range(flags.firstEntryId, lastEntry).forEach(entryId -> {
+                if (lastEntry == -1) {
+                    // If lastEntry is not specified, read the last entry from the ledger
+                    lastEntry = bk.openLedgerNoRecovery(flags.ledgerId).getLastAddConfirmed();
+                }
+                LongStream.rangeClosed(flags.firstEntryId, lastEntry).forEach(entryId -> {
                     CompletableFuture<Void> future = new CompletableFuture<>();
 
                     bookieClient.readEntry(bookie, flags.ledgerId, entryId,

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommandTest.java
@@ -54,6 +54,7 @@ public class ReadLedgerCommandTest extends BookieCommandTestBase {
     private static final BookieId bookieSocketAddress = BookieId.parse("localhost:9000");
 
     private LedgerHandle ledgerHandle;
+    private LedgerHandle ledgerHandleNoRecovery;
     private LedgerEntry entry;
     private OrderedExecutor orderedExecutor;
     private ScheduledExecutorService scheduledExecutorService;
@@ -70,11 +71,13 @@ public class ReadLedgerCommandTest extends BookieCommandTestBase {
         mockServerConfigurationConstruction();
         mockClientConfigurationConstruction();
         ledgerHandle = mock(LedgerHandle.class);
+        ledgerHandleNoRecovery = mock(LedgerHandle.class);
         entry = mock(LedgerEntry.class);
         orderedExecutor = mock(OrderedExecutor.class);
         scheduledExecutorService = mock(ScheduledExecutorService.class);
 
         when(ledgerHandle.getLastAddConfirmed()).thenReturn(1L);
+        when(ledgerHandleNoRecovery.getLastAddConfirmed()).thenReturn(-2L);
 
         List<LedgerEntry> entries = new LinkedList<>();
         entries.add(entry);
@@ -89,6 +92,7 @@ public class ReadLedgerCommandTest extends BookieCommandTestBase {
                 when(bookKeeperAdmin.getBookieAddressResolver())
                         .thenReturn(BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
                 when(bookKeeperAdmin.openLedger(anyLong())).thenReturn(ledgerHandle);
+                when(bookKeeperAdmin.openLedgerNoRecovery(anyLong())).thenReturn(ledgerHandleNoRecovery);
                 when(bookKeeperAdmin.readEntries(anyLong(), anyLong(), anyLong())).thenReturn(entries);
             }
         });


### PR DESCRIPTION
When we use the **bookkeeper shell readledger -bookie** command to read a ledger, and specifying the bookie address without specifying the entry range, no data return.
Because the lastEntry is -1 and no entry will be read.
![image](https://github.com/apache/bookkeeper/assets/2844826/c9465d5b-0be5-467a-96b8-d9e174e006da)
So, I think we should open the ledger first to get the LAC and then read the entry.