### PR TITLE
[Improvement] skip read rebundunct content when scanning entry log.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLogCompactor.java
@@ -91,7 +91,7 @@ public class EntryLogCompactor extends AbstractLogCompactor {
                 }
 
                 @Override
-                public void process(final long ledgerId, long offset, ByteBuf entry) throws IOException {
+                public void process(final long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                     throttler.acquire(entry.readableBytes());
 
                     if (offsets.size() > maxOutstandingRequests) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
@@ -141,7 +141,7 @@ public class InterleavedStorageRegenerateIndexOp {
 
                 @Override
                 public int getLengthToRead() {
-                    return EntryLogScanner.READ_ENTRY_ID;
+                    return EntryLogScanner.READ_LEDGER_ENTRY_ID;
                 }
             });
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedStorageRegenerateIndexOp.java
@@ -114,7 +114,7 @@ public class InterleavedStorageRegenerateIndexOp {
             LOG.info("Scanning {}", entryLogId);
             entryLogger.scanEntryLog(entryLogId, new EntryLogScanner() {
                 @Override
-                public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+                public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                     long entryId = entry.getLong(8);
 
                     stats.computeIfAbsent(ledgerId, (ignore) -> new RecoveryStats()).registerEntry(entryId);
@@ -137,6 +137,11 @@ public class InterleavedStorageRegenerateIndexOp {
                 @Override
                 public boolean accept(long ledgerId) {
                     return ledgerIds.contains(ledgerId);
+                }
+
+                @Override
+                public int getLengthToRead() {
+                    return EntryLogScanner.READ_ENTRY_ID;
                 }
             });
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -330,7 +330,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
 
                 @Override
                 public int getLengthToRead() {
-                    return EntryLogScanner.READ_LEDGER_ENTRY_ID
+                    return EntryLogScanner.READ_LEDGER_ENTRY_ID;
                 }
             });
             LOG.info("Recovered {} entry locations from compacted log {}", offsets.size(), compactionLog.getDstLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/TransactionalEntryLogCompactor.java
@@ -169,7 +169,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                 }
 
                 @Override
-                public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+                public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                     throttler.acquire(entry.readableBytes());
                     synchronized (TransactionalEntryLogCompactor.this) {
                         long lid = entry.getLong(entry.readerIndex());
@@ -315,7 +315,7 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                 }
 
                 @Override
-                public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+                public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                     long lid = entry.getLong(entry.readerIndex());
                     long entryId = entry.getLong(entry.readerIndex() + 8);
                     if (lid != ledgerId || entryId < -1) {
@@ -326,6 +326,11 @@ public class TransactionalEntryLogCompactor extends AbstractLogCompactor {
                     }
                     long location = (compactionLog.getDstLogId() << 32L) | (offset + 4);
                     offsets.add(new EntryLocation(lid, entryId, location));
+                }
+
+                @Override
+                public int getLengthToRead() {
+                    return EntryLogScanner.READ_LEDGER_ENTRY_ID
                 }
             });
             LOG.info("Recovered {} entry locations from compacted log {}", offsets.size(), compactionLog.getDstLogId());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogScanner.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogScanner.java
@@ -27,6 +27,11 @@ import java.io.IOException;
  * Scan entries in a entry log file.
  */
 public interface EntryLogScanner {
+    public static final int READ_ALL = Integer.MAX_VALUE;
+    public static final int READ_NOTHING = 0;
+    public static final int READ_ENTRY_ID = 8;
+    public static final int READ_LEDGER_ENTRY_ID = 16;
+
     /**
      * Tests whether or not the entries belongs to the specified ledger
      * should be processed.
@@ -48,5 +53,9 @@ public interface EntryLogScanner {
      *          Entry ByteBuf
      * @throws IOException
      */
-    void process(long ledgerId, long offset, ByteBuf entry) throws IOException;
+    void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException;
+
+    default int getLengthToRead(){
+        return READ_ALL;
+    }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogScanner.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogScanner.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 public interface EntryLogScanner {
     public static final int READ_ALL = Integer.MAX_VALUE;
     public static final int READ_NOTHING = 0;
-    public static final int READ_ENTRY_ID = 8;
     public static final int READ_LEDGER_ENTRY_ID = 16;
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -423,17 +423,22 @@ public class DirectEntryLogger implements EntryLogger {
         // Read through the entry log file and extract the entry log meta
         scanEntryLog(logId, new EntryLogScanner() {
             @Override
-            public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+            public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                 // add new entry size of a ledger to entry log meta
                 if (throttler != null) {
                     throttler.acquire(entry.readableBytes());
                 }
-                meta.addLedgerSize(ledgerId, entry.readableBytes() + Integer.BYTES);
+                meta.addLedgerSize(ledgerId, entrySize + Integer.BYTES);
             }
 
             @Override
             public boolean accept(long ledgerId) {
                 return ledgerId >= 0;
+            }
+
+            @Override
+            public int getLengthToRead() {
+                return EntryLogScanner.READ_NOTHING;
             }
         });
         return meta;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgersIndexRebuildOp.java
@@ -162,7 +162,7 @@ public class LedgersIndexRebuildOp {
         for (long entryLogId : entryLogs) {
             entryLogger.scanEntryLog(entryLogId, new EntryLogScanner() {
                 @Override
-                public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+                public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                     if (ledgers.add(ledgerId)) {
                         if (verbose) {
                             LOG.info("Found ledger {} in entry log", ledgerId);
@@ -173,6 +173,11 @@ public class LedgersIndexRebuildOp {
                 @Override
                 public boolean accept(long ledgerId) {
                     return true;
+                }
+
+                @Override
+                public int getLengthToRead() {
+                    return EntryLogScanner.READ_NOTHING;
                 }
             });
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildOp.java
@@ -138,7 +138,7 @@ public class LocationsIndexRebuildOp {
 
                     @Override
                     public int getLengthToRead() {
-                        return EntryLogScanner.READ_ENTRY_ID;
+                        return EntryLogScanner.READ_LEDGER_ENTRY_ID;
                     }
                 });
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationsIndexRebuildOp.java
@@ -100,7 +100,7 @@ public class LocationsIndexRebuildOp {
             for (long entryLogId : entryLogs) {
                 entryLogger.scanEntryLog(entryLogId, new EntryLogScanner() {
                     @Override
-                    public void process(long ledgerId, long offset, ByteBuf entry) throws IOException {
+                    public void process(long ledgerId, long offset, ByteBuf entry, int entrySize) throws IOException {
                         long entryId = entry.getLong(8);
 
                         // Actual location indexed is pointing past the entry size
@@ -134,6 +134,11 @@ public class LocationsIndexRebuildOp {
                     @Override
                     public boolean accept(long ledgerId) {
                         return activeLedgers.contains(ledgerId);
+                    }
+
+                    @Override
+                    public int getLengthToRead() {
+                        return EntryLogScanner.READ_ENTRY_ID;
                     }
                 });
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogCommand.java
@@ -184,12 +184,11 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
 
             @Override
-            public void process(long ledgerId, long entryStartPos, ByteBuf entry) throws IOException {
+            public void process(long ledgerId, long entryStartPos, ByteBuf entry, int entrySize) throws IOException {
                 if (!stopScanning.booleanValue()) {
                     if ((rangeEndPos != -1) && (entryStartPos > rangeEndPos)) {
                         stopScanning.setValue(true);
                     } else {
-                        int entrySize = entry.readableBytes();
                         /**
                          * entrySize of an entry (inclusive of payload and
                          * header) value is stored as int value in log file, but
@@ -256,7 +255,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
 
             @Override
-            public void process(long candidateLedgerId, long startPos, ByteBuf entry) {
+            public void process(long candidateLedgerId, long startPos, ByteBuf entry, int entrySize) {
                 long entrysLedgerId = entry.getLong(entry.readerIndex());
                 long entrysEntryId = entry.getLong(entry.readerIndex() + 8);
                 if ((candidateLedgerId == entrysLedgerId) && (candidateLedgerId == ledgerId)
@@ -289,7 +288,7 @@ public class ReadLogCommand extends BookieCommand<ReadLogCommand.ReadLogFlags> {
             }
 
             @Override
-            public void process(long ledgerId, long startPos, ByteBuf entry) {
+            public void process(long ledgerId, long startPos, ByteBuf entry, int entrySize) {
                 FormatUtil.formatEntry(startPos, entry, printMsg, ledgerIdFormatter, entryFormatter);
             }
         });


### PR DESCRIPTION
Descriptions of the changes in this PR:
Remove the rebundunt disk read when scannig the entry log file, which could reduce the pressure of disk a lot.


### Motivation
We have `org.apache.bookkeeper.bookie.storage.EntryLogScanner` to process the entry data when scanning the entry log file, in which `process` method is used to process the entry data.
We have a lot of implementations for `EntryLogScanner` for various reason.
<img width="977" alt="image" src="https://github.com/apache/bookkeeper/assets/52550727/c096d601-1483-4944-ac10-d98828c9ed0f">
But some of them do not need to access all data in the entry log file.
For example:
- scanner implemented in method `extractEntryLogMetadataByScanning` only need to know the `entrySize` field, in such case we do not need to read any data in the entry.
- scanner implemented in method `org.apache.bookkeeper.bookie.InterleavedStorageRegenerateIndexOp#initiate` only need to know the `entryId` field, in such case we only need to read the first 16 bytes(ledgerId+entryId).
- many more simillar situations...

So, we **do not need to read the entry data when scanning the entry log in some cases.**


### Changes

Add method `getLengthToRead` in `EntryLogScanner` to indicate how much data do we need to read, and read this mount of data only.
