### PR TITLE
Add `InetAddress.getLocalHost().getCanonicalHostName()` for TestRackawareEnsemblePlacementPolicy#updateMyRack.

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -80,6 +80,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
     static void updateMyRack(String rack) throws Exception {
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostAddress(), rack);
         StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getHostName(), rack);
+        StaticDNSResolver.addNodeToRack(InetAddress.getLocalHost().getCanonicalHostName(), rack);
         BookieSocketAddress bookieAddress = new BookieSocketAddress(
             InetAddress.getLocalHost().getHostAddress(), 0);
         StaticDNSResolver.addNodeToRack(bookieAddress.getSocketAddress().getHostName(), rack);


### PR DESCRIPTION
The method `InetAddress.getLocalHost().getHostName()` result may be different from `InetAddress.getLocalHost().getCanonicalHostName()`.

In the laptop, the method `InetAddress.getLocalHost().getHostName()` return `horizondeMBP`, the method `InetAddress.getLocalHost().getCanonicalHostName()` return `horizondembp`.


We should also update the rack for `InetAddress.getLocalHost().getCanonicalHostName()`.
