### PR TITLE
Remove duplicate setBatchReadEnabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -2107,11 +2107,6 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
         return getBoolean(BATCH_READ_ENABLED, true);
     }
 
-    public ClientConfiguration setBatchReadEnabled(boolean enabled) {
-        setProperty(BATCH_READ_ENABLED, enabled);
-        return this;
-    }
-
     @Override
     protected ClientConfiguration getThis() {
         return this;


### PR DESCRIPTION
### Motivation

`setBatchReadEnabled` is duplicated, which breaks the compilation:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project bookkeeper-server: Compilation failure: Compilation failure: 
Error:  /home/runner/work/bookkeeper/bookkeeper/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java:[2110,32] method setBatchReadEnabled(boolean) is already defined in class org.apache.bookkeeper.conf.ClientConfiguration
```

### Changes

Remove the duplicated method.