### PR TITLE
Upgrade Netty to 4.1.104.Final and io_uring to 0.0.24.Final

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -217,17 +217,17 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar [11]
-- lib/io.netty-netty-common-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.94.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.94.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
+- lib/io.netty-netty-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -235,13 +235,13 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.21.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -360,7 +360,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.94.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -404,9 +404,9 @@ Apache Software License, Version 2.
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.94.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -415,7 +415,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -423,7 +423,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -431,7 +431,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -439,7 +439,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -449,7 +449,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -457,7 +457,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -466,7 +466,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -474,7 +474,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -482,7 +482,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -490,7 +490,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -498,7 +498,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -506,7 +506,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -514,7 +514,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -522,7 +522,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -531,7 +531,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -539,7 +539,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -547,7 +547,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -555,7 +555,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -563,7 +563,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -571,7 +571,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -579,7 +579,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -587,7 +587,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -595,7 +595,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -603,7 +603,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -612,7 +612,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -620,7 +620,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -217,15 +217,15 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar [11]
-- lib/io.netty-netty-common-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.94.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
+- lib/io.netty-netty-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -233,13 +233,13 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.21.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [16]
@@ -303,7 +303,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.94.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -335,9 +335,9 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.94.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -346,7 +346,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -354,7 +354,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -362,7 +362,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -370,7 +370,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -380,7 +380,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -388,7 +388,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -397,7 +397,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -405,7 +405,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -413,7 +413,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -421,7 +421,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -429,7 +429,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -437,7 +437,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -445,7 +445,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -453,7 +453,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -462,7 +462,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -470,7 +470,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -478,7 +478,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -486,7 +486,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -494,7 +494,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -502,7 +502,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -510,7 +510,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -518,7 +518,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -526,7 +526,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -534,7 +534,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -543,7 +543,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -551,7 +551,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -217,17 +217,17 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar [11]
-- lib/io.netty-netty-common-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.94.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.94.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.94.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
+- lib/io.netty-netty-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -235,13 +235,13 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.21.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -356,7 +356,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.94.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -399,9 +399,9 @@ Apache Software License, Version 2.
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.94.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -410,7 +410,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -418,7 +418,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -426,7 +426,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -434,7 +434,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -444,7 +444,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -452,7 +452,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -461,7 +461,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -469,7 +469,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -477,7 +477,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -485,7 +485,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -493,7 +493,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -501,7 +501,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -509,7 +509,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -517,7 +517,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -526,7 +526,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -534,7 +534,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -542,7 +542,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -550,7 +550,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -558,7 +558,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -566,7 +566,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -574,7 +574,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -582,7 +582,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -590,7 +590,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -598,7 +598,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -607,7 +607,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -615,7 +615,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.94.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,17 +23,17 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.94.Final.jar
-- lib/io.netty-netty-codec-4.1.94.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar
-- lib/io.netty-netty-common-4.1.94.Final.jar
-- lib/io.netty-netty-handler-4.1.94.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar
-- lib/io.netty-netty-resolver-4.1.94.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.94.Final.jar
+- lib/io.netty-netty-buffer-4.1.104.Final.jar
+- lib/io.netty-netty-codec-4.1.104.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
+- lib/io.netty-netty-common-4.1.104.Final.jar
+- lib/io.netty-netty-handler-4.1.104.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
+- lib/io.netty-netty-resolver-4.1.104.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -41,12 +41,12 @@ LongAdder), which was released with the following comments:
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.94.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar
+- lib/io.netty-netty-transport-4.1.104.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,15 +5,15 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.94.Final.jar
-- lib/io.netty-netty-codec-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar
-- lib/io.netty-netty-common-4.1.94.Final.jar
-- lib/io.netty-netty-handler-4.1.94.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar
-- lib/io.netty-netty-resolver-4.1.94.Final.jar
+- lib/io.netty-netty-buffer-4.1.104.Final.jar
+- lib/io.netty-netty-codec-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
+- lib/io.netty-netty-common-4.1.104.Final.jar
+- lib/io.netty-netty-handler-4.1.104.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
+- lib/io.netty-netty-resolver-4.1.104.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -21,12 +21,12 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.94.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar
+- lib/io.netty-netty-transport-4.1.104.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,17 +5,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.94.Final.jar
-- lib/io.netty-netty-codec-4.1.94.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http-4.1.94.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.94.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.94.Final.jar
-- lib/io.netty-netty-common-4.1.94.Final.jar
-- lib/io.netty-netty-handler-4.1.94.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.94.Final.jar
-- lib/io.netty-netty-resolver-4.1.94.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.94.Final.jar
+- lib/io.netty-netty-buffer-4.1.104.Final.jar
+- lib/io.netty-netty-codec-4.1.104.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http-4.1.104.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
+- lib/io.netty-netty-common-4.1.104.Final.jar
+- lib/io.netty-netty-handler-4.1.104.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
+- lib/io.netty-netty-resolver-4.1.104.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -23,12 +23,12 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.94.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.94.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.94.Final.jar
+- lib/io.netty-netty-transport-4.1.104.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
 
 
                             The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -152,9 +152,9 @@
     <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
-    <netty.version>4.1.94.Final</netty.version>
+    <netty.version>4.1.104.Final</netty.version>
     <netty-boringssl.version>2.0.61.Final</netty-boringssl.version>
-    <netty-iouring.version>0.0.21.Final</netty-iouring.version>
+    <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>
     <prometheus.version>0.15.0</prometheus.version>


### PR DESCRIPTION
### Motivation

Keep Netty and Netty's io_uring libraries up-to-date. 

Release notes since last upgrades:
Netty:
- https://netty.io/news/2023/12/15/4-1-104-Final.html
- https://netty.io/news/2023/12/13/4-1-103-Final.html
- https://netty.io/news/2023/11/09/4-1-101-Final.html
- https://netty.io/news/2023/10/10/4-1-100-Final.html
- https://netty.io/news/2023/09/21/4-1-99-Final.html
- https://netty.io/news/2023/09/21/4-1-98-Final.html
- https://netty.io/news/2023/08/23/4-1-97-Final.html
- https://netty.io/news/2023/07/27/4-1-96-Final.html
- https://netty.io/news/2023/07/20/4-1-95-Final.html
io_uring: 
- https://netty.io/news/2023/11/17/io_uring_0-0-24-Final.html
- https://netty.io/news/2023/10/02/multiple_releases_incubator.html

### Changes

- Upgrade Netty to 4.1.103.Final (from 4.1.94.Final)
- Upgrade Netty io_uring to 0.0.24.Final (from 0.0.21.Final)
