### PR TITLE
[improve] fix doc & fix listfilesondisc cmd description

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1413,12 +1413,12 @@ public class BookieShell implements Tool {
 
         @Override
         String getDescription() {
-            return "List the files in JournalDirectory/LedgerDirectories/IndexDirectories.";
+            return "List the files in JournalDirectories/LedgerDirectories/IndexDirectories.";
         }
 
         @Override
         String getUsage() {
-            return "listfilesondisc      List the files in JournalDirectory/LedgerDirectories/IndexDirectories \n"
+            return "listfilesondisc      List the files in JournalDirectories/LedgerDirectories/IndexDirectories \n"
                     + "             Usage: listfilesondisc [options]\n"
                     + "             Options:\n"
                     + "               -txn, --journal\n"

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListFilesOnDiscCommand.java
@@ -34,12 +34,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Command to list the files in JournalDirectory/LedgerDirectories/IndexDirectories.
+ * Command to list the files in JournalDirectories/LedgerDirectories/IndexDirectories.
  */
 public class ListFilesOnDiscCommand extends BookieCommand<ListFilesOnDiscCommand.LFODFlags > {
 
     private static final String NAME = "listfilesondisc";
-    private static final String DESC = "List the files in JournalDirectory/LedgerDirectories/IndexDirectories.";
+    private static final String DESC = "List the files in JournalDirectories/LedgerDirectories/IndexDirectories.";
     private static final Logger LOG = LoggerFactory.getLogger(ListFilesOnDiscCommand.class);
 
     public ListFilesOnDiscCommand() {

--- a/docker/README.md
+++ b/docker/README.md
@@ -158,7 +158,7 @@ $ docker run --name bookie1 -d \
     -v $(local_configure_dir):/opt/bookkeeper/conf/ \   < == use 2nd approach, mount dir contains config_files
     -e BK_bookiePort=3181 \                             < == use 1st approach, set bookiePort
     -e BK_zkServers=zk-server1:2181,zk-server2:2181 \   < == use 1st approach, set zookeeper servers
-    -e BK_journalPreAllocSizeMB=32 \                    < == use 1st approach, set journalPreAllocSizeMB in [bk_server.conf](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/conf/bk_server.conf)
+    -e BK_journalPreAllocSizeMB=32 \                    < == use 1st approach, set journalPreAllocSizeMB in [bk_server.conf](https://github.com/apache/bookkeeper/blob/master/conf/bk_server.conf)
     apache/bookkeeper
 ```
 
@@ -215,7 +215,7 @@ Default value is empty - " ". so ledgers dir in zookeeper will be at "/ledgers" 
 #### `BK_DATA_DIR`
 This variable allows you to specify where to store data in docker instance.
 
-This could be override by env vars "BK_journalDirectory", "BK_ledgerDirectories", "BK_indexDirectories"  and also `journalDirectory`, `ledgerDirectories`, `indexDirectories` in [bk_server.conf](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/conf/bk_server.conf).
+This could be override by env vars "BK_journalDirectories", "BK_ledgerDirectories", "BK_indexDirectories"  and also `journalDirectories`, `ledgerDirectories`, `indexDirectories` in [bk_server.conf](https://github.com/apache/bookkeeper/blob/master/conf/bk_server.conf).
 
 Default value is "/data/bookkeeper", which contains volumes `/data/bookkeeper/journal`, `/data/bookkeeper/ledgers` and `/data/bookkeeper/index` to hold Bookkeeper data in docker.
 

--- a/site3/website/docs/admin/bookies.md
+++ b/site3/website/docs/admin/bookies.md
@@ -68,10 +68,10 @@ Parameter | Description | Default
 :---------|:------------|:-------
 `bookiePort` | The TCP port that the bookie listens on | `3181`
 `zkServers` | A comma-separated list of ZooKeeper servers in `hostname:port` format | `localhost:2181`
-`journalDirectory` | The directory where the [log device](../getting-started/concepts#log-device) stores the bookie's write-ahead log (WAL) | `/tmp/bk-txn`
+`journalDirectories` | The directories where the [log device](../getting-started/concepts#log-device) stores the bookie's write-ahead log (WAL) | `/tmp/bk-txn`
 `ledgerDirectories` | The directories where the [ledger device](../getting-started/concepts#ledger-device) stores the bookie's ledger entries (as a comma-separated list) | `/tmp/bk-data`
 
-> Ideally, the directories specified `journalDirectory` and `ledgerDirectories` should be on difference devices.
+> Ideally, the directories specified `journalDirectories` and `ledgerDirectories` should be on difference devices.
 
 ## Logging
 
@@ -163,7 +163,7 @@ org.apache.bookkeeper.bookie.BookieException$InvalidCookieException
 If the change was the result of an accidental configuration change, the change can be reverted and the bookie can be restarted. However, if the change *cannot* be reverted, such as is the case when you want to add a new disk or replace a disk, the bookie must be wiped and then all its data re-replicated onto it.
 
 1. Increment the [`bookiePort`](../reference/config#bookiePort) parameter in the [`bk_server.conf`](../reference/config)
-1. Ensure that all directories specified by [`journalDirectory`](../reference/config#journalDirectory) and [`ledgerDirectories`](../reference/config#ledgerDirectories) are empty.
+1. Ensure that all directories specified by [`journalDirectories`](../reference/config#journalDirectories) and [`ledgerDirectories`](../reference/config#ledgerDirectories) are empty.
 1. [Start the bookie](#starting-and-stopping-bookies).
 1. Run the following command to re-replicate the data:
 

--- a/site3/website/docs/admin/bookies.md
+++ b/site3/website/docs/admin/bookies.md
@@ -68,7 +68,7 @@ Parameter | Description | Default
 :---------|:------------|:-------
 `bookiePort` | The TCP port that the bookie listens on | `3181`
 `zkServers` | A comma-separated list of ZooKeeper servers in `hostname:port` format | `localhost:2181`
-`journalDirectories` | The directories where the [log device](../getting-started/concepts#log-device) stores the bookie's write-ahead log (WAL) | `/tmp/bk-txn`
+`journalDirectories` | The directories where the [log device](../getting-started/concepts#log-device) stores the bookie's write-ahead log (WAL, as a comma-separated list) | `/tmp/bk-txn`
 `ledgerDirectories` | The directories where the [ledger device](../getting-started/concepts#ledger-device) stores the bookie's ledger entries (as a comma-separated list) | `/tmp/bk-data`
 
 > Ideally, the directories specified `journalDirectories` and `ledgerDirectories` should be on difference devices.

--- a/site3/website/docs/reference/cli.md
+++ b/site3/website/docs/reference/cli.md
@@ -310,7 +310,7 @@ $ bin/bookkeeper shell listbookies \
 
 ### listfilesondisc {#bookkeeper-shell-listfilesondisc}
 
-List the files in JournalDirectory/LedgerDirectories/IndexDirectories.
+List the files in JournalDirectories/LedgerDirectories/IndexDirectories.
 
 ##### Usage
 

--- a/site3/website/src/pages/community/coding-guide.md
+++ b/site3/website/src/pages/community/coding-guide.md
@@ -68,7 +68,7 @@ Please log the _stack traces_ at **ERROR** level, but never at **INFO** level or
 
 * Names should be thought through from the point of view of the person using the config.
 * The default values should be thought as best value for people who runs the program without tuning parameters.
-* All configuration settings should be added to [default configuration file](https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/conf/bk_server.conf) and [documented](https://github.com/apache/bookkeeper/blob/master/site/_data/config/bk_server.yaml).
+* All configuration settings should be added to [default configuration file](https://github.com/apache/bookkeeper/blob/master/conf/bk_server.conf) and [documented](https://github.com/apache/bookkeeper/blob/master/site/_data/config/bk_server.yaml).
 
 ### Concurrency
 


### PR DESCRIPTION
Descriptions of the changes in this PR:
## Journal settings

| Parameter | Description | Default
| --------- | ----------- | ------- | 
| journalDirectories | The directories to which Bookkeeper outputs its write-ahead log (WAL). Could define multi directories to store write head logs, separated by ','.<br />For example:<br /> journalDirectories=/tmp/bk-journal1,/tmp/bk-journal2<br />If journalDirectories is set, bookies will skip journalDirectory and use this setting directory.<br /> | /tmp/bk-journal | 
| journalDirectory | @Deprecated since 4.5.0, in favor of using `journalDirectories`.<br /><br />The directory to which Bookkeeper outputs its write-ahead log (WAL).<br /> | /tmp/bk-txn | 


### Motivation
update doc about conf#JournalDirectory 2 conf#JournalDirectories& fix listfilesondisc cmd description

### Changes
Master Issue: #4183