### PR TITLE
A more universal method to detect java8

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -71,8 +71,8 @@ source ${BK_CONFDIR}/bkenv.sh
 source ${BK_CONFDIR}/bk_cli_env.sh
 
 detect_jdk8() {
-
-  if [ -f "$JAVA_HOME/lib/modules" ]; then
+  local is_java_8=$($JAVA -version 2>&1 | grep version | grep '"1\.8')
+  if [ -z "$is_java_8" ]; then
      echo "0"
   else
      echo "1"


### PR DESCRIPTION
The current bookkeeper installation package's scripts in the bin directory depend on JAVA_HOME to detect whether the current Java runtime environment is Java 8. However, in some deployment scenarios, the system does not configure the JAVA_HOME environment variable. If Java 11 or a higher version is installed, running the script will result in the following error:

```
# yum install java-11-openjdk-devel
# bin/bookkeeper shell
JAVA_HOME not set, using java from PATH. (/usr/bin/java)
OpenJDK 64-Bit Server VM warning: Option AggressiveOpts was deprecated in version 11.0 and will likely be removed in a future release.
Unrecognized VM option 'PrintGCApplicationStoppedTime'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This patch provides a more universal method to detect whether the runtime environment is Java 8, while avoiding the restriction of forcing users to set the JAVA_HOME variable.