### PR TITLE
Issue 4136: Fix logging configurations are broken in docker image

### DIFF
--- a/docker/scripts/apply-config-from-env.py
+++ b/docker/scripts/apply-config-from-env.py
@@ -23,21 +23,28 @@
 ## based on the ENV variables
 ## export my-key=new-value
 ##
-## ./apply-config-from-env config_dir
+## ./apply-config-from-env file ...
 ##
 
 import os, sys
 
-if len(sys.argv) != 2:
-    print('Usage: %s ' + 'config_dir' % (sys.argv[0]))
+if len(sys.argv) < 2:
+    print('Usage: %s file ...' % (sys.argv[0]))
     sys.exit(1)
 
-def mylistdir(dir):
-    return [os.path.join(dir, filename) for filename in os.listdir(dir)]
+def prepare_conf_files(files):
+    conf_files = []
+    for f in files:
+        if os.path.isfile(f):
+            if not os.path.isabs(f):
+                f = os.path.join(os.getcwd(), f)
+            conf_files.append(f)
+        else:
+            print('%s is not a readable file' % f)
+            sys.exit(1)
+    return conf_files
 
-# Always apply env config to all the files under conf
-conf_dir = sys.argv[1]
-conf_files = mylistdir(conf_dir)
+conf_files = prepare_conf_files(sys.argv[1:])
 print('conf files: ')
 print(conf_files)
 

--- a/docker/scripts/common.sh
+++ b/docker/scripts/common.sh
@@ -71,7 +71,7 @@ echo "  BK_STREAM_STORAGE_ROOT_PATH is ${BK_STREAM_STORAGE_ROOT_PATH}"
 echo "  BK_NUM_STORAGE_CONTAINERS is ${BK_NUM_STORAGE_CONTAINERS}"
 echo "  BOOKIE_GRPC_PORT is ${BOOKIE_GRPC_PORT}"
 
-python scripts/apply-config-from-env.py ${BK_HOME}/conf
+python scripts/apply-config-from-env.py ${BK_HOME}/conf/*.conf
 
 export BOOKIE_CONF=${BK_HOME}/conf/bk_server.conf
 export SERVICE_PORT=${PORT0}

--- a/docker/scripts/init_zookeeper.sh
+++ b/docker/scripts/init_zookeeper.sh
@@ -63,7 +63,7 @@ function create_zk_dynamic_conf() {
 function init_zookeeper() {
 
     # apply zookeeper envs
-    python scripts/apply-config-from-env.py ${BK_HOME}/conf
+    python scripts/apply-config-from-env.py ${BK_HOME}/conf/zookeeper.conf
 
     # create dirs if they don't exist
     create_zk_dirs


### PR DESCRIPTION
### Motivation

Fix #4136 

### Changes

Modify `apply-config-from-env.py` to accept individual files as parameters instead of a configuration folder. This change will enable the script to selectively apply the configuration override mechanism only to the necessary files.
