### PR TITLE
[improve][stats] Enhance bookie metrics to support URL parameter filtering

### DIFF
--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/StatsProvider.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/StatsProvider.java
@@ -48,6 +48,16 @@ public interface StatsProvider {
     }
 
     /**
+     *
+     * @param writer
+     * @param filterRegexStr
+     * @throws IOException
+     */
+    default void writeAllMetrics(Writer writer, String filterRegexStr) throws IOException {
+        throw new UnsupportedOperationException("writeAllMetrics is not implemented yet");
+    }
+
+    /**
      * Return the stats logger to a given <i>scope</i>.
      * @param scope
      *          Scope for the given stats

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusMetricsProvider.java
@@ -179,11 +179,27 @@ public class PrometheusMetricsProvider implements StatsProvider {
     public void writeAllMetrics(Writer writer) throws IOException {
         PrometheusTextFormat prometheusTextFormat = new PrometheusTextFormat();
         PrometheusTextFormat.writeMetricsCollectedByPrometheusClient(writer, registry);
-
         gauges.forEach((sc, gauge) -> prometheusTextFormat.writeGauge(writer, sc.getScope(), gauge));
         counters.forEach((sc, counter) -> prometheusTextFormat.writeCounter(writer, sc.getScope(), counter));
         opStats.forEach((sc, opStatLogger) ->
                 prometheusTextFormat.writeOpStat(writer, sc.getScope(), opStatLogger));
+    }
+
+    @Override
+    public void writeAllMetrics(Writer writer, String filterRegexStr) throws IOException {
+        PrometheusTextFormat prometheusTextFormat = new PrometheusTextFormat();
+        PrometheusTextFormat.writeMetricsCollectedByPrometheusClient(writer, registry);
+        gauges.entrySet().stream()
+                .filter(entry -> entry.getKey().getScope().matches(filterRegexStr))
+                .forEach(entry -> prometheusTextFormat.writeGauge(writer, entry.getKey().getScope(), entry.getValue()));
+
+        counters.entrySet().stream()
+                .filter(entry -> entry.getKey().getScope().matches(filterRegexStr))
+                .forEach(entry -> prometheusTextFormat.writeCounter(writer, entry.getKey().getScope(), entry.getValue()));
+
+        opStats.entrySet().stream()
+                .filter(entry -> entry.getKey().getScope().matches(filterRegexStr))
+                .forEach(entry -> prometheusTextFormat.writeOpStat(writer, entry.getKey().getScope(), entry.getValue()));
     }
 
     @Override

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusServlet.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/PrometheusServlet.java
@@ -17,6 +17,8 @@
 package org.apache.bookkeeper.stats.prometheus;
 
 import io.prometheus.client.exporter.common.TextFormat;
+import org.apache.commons.lang.StringUtils;
+
 import java.io.IOException;
 import java.io.Writer;
 import javax.servlet.ServletException;
@@ -40,10 +42,15 @@ public class PrometheusServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType(TextFormat.CONTENT_TYPE_004);
+        String m_regex = req.getParameter("m_regex");
 
         Writer writer = resp.getWriter();
         try {
-            provider.writeAllMetrics(writer);
+            if (StringUtils.isNotBlank(m_regex)) {
+                provider.writeAllMetrics(writer, m_regex);
+            } else {
+                provider.writeAllMetrics(writer);
+            }
             writer.flush();
         } finally {
             writer.close();


### PR DESCRIPTION
### Motivation
Allow filtering of metrics using URL parameters, for example:

/metrics?m_regex=bookkeeper_server_thread_executor_queue
/metrics?m_regex=.*_thread_executor_queue

Master Issue: #4143 