### PR TITLE
Issue 4134: Fixing memory leak error when using DirectEntryLogger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -244,6 +244,7 @@ public class DirectEntryLogger implements EntryLogger {
 
         long start = System.nanoTime();
         LogReader reader = getReader(logId);
+        
         try {
             ByteBuf buf = reader.readEntryAt(pos);
             if (validateEntry) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -244,14 +244,15 @@ public class DirectEntryLogger implements EntryLogger {
 
         long start = System.nanoTime();
         LogReader reader = getReader(logId);
-
+        ByteBuf buf = null;
         try {
-            ByteBuf buf = reader.readEntryAt(pos);
+            buf = reader.readEntryAt(pos);
             if (validateEntry) {
                 long thisLedgerId = buf.getLong(0);
                 long thisEntryId = buf.getLong(8);
                 if (thisLedgerId != ledgerId
                     || thisEntryId != entryId) {
+                    ReferenceCountUtil.release(buf);
                     throw new IOException(
                             exMsg("Bad location").kv("location", location)
                             .kv("expectedLedger", ledgerId).kv("expectedEntry", entryId)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -244,7 +244,7 @@ public class DirectEntryLogger implements EntryLogger {
 
         long start = System.nanoTime();
         LogReader reader = getReader(logId);
-        
+
         try {
             ByteBuf buf = reader.readEntryAt(pos);
             if (validateEntry) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -244,9 +244,8 @@ public class DirectEntryLogger implements EntryLogger {
 
         long start = System.nanoTime();
         LogReader reader = getReader(logId);
-        ByteBuf buf = null;
         try {
-            buf = reader.readEntryAt(pos);
+            ByteBuf buf = reader.readEntryAt(pos);
             if (validateEntry) {
                 long thisLedgerId = buf.getLong(0);
                 long thisEntryId = buf.getLong(8);


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

When we use DirectIO and a catch up read occurs, a memory leak occurs because the ByteBuf is not released. 

Because although in the `internalReadEntry` method in `DirectEntryLogger`, even if the upper layer `fillReadAheadCache` uses the `ReferenceCountUtil.release(entry)` method in the finally block to release ByteBuf, it will still cause an exception thrown by `internalReadEntry`, and the `entryLogger.readEntry` method happens to be in try. ..catch unexpected, causing ByteBuf to not be released correctly

### Changes

Master Issue: #4134 

