### PR TITLE
Fix race condition in LedgerHandle in drainPendingAddsAndAdjustLength & sendAddSuccessCallbacks

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1827,14 +1827,6 @@ public class LedgerHandle implements WriteHandle {
                     }
                     return;
                 }
-                // Check if it is the next entry in the sequence.
-                if (pendingAddOp.entryId != 0 && pendingAddOp.entryId != pendingAddsSequenceHead + 1) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Head of the queue entryId: {} is not the expected value: {}", pendingAddOp.entryId,
-                                pendingAddsSequenceHead + 1);
-                    }
-                    return;
-                }
 
                 pendingAddOps.remove();
                 explicitLacFlushPolicy.updatePiggyBackedLac(lastAddConfirmed);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -163,7 +163,7 @@ public class LedgerHandle implements WriteHandle {
     public static final long INVALID_LEDGER_ID = -0xABCDABCDL;
 
     final Object metadataLock = new Object();
-    boolean changingEnsemble = false;
+    volatile boolean changingEnsemble = false;
     final AtomicInteger numEnsembleChanges = new AtomicInteger(0);
     Queue<PendingAddOp> pendingAddOps;
     ExplicitLacFlushPolicy explicitLacFlushPolicy;
@@ -557,7 +557,7 @@ public class LedgerHandle implements WriteHandle {
                         pendingAdds = drainPendingAddsAndAdjustLength();
 
                         // taking the length must occur after draining, as draining changes the length
-                        lastEntry = lastAddPushed = LedgerHandle.this.lastAddConfirmed;
+                        lastEntry = lastAddPushed = pendingAddsSequenceHead = LedgerHandle.this.lastAddConfirmed;
                         finalLength = LedgerHandle.this.length;
                         handleState = HandleState.CLOSED;
                     }
@@ -1791,13 +1791,17 @@ public class LedgerHandle implements WriteHandle {
     }
 
     synchronized List<PendingAddOp> drainPendingAddsAndAdjustLength() {
-        PendingAddOp pendingAddOp;
-        List<PendingAddOp> opsDrained = new ArrayList<PendingAddOp>(pendingAddOps.size());
-        while ((pendingAddOp = pendingAddOps.poll()) != null) {
-            addToLength(-pendingAddOp.entryLength);
-            opsDrained.add(pendingAddOp);
+        // synchronize on pendingAddOps to ensure that sendAddSuccessCallbacks isn't concurrently
+        // modifying pendingAddOps
+        synchronized (pendingAddOps) {
+            PendingAddOp pendingAddOp;
+            List<PendingAddOp> opsDrained = new ArrayList<PendingAddOp>(pendingAddOps.size());
+            while ((pendingAddOp = pendingAddOps.poll()) != null) {
+                addToLength(-pendingAddOp.entryLength);
+                opsDrained.add(pendingAddOp);
+            }
+            return opsDrained;
         }
-        return opsDrained;
     }
 
     void errorOutPendingAdds(int rc, List<PendingAddOp> ops) {
@@ -1809,33 +1813,38 @@ public class LedgerHandle implements WriteHandle {
     void sendAddSuccessCallbacks() {
         // Start from the head of the queue and proceed while there are
         // entries that have had all their responses come back
-        PendingAddOp pendingAddOp;
 
-        while ((pendingAddOp = pendingAddOps.peek()) != null
-               && !changingEnsemble) {
-            if (!pendingAddOp.completed) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("pending add not completed: {}", pendingAddOp);
+        // synchronize on pendingAddOps to ensure that drainPendingAddsAndAdjustLength isn't concurrently
+        // modifying pendingAddOps
+        synchronized (pendingAddOps) {
+            PendingAddOp pendingAddOp;
+
+            while ((pendingAddOp = pendingAddOps.peek()) != null
+                    && !changingEnsemble) {
+                if (!pendingAddOp.completed) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("pending add not completed: {}", pendingAddOp);
+                    }
+                    return;
                 }
-                return;
-            }
-            // Check if it is the next entry in the sequence.
-            if (pendingAddOp.entryId != 0 && pendingAddOp.entryId != pendingAddsSequenceHead + 1) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Head of the queue entryId: {} is not the expected value: {}", pendingAddOp.entryId,
-                               pendingAddsSequenceHead + 1);
+                // Check if it is the next entry in the sequence.
+                if (pendingAddOp.entryId != 0 && pendingAddOp.entryId != pendingAddsSequenceHead + 1) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Head of the queue entryId: {} is not the expected value: {}", pendingAddOp.entryId,
+                                pendingAddsSequenceHead + 1);
+                    }
+                    return;
                 }
-                return;
-            }
 
-            pendingAddOps.remove();
-            explicitLacFlushPolicy.updatePiggyBackedLac(lastAddConfirmed);
-            pendingAddsSequenceHead = pendingAddOp.entryId;
-            if (!writeFlags.contains(WriteFlag.DEFERRED_SYNC)) {
-                this.lastAddConfirmed = pendingAddsSequenceHead;
-            }
+                pendingAddOps.remove();
+                explicitLacFlushPolicy.updatePiggyBackedLac(lastAddConfirmed);
+                pendingAddsSequenceHead = pendingAddOp.entryId;
+                if (!writeFlags.contains(WriteFlag.DEFERRED_SYNC)) {
+                    this.lastAddConfirmed = pendingAddsSequenceHead;
+                }
 
-            pendingAddOp.submitCallback(BKException.Code.OK);
+                pendingAddOp.submitCallback(BKException.Code.OK);
+            }
         }
 
     }


### PR DESCRIPTION
### Motivation

There's a race condition in LedgerHandle between drainPendingAddsAndAdjustLength & sendAddSuccessCallbacks method calls. The methods could get called simultaneously which would cause inconsistency. 
The changingEnsemble field has a thread safety issue and the changes might not be visible to the reading thread.

### Changes

- use `synchronized (pendingAddOps)` as the object monitor for serializing drainPendingAddsAndAdjustLength & sendAddSuccessCallbacks method calls.
- make changingEnsemble field volatile
- remove the too strict rule for pendingAddsSequenceHead which breaks things after failures

This rule is removed:
https://github.com/apache/bookkeeper/blob/13e7efaa971cd3613b065ac50836c5ee98985d13/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L1822-L1829
The current assumption is that this doesn't hold under failure conditions.

### Additional Context

- this is an alternative fix for https://github.com/apache/pulsar/issues/21860 
- the other fix is #4171