### PR TITLE
Upgrade Netty to 4.1.107.Final and io_uring to 0.0.25.Final

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -217,17 +217,17 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
-- lib/io.netty-netty-common-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar [11]
+- lib/io.netty-netty-common-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.107.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.107.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -235,14 +235,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -360,7 +360,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.107.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -403,9 +403,9 @@ Apache Software License, Version 2.
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.107.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -414,7 +414,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -422,7 +422,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -430,7 +430,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -438,7 +438,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -448,7 +448,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -456,7 +456,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -465,7 +465,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -473,7 +473,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -481,7 +481,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -489,7 +489,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -497,7 +497,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -505,7 +505,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -513,7 +513,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -521,7 +521,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -530,7 +530,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -538,7 +538,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -546,7 +546,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -554,7 +554,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -562,7 +562,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -570,7 +570,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -578,7 +578,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -586,7 +586,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -594,7 +594,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -602,7 +602,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -611,7 +611,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -619,7 +619,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -217,15 +217,15 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
-- lib/io.netty-netty-common-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar [11]
+- lib/io.netty-netty-common-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.107.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -233,14 +233,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [16]
@@ -303,7 +303,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.107.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -334,9 +334,9 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.107.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -345,7 +345,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -353,7 +353,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -361,7 +361,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -369,7 +369,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -379,7 +379,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -387,7 +387,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -396,7 +396,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -404,7 +404,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -412,7 +412,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -420,7 +420,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -428,7 +428,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -436,7 +436,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -444,7 +444,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -452,7 +452,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -461,7 +461,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -469,7 +469,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -477,7 +477,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -485,7 +485,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -493,7 +493,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -501,7 +501,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -509,7 +509,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -517,7 +517,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -525,7 +525,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -533,7 +533,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -542,7 +542,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -550,7 +550,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -217,17 +217,17 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar [11]
-- lib/io.netty-netty-common-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.104.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.104.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar [11]
+- lib/io.netty-netty-common-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.107.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.107.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.107.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -235,14 +235,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -356,7 +356,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.104.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.107.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -398,9 +398,9 @@ Apache Software License, Version 2.
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.104.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.107.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -409,7 +409,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -417,7 +417,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -425,7 +425,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -433,7 +433,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -443,7 +443,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -451,7 +451,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -460,7 +460,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -468,7 +468,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -476,7 +476,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -484,7 +484,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -492,7 +492,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -500,7 +500,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -508,7 +508,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -516,7 +516,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -525,7 +525,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -533,7 +533,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -541,7 +541,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -549,7 +549,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -557,7 +557,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -565,7 +565,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.107.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -573,7 +573,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -581,7 +581,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -589,7 +589,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -597,7 +597,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.107.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -606,7 +606,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -614,7 +614,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.104.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.107.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,17 +23,17 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.104.Final.jar
-- lib/io.netty-netty-codec-4.1.104.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
-- lib/io.netty-netty-common-4.1.104.Final.jar
-- lib/io.netty-netty-handler-4.1.104.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
-- lib/io.netty-netty-resolver-4.1.104.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar
+- lib/io.netty-netty-buffer-4.1.107.Final.jar
+- lib/io.netty-netty-codec-4.1.107.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar
+- lib/io.netty-netty-common-4.1.107.Final.jar
+- lib/io.netty-netty-handler-4.1.107.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar
+- lib/io.netty-netty-resolver-4.1.107.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.107.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -41,13 +41,13 @@ LongAdder), which was released with the following comments:
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.104.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
+- lib/io.netty-netty-transport-4.1.107.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,15 +5,15 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.104.Final.jar
-- lib/io.netty-netty-codec-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
-- lib/io.netty-netty-common-4.1.104.Final.jar
-- lib/io.netty-netty-handler-4.1.104.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
-- lib/io.netty-netty-resolver-4.1.104.Final.jar
+- lib/io.netty-netty-buffer-4.1.107.Final.jar
+- lib/io.netty-netty-codec-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar
+- lib/io.netty-netty-common-4.1.107.Final.jar
+- lib/io.netty-netty-handler-4.1.107.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar
+- lib/io.netty-netty-resolver-4.1.107.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -21,13 +21,13 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.104.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
+- lib/io.netty-netty-transport-4.1.107.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,17 +5,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.104.Final.jar
-- lib/io.netty-netty-codec-4.1.104.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http-4.1.104.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.104.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.104.Final.jar
-- lib/io.netty-netty-common-4.1.104.Final.jar
-- lib/io.netty-netty-handler-4.1.104.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.104.Final.jar
-- lib/io.netty-netty-resolver-4.1.104.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.104.Final.jar
+- lib/io.netty-netty-buffer-4.1.107.Final.jar
+- lib/io.netty-netty-codec-4.1.107.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http-4.1.107.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.107.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.107.Final.jar
+- lib/io.netty-netty-common-4.1.107.Final.jar
+- lib/io.netty-netty-handler-4.1.107.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.107.Final.jar
+- lib/io.netty-netty-resolver-4.1.107.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.107.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
@@ -23,13 +23,13 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
-- lib/io.netty-netty-transport-4.1.104.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
+- lib/io.netty-netty-transport-4.1.107.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.107.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.107.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.107.Final.jar
 
 
                             The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
     <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>4.11.0</mockito.version>
-    <netty.version>4.1.104.Final</netty.version>
-    <netty-iouring.version>0.0.24.Final</netty-iouring.version>
+    <netty.version>4.1.107.Final</netty.version>
+    <netty-iouring.version>0.0.25.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>
     <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>


### PR DESCRIPTION
### Motivation

Keep Netty and Netty's io_uring libraries up-to-date.

Release notes since last upgrades:

Netty:

- https://netty.io/news/2024/02/13/4-1-107-Final.html
- https://netty.io/news/2024/01/19/4-1-106-Final.html
- https://netty.io/news/2024/01/16/4-1-105-Final.html

io_uring:

- https://netty.io/news/2024/02/19/io_uring_0-0-25-Final.html


### Changes

updated dependencies in pom.xml


