### PR TITLE
log error when ReadEntryProcessor IOException

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -105,9 +105,7 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
             }
             errorCode = BookieProtocol.ENOENTRY;
         } catch (IOException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Error reading {}", request, e);
-            }
+            LOG.error("Error reading {}", request, e);
             errorCode = BookieProtocol.EIO;
         } catch (BookieException.DataUnknownException e) {
             LOG.error("Ledger {} is in an unknown state", request.getLedgerId(), e);


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Change the log-level to error when `ReadEntryProcessor` throw `IOException`.   The reason is that:
1. `IOException` should not happen frequently，so the error log will not print too much
2. It will be convenient for troubleshooting  if we print the  error log.
3. Also we can see that `ReadEntryProcessorV3` has printed the error log

https://github.com/apache/bookkeeper/blob/dc2bb1dfed38d7f9ad7a29fc92bd907e51af5b21/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java#L233-L236

### Changes

`log.debug` -> `log.error`

