### PR TITLE
Upgrade mockito from 3.12.4 to 4.11.0

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieMultipleJournalsTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieMultipleJournalsTest.java
@@ -74,7 +74,7 @@ public class BookieMultipleJournalsTest extends BookKeeperClusterTestCase {
         Field journalList = bookie.getClass().getDeclaredField("journals");
         journalList.setAccessible(true);
         List<Journal> journals = (List<Journal>) journalList.get(bookie);
-        journals.get(0).interrupt();
+        journals.get(0).interruptThread();
         Awaitility.await().untilAsserted(() -> assertFalse(bookie.isRunning()));
     }
 
@@ -92,7 +92,7 @@ public class BookieMultipleJournalsTest extends BookKeeperClusterTestCase {
         Field journalList = bookie.getClass().getDeclaredField("journals");
         journalList.setAccessible(true);
         List<Journal> journals = (List<Journal>) journalList.get(bookie);
-        journals.get(0).interrupt();
+        journals.get(0).interruptThread();
         bookie.shutdown(ExitCode.OK);
         Awaitility.await().untilAsserted(() -> assertFalse(bookie.isRunning()));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <lombok.version>1.18.30</lombok.version>
     <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <netty.version>4.1.104.Final</netty.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>


### PR DESCRIPTION
### Motivation

Upgrade the mockito for better compatibility with the latest JDK.

Because mockito@5 requires the JDK 11, we can only upgrade to mockito@4.11.0.

### Changes

- Upgrade mockito from 3.12.4 to 4.11.0.
- Using wrapper instead of extend the `BookieCriticalThread` in the `Journal` and `BookieImpl`, because the mocktio doesn't support spying the `Thread` class: https://github.com/mockito/mockito/issues/2906#issuecomment-1426688993
