### PR TITLE
Issue 4200: fix flaky test DeferredSyncTest.testForceWillAdvanceLacOnlyUpToLastAcknoledgedWrite

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockBookKeeperTestCase.java
@@ -304,6 +304,9 @@ public abstract class MockBookKeeperTestCase {
 
     protected void resumeBookieWriteAcks(BookieId address) {
         List<Runnable> pendingResponses;
+
+        // why use the BookieId instance as the object monitor? there is a date race problem if not
+        // see https://github.com/apache/bookkeeper/issues/4200
         synchronized (address) {
             suspendedBookiesForForceLedgerAcks.remove(address);
             pendingResponses = deferredBookieForceLedgerResponses.remove(address);
@@ -661,6 +664,7 @@ public abstract class MockBookKeeperTestCase {
                 });
             };
             List<Runnable> queue = null;
+
             synchronized (bookieSocketAddress) {
                 if (suspendedBookiesForForceLedgerAcks.contains(bookieSocketAddress)) {
                     queue = deferredBookieForceLedgerResponses.computeIfAbsent(bookieSocketAddress,


### PR DESCRIPTION
### Motivation

fix #4200 

`DeferredSyncTest.testForceWillAdvanceLacOnlyUpToLastAcknoledgedWrite` is flaky. The build times out since the test MAY never finishes.  This PR fix it.

### Changes

Use `synchronized` block to operate `suspendedBookiesForForceLedgerAcks` and `deferredBookieForceLedgerResponses`

Master Issue: #4200
