### PR TITLE
Cleanup logfileHeader  in DefaultEntryLogger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -255,8 +255,6 @@ public class DefaultEntryLogger implements EntryLogger {
      * </pre>
      */
     static final int LOGFILE_HEADER_SIZE = 1024;
-    final ByteBuf logfileHeader = Unpooled.buffer(LOGFILE_HEADER_SIZE);
-
     static final int HEADER_VERSION_POSITION = 4;
     static final int LEDGERS_MAP_OFFSET_POSITION = HEADER_VERSION_POSITION + 4;
 
@@ -327,15 +325,6 @@ public class DefaultEntryLogger implements EntryLogger {
         if (listener != null) {
             addListener(listener);
         }
-
-        // Initialize the entry log header buffer. This cannot be a static object
-        // since in our unit tests, we run multiple Bookies and thus EntryLoggers
-        // within the same JVM. All of these Bookie instances access this header
-        // so there can be race conditions when entry logs are rolled over and
-        // this header buffer is cleared before writing it into the new logChannel.
-        logfileHeader.writeBytes("BKLO".getBytes(UTF_8));
-        logfileHeader.writeInt(HEADER_CURRENT_VERSION);
-        logfileHeader.writerIndex(LOGFILE_HEADER_SIZE);
 
         // Find the largest logId
         long logId = INVALID_LID;


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Cleanup `logfileHeader`  in `DefaultEntryLogger`.   There is no place to invoke `DefaultEntryLogger#logfileHeader` to write,  and the `logfileHeader` has moved to `EntryLoggerAllocator`:

https://github.com/apache/bookkeeper/blob/a842f3e92cbe7c9a99f72567af19b8f7c4ce7e82/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java#L66

https://github.com/apache/bookkeeper/blob/a842f3e92cbe7c9a99f72567af19b8f7c4ce7e82/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java#L79-L87

https://github.com/apache/bookkeeper/blob/a842f3e92cbe7c9a99f72567af19b8f7c4ce7e82/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java#L170-L171



### Changes

Cleanup `logfileHeader`  in `DefaultEntryLogger`

