### PR TITLE
Fixed issue where entries could not be read due to mismatch between the ensemble on metadata and the actual written bookies.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2010,6 +2010,21 @@ public class LedgerHandle implements WriteHandle {
                 pendingAddOp.unsetSuccessAndSendWriteRequest(ensemble, bookieIndex);
             }
         }
+        // Suppose that unset doesn't happen on the write set of an entry. In this
+        // case we don't need to resend the write request upon an ensemble change.
+        // We do need to invoke #sendAddSuccessCallbacks() for such entries because
+        // they may have already completed, but they are just waiting for the ensemble
+        // to change.
+        // E.g.
+        // ensemble (A, B, C, D), entry k is written to (A, B, D). An ensemble change
+        // happens to replace C with E. Entry k does not complete until C is
+        // replaced with E successfully. When the ensemble change completes, it tries
+        // to unset entry k. C however is not in k's write set, so no entry is written
+        // again, and no one triggers #sendAddSuccessCallbacks. Consequently, k never
+        // completes.
+        //
+        // We call sendAddSuccessCallback to cover this case.
+        sendAddSuccessCallbacks();
     }
 
     void registerOperationFailureOnBookie(BookieId bookie, long entryId) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -188,20 +188,7 @@ class PendingAddOp implements WriteCallback {
         }
         // Suppose that unset doesn't happen on the write set of an entry. In this
         // case we don't need to resend the write request upon an ensemble change.
-        // We do need to invoke #sendAddSuccessCallbacks() for such entries because
-        // they may have already completed, but they are just waiting for the ensemble
-        // to change.
-        // E.g.
-        // ensemble (A, B, C, D), entry k is written to (A, B, D). An ensemble change
-        // happens to replace C with E. Entry k does not complete until C is
-        // replaced with E successfully. When the ensemble change completes, it tries
-        // to unset entry k. C however is not in k's write set, so no entry is written
-        // again, and no one triggers #sendAddSuccessCallbacks. Consequently, k never
-        // completes.
-        //
-        // We call sendAddSuccessCallback when unsetting t cover this case.
         if (!lh.distributionSchedule.hasEntry(entryId, bookieIndex)) {
-            lh.sendAddSuccessCallbacks();
             return;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperTest.java
@@ -94,9 +94,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
             .setZkTimeout(20000);
 
-        CountDownLatch l = new CountDownLatch(1);
-        zkUtil.sleepCluster(200, TimeUnit.MILLISECONDS, l);
-        l.await();
+        zkUtil.sleepCluster(200, TimeUnit.MILLISECONDS);
 
         BookKeeper bkc = new BookKeeper(conf);
         bkc.createLedger(digestType, "testPasswd".getBytes()).close();
@@ -109,9 +107,7 @@ public class BookKeeperTest extends BookKeeperClusterTestCase {
         conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri())
             .setZkTimeout(20000);
 
-        CountDownLatch l = new CountDownLatch(1);
-        zkUtil.sleepCluster(200, TimeUnit.MILLISECONDS, l);
-        l.await();
+        zkUtil.sleepCluster(200, TimeUnit.MILLISECONDS);
 
         ZooKeeper zk = new ZooKeeper(
             zkUtil.getZooKeeperConnectString(),

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -37,6 +37,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1539,7 +1541,142 @@ public class BookieWriteLedgerTest extends
         lh.close();
     }
 
+    @Test
+    public void testToDelayEnsembleReplacementAndRewriteEntry() throws Exception {
+        lh = bkc.createLedger(4, 2, digestType, ledgerPassword);
+
+        // Put Bookie0 to sleep.
+        List<BookieId> currentEnsemble = lh.getLedgerMetadata()
+                .getAllEnsembles().entrySet().iterator().next().getValue();
+        CountDownLatch bookie0Latch = new CountDownLatch(1);
+        sleepBookie(currentEnsemble.get(0), bookie0Latch);
+
+        // Write entry0,1,2,3 to Bookie.
+        int sendCount = 7;
+        CountDownLatch addCompleteLatch = new CountDownLatch(sendCount);
+        for (int count = 0; count < 4; count++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(count);
+            entry.position(0);
+            entries1.add(entry.array());
+
+            lh.asyncAddEntry(entry.array(), new AddCallback() {
+                @Override
+                public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
+                    CountDownLatch addCompleteLatch = (CountDownLatch) ctx;
+                    addCompleteLatch.countDown();
+                }
+            }, addCompleteLatch);
+        }
+
+        // Expected state of entries.
+        //  entry: 0(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
+        //  entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
+        //  entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
+        //  entry: 3(Bookie3, Bookie0) -> Waiting for successful write to Bookie0.
+        Field fieldPendingAddOps = lh.getClass().getDeclaredField("pendingAddOps");
+        fieldPendingAddOps.setAccessible(true);
+        int completedCount;
+        do {
+            Thread.sleep(100);
+
+            completedCount = 0;
+            for (PendingAddOp pendingAddOp : (Queue<PendingAddOp>) fieldPendingAddOps.get(lh)) {
+                if (pendingAddOp.completed) {
+                    completedCount++;
+                }
+            }
+        } while (completedCount != 2);
+
+        // Kill Bookie2,3 and start a new Bookie.
+        killBookie(currentEnsemble.get(2));
+        killBookie(currentEnsemble.get(3));
+        startNewBookie();
+
+        // Put ZK cluster to sleep to delay ensemble replacement.
+        CountDownLatch zkLatch = new CountDownLatch(1);
+        sleepZKCluster(zkLatch);
+
+        // Write entry4,5,6 to Bookie.
+        for (int count = 4; count < sendCount; count++) {
+            ByteBuffer entry = ByteBuffer.allocate(4);
+            entry.putInt(count);
+            entry.position(0);
+            entries1.add(entry.array());
+
+            lh.asyncAddEntry(entry.array(), new AddCallback() {
+                @Override
+                public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
+                    CountDownLatch addCompleteLatch = (CountDownLatch) ctx;
+                    addCompleteLatch.countDown();
+                }
+            }, addCompleteLatch);
+        }
+
+        // Expected state of entries.
+        //  entry: 0(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
+        //  entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
+        //  entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
+        //  entry: 3(Bookie3, Bookie0) -> Waiting for successful write to Bookie0.
+        //  entry: 4(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
+        //  entry: 5(Bookie1, Bookie2) -> Failed to write to Bookie2.
+        //  entry: 6(Bookie2, Bookie3) -> Failed to write to Bookie2,3.
+        Field fieldChangingEnsemble = lh.getClass().getDeclaredField("changingEnsemble");
+        fieldChangingEnsemble.setAccessible(true);
+        boolean changingEnsemble;
+        do {
+            Thread.sleep(100);
+
+            changingEnsemble = (boolean) fieldChangingEnsemble.get(lh);
+        } while (!changingEnsemble);
+
+        // Bookie0 is wake up, write to Bookie0 is successful.
+        //
+        // Expected state of entries.
+        //  entry: 0(Bookie0, Bookie1) -> Writing to Bookie0,1 was successful, but its completion is pending.
+        //  entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
+        //  entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
+        //  entry: 3(Bookie3, Bookie0) -> Writing to Bookie3,0 was successful, but its completion is pending.
+        //  entry: 4(Bookie0, Bookie1) -> Writing to Bookie0,1 was successful, but its completion is pending.
+        //  entry: 5(Bookie1, Bookie2) -> Failed to write to Bookie2.
+        //  entry: 6(Bookie2, Bookie3) -> Failed to write to Bookie2,3.
+        bookie0Latch.countDown();
+        do {
+            Thread.sleep(100);
+
+            completedCount = 0;
+            for (PendingAddOp pendingAddOp : (Queue<PendingAddOp>) fieldPendingAddOps.get(lh)) {
+                if (pendingAddOp.completed) {
+                    completedCount++;
+                }
+            }
+        } while (completedCount != 5);
+
+        // ZK cluster is wake up, then ensemble replacement is completed.
+        //
+        // Expected state of entries.
+        //  entry: 0(Bookie0, Bookie1) -> Entry write is completed.
+        //  entry: 1(Bookie1, Bookie4) -> Write to Bookie4.
+        //  entry: 2(Bookie4, Bookie5) -> Write to Bookie4,5.
+        //  entry: 3(Bookie5, Bookie0) -> Write to Bookie5.
+        //  entry: 4(Bookie0, Bookie1) -> Writing to Bookie0,1 was successful, but its completion is pending.
+        //  entry: 5(Bookie1, Bookie4) -> Write to Bookie4.
+        //  entry: 6(Bookie4, Bookie5) -> Write to Bookie4,5.
+        zkLatch.countDown();
+
+        // Waiting for all Entry writes to complete.
+        addCompleteLatch.await();
+
+        readEntries(lh, entries1, sendCount);
+        lh.close();
+    }
+
     private void readEntries(LedgerHandle lh, List<byte[]> entries) throws InterruptedException, BKException {
+        readEntries(lh, entries, numEntriesToWrite);
+    }
+
+    private void readEntries(LedgerHandle lh, List<byte[]> entries, int numEntriesToWrite)
+            throws InterruptedException, BKException {
         ls = lh.readEntries(0, numEntriesToWrite - 1);
         int index = 0;
         while (ls.hasMoreElements()) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -244,6 +244,11 @@ public abstract class BookKeeperClusterTestCase {
         zkUtil.killCluster();
     }
 
+    protected void sleepZKCluster(final CountDownLatch l)
+            throws InterruptedException, IOException {
+        zkUtil.sleepCluster(l);
+    }
+
     /**
      * Start cluster. Also, starts the auto recovery process for each bookie, if
      * isAutoRecoveryEnabled is true.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperCluster.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperCluster.java
@@ -58,7 +58,10 @@ public interface ZooKeeperCluster {
 
     void killCluster() throws Exception;
 
-    void sleepCluster(int time, TimeUnit timeUnit, CountDownLatch l)
+    void sleepCluster(int time, TimeUnit timeUnit)
+            throws InterruptedException, IOException;
+
+    void sleepCluster(CountDownLatch l)
             throws InterruptedException, IOException;
 
     default void expireSession(ZooKeeper zk) throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperClusterUtil.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ZooKeeperClusterUtil.java
@@ -136,7 +136,12 @@ public class ZooKeeperClusterUtil implements ZooKeeperCluster {
     }
 
     @Override
-    public void sleepCluster(int time, TimeUnit timeUnit, CountDownLatch l) throws InterruptedException, IOException {
+    public void sleepCluster(int time, TimeUnit timeUnit) throws InterruptedException, IOException {
+        throw new UnsupportedOperationException("sleepServer operation is not supported for ZooKeeperClusterUtil");
+    }
+
+    @Override
+    public void sleepCluster(CountDownLatch l) throws InterruptedException, IOException {
         throw new UnsupportedOperationException("sleepServer operation is not supported for ZooKeeperClusterUtil");
     }
 }


### PR DESCRIPTION
Related Issue: https://github.com/apache/bookkeeper/issues/4097

### Motivation
- If write to Bookies succeeds during replacing ensemble, there may be a mismatch between the ensemble on metadata and the actual written bookies.

- This issue occurs in the following scenario.
```
STEP1:
Write entry0,1,2,3 to Bookies, but the entries are in the following state.
 - entry: 0(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
 - entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
 - entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
 - entry: 3(Bookie3, Bookie0) -> Waiting for successful write to Bookie0.

STEP2:
Write entry4,5,6 to Bookies, but the entries are in the following state.
 - entry: 0(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
 - entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
 - entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
 - entry: 3(Bookie3, Bookie0) -> Waiting for successful write to Bookie0.
 - entry: 4(Bookie0, Bookie1) -> Waiting for successful write to Bookie0.
 - entry: 5(Bookie1, Bookie2) -> Failed to write to Bookie2.
 - entry: 6(Bookie2, Bookie3) -> Failed to write to Bookie2,3.

Writing of entry5,6 failed, so ensemble replacement is started.

STEP3:
Write entry0,3,4 succeeded, but its completion is pending because ensemble is in the process of being replaced.

entries are in the following state.
 - entry: 0(Bookie0, Bookie1) -> Writing to Bookie0,1 was successful, but its completion is pending.
 - entry: 1(Bookie1, Bookie2) -> Writing to Bookie1,2 was successful, but its completion is pending.
 - entry: 2(Bookie2, Bookie3) -> Writing to Bookie2,3 was successful, but its completion is pending.
 - entry: 3(Bookie3, Bookie0) -> Writing to Bookie3,0 was successful, but its completion is pending.
 - entry: 4(Bookie0, Bookie1) -> Writing to Bookie0,1 was successful, but its completion is pending.
 - entry: 5(Bookie1, Bookie2) -> Failed to write to Bookie2.
 - entry: 6(Bookie2, Bookie3) -> Failed to write to Bookie2,3.

STEP4:
The ensemble replacement is completed and LedgerHandle#unsetSuccessAndSendWriteRequest is called.
 https://github.com/apache/bookkeeper/blob/13e7efaa971cd3613b065ac50836c5ee98985d13/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L2007-L2013

Entry0 is processed first, but since entry0 is not written to Bookie2,3, LedgerHandle#sendAddSuccessCallbacks is called.
 https://github.com/apache/bookkeeper/blob/234b817cdb4e054887ffd5e42eaed25dc02daf63/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java#L203-L206

Entry1,2,3 must be written again to Bookies after replacing ensemble, but writing of entry0,1,2,3,4 is completed at the above timing.
 https://github.com/apache/bookkeeper/blob/13e7efaa971cd3613b065ac50836c5ee98985d13/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L1814-L1839

As a result, entry1,2,3 is mismatched between the ensemble on metadata and the actual written bookies. 
```
- Running the test added in this PR with the unfixed source reproduces the issue.

### Changes
- Change the timing of when `LedgerHandle#sendAddSuccessCallbacks` is called.