### PR TITLE
FastTimer to return rates if queried at the same second as update

### DIFF
--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/FastTimer.java
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/main/java/org/apache/bookkeeper/stats/codahale/FastTimer.java
@@ -477,8 +477,9 @@ public class FastTimer extends Timer {
      */
     public double getRate(int seconds) {
         seconds = Math.min(seconds, timeWindow - 2);
-        int t = getNow(getHash()) - 1; // start from last completed second
-        int secFrom = t - seconds;
+        int t = getNow(getHash());
+        // start from last completed second
+        int secFrom = t - seconds - 1;
         long sum = 0;
         for (int h = 0; h < HASH_SIZE; h++) {
             for (int i = t; i > secFrom; i--) {

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/test/java/org/apache/bookkeeper/stats/codahale/FastTimerTest.java
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/src/test/java/org/apache/bookkeeper/stats/codahale/FastTimerTest.java
@@ -17,6 +17,7 @@
 package org.apache.bookkeeper.stats.codahale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.codahale.metrics.Snapshot;
 import java.util.ArrayList;
@@ -51,6 +52,17 @@ public class FastTimerTest {
             }
         };
     }
+
+    @Test
+    public void testMeanRate() {
+        FastTimer t = getMockedFastTimer(1, FastTimer.Buckets.fine);
+
+        t.update(10, TimeUnit.NANOSECONDS);
+        assertTrue("should calculate mean before advancing time", t.getMeanRate() > 0);
+
+        incSec();
+        assertTrue("should calculate mean after advancing time", t.getMeanRate() > 0);
+   }
 
     @Test
     public void testBuckets() {


### PR DESCRIPTION
### Motivation

FastTimer returns zero rate if rate call happens immediately after the first timer update. E.g. this test would fail:

```java
        FastTimer t = new FastTimer();
        t.update(10, TimeUnit.NANOSECONDS);
        assertTrue("should calculate mean before advancing time", t.getMeanRate() > 0);
```

### Changes

Fixed + added a test


