### PR TITLE
Use netty-bom for aligning netty library versions, add epoll for linux-aarch_64

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -237,6 +237,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
 - lib/io.netty-netty-transport-4.1.104.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -235,6 +235,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
 - lib/io.netty-netty-transport-4.1.104.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -237,6 +237,7 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
 - lib/io.netty-netty-transport-4.1.104.Final.jar [11]
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -43,6 +43,7 @@ LongAdder), which was released with the following comments:
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
 - lib/io.netty-netty-transport-4.1.104.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -23,6 +23,7 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
 - lib/io.netty-netty-transport-4.1.104.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -25,6 +25,7 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
 - lib/io.netty-netty-transport-4.1.104.Final.jar
 - lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
 - lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -82,7 +82,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
         <classifier>linux-x86_64</classifier>
-      </dependency>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
     <netty.version>4.1.104.Final</netty.version>
-    <netty-boringssl.version>2.0.61.Final</netty-boringssl.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>
@@ -384,82 +383,12 @@
         </exclusions>
       </dependency>
 
-      <!-- netty dependencies -->
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
+        <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-buffer</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${netty.version}</version>
-        <classifier>linux-x86_64</classifier>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-dns</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http2</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-socks</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler-proxy</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-resolver</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-resolver-dns</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${netty-boringssl.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.netty.incubator</groupId>
@@ -477,6 +406,11 @@
         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
         <version>${netty-iouring.version}</version>
         <classifier>linux-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty.incubator</groupId>
+        <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+        <version>${netty-iouring.version}</version>
       </dependency>
 
       <!-- grpc dependencies -->


### PR DESCRIPTION
### Motivation

Netty's epoll support for Linux on ARM64 (aarch_64) is missing. 

### Changes

- add netty-transport-native-epoll for linux-aarch_64
- use netty-bom to align versions