### PR TITLE
[improve] Support specifying multiple journalDir as bookie start command parameters

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -61,7 +61,9 @@ public class Main {
         BK_OPTS.addOption("m", "zkledgerpath", true, "Zookeeper ledgers root path");
         BK_OPTS.addOption("p", "bookieport", true, "bookie port exported");
         BK_OPTS.addOption("hp", "httpport", true, "bookie http port exported");
-        BK_OPTS.addOption("j", "journal", true, "bookie journal directory");
+        Option journalDirs = new Option ("j", "journaldirs", true, "bookie journal directories");
+        journalDirs.setArgs(10);
+        BK_OPTS.addOption(journalDirs);
         Option indexDirs = new Option ("i", "indexdirs", true, "bookie index directories");
         indexDirs.setArgs(10);
         BK_OPTS.addOption(indexDirs);
@@ -82,7 +84,9 @@ public class Main {
             + "Options including:\n";
         String footer = "Here is an example:\n"
             + "\tBookieServer -c bookie.conf -z localhost:2181 -m /bookkeeper/ledgers "
-            + "-p 3181 -j /mnt/journal -i \"/mnt/index1 /mnt/index2\""
+            + " -p 3181 "
+            + " -j \"/mnt/journal1 /mnt/journal2 \" "
+            + " -i \"/mnt/index1 /mnt/index2\" "
             + " -l \"/mnt/ledger1 /mnt/ledger2 /mnt/ledger3\"\n";
         hf.printHelp("BookieServer [options]\n", header, BK_OPTS, footer, true);
     }
@@ -165,9 +169,12 @@ public class Main {
             }
 
             if (cmdLine.hasOption('j')) {
-                String sJournalDir = cmdLine.getOptionValue('j');
-                log.info("Get cmdline journal dir: {}", sJournalDir);
-                conf.setJournalDirName(sJournalDir);
+                String sJournalDirs = cmdLine.getOptionValue('j');
+                log.info("Get cmdline journal dirs: ");
+                for (String journal : sJournalDirs) {
+                    log.info("journalDir : {}", journal);
+                }
+                conf.setJournalDirsName(sJournalDirs);
             }
 
             if (cmdLine.hasOption('i')) {


### PR DESCRIPTION
### Motivation
Start the bookie server by cmd and specify multiple journalDir
such as: docker/k8s pod

### Changes
Master Issue: #4180

Support specifying multiple journalDir as bookie start command parameters