### PR TITLE
fix calculate checkSum when using Java9IntHash

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
@@ -19,6 +19,7 @@
 package com.scurrilous.circe.checksum;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -106,6 +107,12 @@ public class Java9IntHash implements IntHash {
         } else if (buffer.hasArray()) {
             int arrayOffset = buffer.arrayOffset() + offset;
             negCrc = resume(negCrc, buffer.array(), arrayOffset, len);
+        } else if (buffer instanceof CompositeByteBuf) {
+           CompositeByteBuf compositeByteBuf = (CompositeByteBuf) buffer;
+           for (int i = 0; i < compositeByteBuf.numComponents(); i ++) {
+               negCrc = resume(~negCrc, compositeByteBuf.component(i));
+           }
+           return ~negCrc;
         } else {
             byte[] b = TL_BUFFER.get();
             int toRead = len;

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
@@ -112,7 +112,7 @@ public class Java9IntHash implements IntHash {
             int loopOffset = offset;
             while (toRead > 0) {
                 int length = Math.min(toRead, b.length);
-                buffer.slice(loopOffset, len).readBytes(b, 0, length);
+                buffer.slice(loopOffset, length).readBytes(b, 0, length);
                 negCrc = resume(negCrc, b, 0, length);
                 toRead -= length;
                 loopOffset += length;

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
@@ -109,11 +109,13 @@ public class Java9IntHash implements IntHash {
         } else {
             byte[] b = TL_BUFFER.get();
             int toRead = len;
+            int loopOffset = offset;
             while (toRead > 0) {
                 int length = Math.min(toRead, b.length);
-                buffer.slice(offset, len).readBytes(b, 0, length);
+                buffer.slice(loopOffset, len).readBytes(b, 0, length);
                 negCrc = resume(negCrc, b, 0, length);
                 toRead -= length;
+                loopOffset += length;
             }
         }
 

--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
@@ -109,10 +109,11 @@ public class Java9IntHash implements IntHash {
             negCrc = resume(negCrc, buffer.array(), arrayOffset, len);
         } else if (buffer instanceof CompositeByteBuf) {
            CompositeByteBuf compositeByteBuf = (CompositeByteBuf) buffer;
+           int loopedCurrent = current;
            for (int i = 0; i < compositeByteBuf.numComponents(); i ++) {
-               negCrc = resume(~negCrc, compositeByteBuf.component(i));
+               loopedCurrent = resume(loopedCurrent, compositeByteBuf.component(i));
            }
-           return ~negCrc;
+           return loopedCurrent;
         } else {
             byte[] b = TL_BUFFER.get();
             int toRead = len;

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
@@ -1,0 +1,113 @@
+package com.scurrilous.circe.checksum;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.DuplicatedByteBuf;
+import java.util.Random;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Test;
+
+@Slf4j
+public class Java9IntHashTest {
+
+    @Test
+    public void calculateCheckSum() {
+        Random random = new Random();
+        int hugeDataLen = 4096 * 3;
+        byte[] hugeData = new byte[hugeDataLen];
+        for (int i = 0; i < hugeDataLen; i ++) {
+            hugeData[i] = (byte) (random.nextInt() % 127);
+        }
+
+        // b_total = b1 + b2 + b3;
+        ByteBuf bTotal = ByteBufAllocator.DEFAULT.heapBuffer(6 + hugeDataLen);
+        bTotal.writeBytes(new byte[]{1,2,3,4,5,6});
+        bTotal.writeBytes(hugeData);
+        ByteBuf b1 = ByteBufAllocator.DEFAULT.heapBuffer(3);
+        b1.writeBytes(new byte[]{1,2,3});
+        ByteBuf b2 = ByteBufAllocator.DEFAULT.heapBuffer(3);
+        b2.writeBytes(new byte[]{4,5,6});
+        ByteBuf b3 = ByteBufAllocator.DEFAULT.heapBuffer(hugeDataLen);
+        b2.writeBytes(hugeData);
+
+        // Calculate: case-1.
+        int checksumRes1 = Crc32cIntChecksum.computeChecksum(bTotal);
+        log.info("checksumRes1: {}", checksumRes1);
+
+        // Calculate: case-2.
+        int b1CheckSum = Crc32cIntChecksum.computeChecksum(b1);
+        log.info("b1CheckSum: {}", b1CheckSum);
+        int checksumRes2 = Crc32cIntChecksum.resumeChecksum(b1CheckSum,
+                new CompositeByteBuf(ByteBufAllocator.DEFAULT, false, 2,  b2, b3));
+        log.info("checksumRes2: {}", checksumRes2);
+
+        // Verify: the results of both ways to calculate the checksum are same.
+        Assert.assertEquals(checksumRes1, checksumRes2);
+
+        // cleanup.
+        bTotal.release();
+        b1.release();
+        b2.release();
+        b3.release();
+    }
+
+    @Test
+    public void calculateCheckSum2() {
+        Random random = new Random();
+        int hugeDataLen = 4096 * 3;
+        byte[] hugeData = new byte[hugeDataLen];
+        for (int i = 0; i < hugeDataLen; i ++) {
+            hugeData[i] = (byte) (random.nextInt() % 127);
+        }
+
+        // b_total = b1 + b2 + b3;
+        ByteBuf bTotal = ByteBufAllocator.DEFAULT.heapBuffer(6 + hugeDataLen);
+        bTotal.writeBytes(new byte[]{1,2,3,4,5,6});
+        bTotal.writeBytes(hugeData);
+        ByteBuf b1 = ByteBufAllocator.DEFAULT.heapBuffer(3);
+        b1.writeBytes(new byte[]{1,2,3});
+        ByteBuf b2 = ByteBufAllocator.DEFAULT.heapBuffer(3);
+        b2.writeBytes(new byte[]{4,5,6});
+        ByteBuf b3 = ByteBufAllocator.DEFAULT.heapBuffer(hugeDataLen);
+        b2.writeBytes(hugeData);
+
+        // Calculate: case-1.
+        int checksumRes1 = Crc32cIntChecksum.computeChecksum(bTotal);
+        log.info("checksumRes1: {}", checksumRes1);
+
+        // Calculate: case-2.
+        int b1CheckSum = Crc32cIntChecksum.computeChecksum(b1);
+        log.info("b1CheckSum: {}", b1CheckSum);
+        int checksumRes2 = Crc32cIntChecksum.resumeChecksum(b1CheckSum,
+                new NoArrayNoMemoryAddrByteBuff(new CompositeByteBuf(ByteBufAllocator.DEFAULT, false, 2,  b2, b3)));
+        log.info("checksumRes2: {}", checksumRes2);
+
+        // Verify: the results of both ways to calculate the checksum are same.
+        Assert.assertEquals(checksumRes1, checksumRes2);
+
+        // cleanup.
+        bTotal.release();
+        b1.release();
+        b2.release();
+        b3.release();
+    }
+
+    public static class NoArrayNoMemoryAddrByteBuff extends DuplicatedByteBuf {
+
+        public NoArrayNoMemoryAddrByteBuff(ByteBuf buffer) {
+            super(buffer);
+        }
+
+        @Override
+        public boolean hasArray(){
+            return false;
+        }
+
+        @Override
+        public boolean hasMemoryAddress(){
+            return false;
+        }
+    }
+}

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
@@ -35,7 +35,7 @@ public class Java9IntHashTest {
     }
 
     @Test
-    public void calculateCheckSum() {
+    public void calculateCheckSumUsingCompositeByteBuf() {
         // byteBuffers[0] = byteBuffers[1] + byteBuffers[2].
         // byteBuffers[2] is a composite ByteBuf.
         ByteBuf[] byteBuffers = generateByteBuffers();
@@ -60,7 +60,7 @@ public class Java9IntHashTest {
     }
 
     @Test
-    public void calculateCheckSumUsingNoArrayNoMemoryAddrData() {
+    public void calculateCheckSumUsingNoArrayNoMemoryAddrByteBuf() {
         // byteBuffers[0] = byteBuffers[1] + byteBuffers[2].
         // byteBuffers[2] is a composite ByteBuf.
         ByteBuf[] byteBuffers = generateByteBuffers();

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
@@ -47,7 +47,7 @@ public class Java9IntHashTest {
         ByteBuf b2 = ByteBufAllocator.DEFAULT.heapBuffer(3);
         b2.writeBytes(new byte[]{4,5,6});
         ByteBuf b3 = ByteBufAllocator.DEFAULT.heapBuffer(hugeDataLen);
-        b2.writeBytes(hugeData);
+        b3.writeBytes(hugeData);
 
         return new ByteBuf[]{bTotal, b1, new CompositeByteBuf(ByteBufAllocator.DEFAULT, false, 2,  b2, b3)};
     }

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.scurrilous.circe.checksum;
 
 import io.netty.buffer.ByteBuf;


### PR DESCRIPTION
### Motivation

In the method `Java9IntHash.resume(int current, ByteBuf buffer, int offset, int len)`, It tries to read all the data batch an batch, and finally to calculate `checksum`. But it forgets to forward the `offset` of the `ByteBuf`.

https://github.com/apache/bookkeeper/blob/master/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java#L110-L117

```java
byte[] b = TL_BUFFER.get();
int toRead = len;
while (toRead > 0) {
    int length = Math.min(toRead, b.length);
    buffer.slice(offset, len).readBytes(b, 0, length); // Here, the variable `offset` never change.
    negCrc = resume(negCrc, b, 0, length);
    toRead -= length;
}
```

The log of issue:

```
2023-12-01T08:16:58,235+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,241+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,247+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,254+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,260+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,266+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,273+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,279+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,285+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,292+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,298+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,304+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,310+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,317+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,323+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,329+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
2023-12-01T08:16:58,336+0000 [pulsar-io-8-5] ERROR org.apache.pulsar.broker.service.Producer - [PersistentTopic{topic=persistent://x/x/x}] [pulsar.repl.c1-->c2] Failed to verify checksum
```

<img width="836" alt="Screenshot 2023-12-02 at 06 35 22" src="https://github.com/apache/bookkeeper/assets/25195800/fc607f85-0012-48ba-a90e-b383ef4f5881">


### Changes

- Fix the bug.
- Improve for the ByteBuf typed CompositeByteBuf
