### PR TITLE
[fix][conf-stats] Fix default configuration 'statsProviderClass'

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -883,10 +883,10 @@ zkEnableSecurity=false
 #############################################################################
 
 # Whether statistics are enabled
-enableStatistics=true
+# enableStatistics=true
 
 # Flag to enable sanity check metrics in bookie stats
-sanityCheckMetricsEnabled=false
+# sanityCheckMetricsEnabled=false
 
 # The flag to enable recording task execution stats.
 # enableTaskExecutionStats=false

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -883,10 +883,10 @@ zkEnableSecurity=false
 #############################################################################
 
 # Whether statistics are enabled
-# enableStatistics=true
+enableStatistics=true
 
 # Flag to enable sanity check metrics in bookie stats
-# sanityCheckMetricsEnabled=false
+sanityCheckMetricsEnabled=false
 
 # The flag to enable recording task execution stats.
 # enableTaskExecutionStats=false
@@ -900,7 +900,7 @@ zkEnableSecurity=false
 #
 # For configuring corresponding stats provider, see details at each section below.
 #
-# statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 
 #############################################################################
 ## Prometheus Metrics Provider


### PR DESCRIPTION
https://bookkeeper.apache.org/docs/reference/config/#statistics

Descriptions of the changes in this PR:
![image](https://github.com/apache/bookkeeper/assets/18533252/1036b9df-1308-4da2-bfe1-57af88f94181)



### Motivation
The default configuration declared on the bookkeeper.apache.org website has been annotated and is invalid

### Changes

Master Issue: #4154
