### PR TITLE
Fix getHosts by ip

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
@@ -99,7 +99,13 @@ public class DNS {
             throw new NamingException("PTR attribute value is null");
         }
 
-        return ptrAttr.get().toString();
+        String ptr = ptrAttr.get().toString();
+        int ptrLen = ptr.length();
+        if (ptr.charAt(ptrLen - 1) == '.') {
+            ptr = ptr.substring(0, ptrLen - 1);
+        }
+
+        return ptr;
     }
 
     /**
@@ -234,8 +240,12 @@ public class DNS {
         Vector<String> hosts = new Vector<String>();
         for (int ctr = 0; ctr < ips.length; ctr++) {
             try {
-                hosts.add(reverseDns(InetAddress.getByName(ips[ctr]),
-                        nameserver));
+                InetAddress inetAddress = InetAddress.getByName(ips[ctr]);
+                if (inetAddress.isLoopbackAddress()) {
+                    hosts.add(inetAddress.getHostName());
+                } else {
+                    hosts.add(reverseDns(inetAddress, nameserver));
+                }
             } catch (UnknownHostException ignored) {
             } catch (NamingException ignored) {
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/DNSTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/DNSTest.java
@@ -1,0 +1,86 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.net;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Enumeration;
+import javax.naming.NamingException;
+import lombok.Cleanup;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class DNSTest {
+
+    private NetworkInterface getLoopbackInterface() throws SocketException {
+        Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
+        for (NetworkInterface nif : Collections.list(nifs)) {
+            if (nif.isLoopback()) {
+                return nif;
+            }
+        }
+
+        return null;
+    }
+
+    @Test
+    public void testGetHostsByLoopbackInterface() throws UnknownHostException, SocketException {
+        NetworkInterface loopbackInterface = getLoopbackInterface();
+        if (loopbackInterface == null) {
+            return;
+        }
+
+        String loopbackInterfaceName = loopbackInterface.getName();
+
+        @Cleanup
+        MockedStatic<DNS> dnsMockedStatic = mockStatic(DNS.class, CALLS_REAL_METHODS);
+        DNS.getHosts(loopbackInterfaceName, null);
+
+        dnsMockedStatic.verify(() -> DNS.reverseDns(any(), any()), never());
+    }
+
+
+    @Test
+    public void testReversDNSByLoopbackInterface() throws UnknownHostException, SocketException, NamingException {
+        NetworkInterface loopbackInterface = getLoopbackInterface();
+        if (loopbackInterface == null) {
+            return;
+        }
+
+        String[] iPs = DNS.getIPs(loopbackInterface.getName());
+        for (String iP : iPs) {
+            InetAddress inetAddress = InetAddress.getByName(iP);
+            if (inetAddress.isLoopbackAddress()) {
+                String host = DNS.reverseDns(inetAddress, null);
+                assertNotEquals(host.charAt(host.length() - 1), '.');
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- The PTR result will end with a `.`, we need to trim that, please see https://datatracker.ietf.org/doc/html/rfc1035#autoid-37
   
- In testing, we use the loopback net interface, which doesn't need to do PTR parse by DNS: 

```
java.lang.RuntimeException: java.net.UnknownHostException: Unable to resolve default hostname: 1.0.0.127.in-addr.arpa. for interface: lo0

 at org.apache.bookkeeper.proto.SimpleBookieServiceInfoProvider.<init>(SimpleBookieServiceInfoProvider.java:41)
 at org.apache.bookkeeper.bookie.TestBookieImpl.<init>(TestBookieImpl.java:71)
 at org.apache.bookkeeper.bookie.TestBookieImpl.<init>(TestBookieImpl.java:46)
 at org.apache.bookkeeper.bookie.BookieWriteToJournalTest.testForceLedger(BookieWriteToJournalTest.java:167)
```

### Changes

- Trim the PTR result.
- Skip PTR parsing of loopback address by DNS.
