### PR TITLE
Improve release script instructions

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -92,9 +92,18 @@ echo 'RC_TAG                    = $RC_TAG'
 echo
 echo 'Before executing any release scripts, PLEASE configure your git to cache your github password:'
 echo
+echo ' // take a backup of ~/.gitconfig, remember to restore it after the release process'
+echo ' \$ cp ~/.gitconfig ~/.gitconfig.bak.\$(date -I)'
+echo ' // remove any previous credential helper configuration'
+echo ' \$ git config --global -l --name-only | grep credential | uniq | xargs -i{} git config --global --unset-all {}'
+echo ' // fix permission warning with git in docker on MacOS'
+echo ' \$ git config --global safe.directory $PWD'
 echo ' // configure credential helper to cache your github password for 1 hr during the whole release process '
 echo ' \$ git config --global credential.helper \"cache --timeout=3600\" '
-echo ' \$ git push apache --dry-run '
+echo ' // in another terminal get a GitHub token to be used as a password for the release process, assuming you are using GitHub CLI.'
+echo ' \$ gh auth token '
+echo ' // attempt to push to apache remote to cache your password'
+echo ' \$ git push apache HEAD:test --dry-run '
 echo
 bash
 "

--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -51,6 +51,7 @@ docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
 FROM --platform=linux/amd64 ${IMAGE_NAME}
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
   useradd -l -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME} && \
+  ([ "$(dirname "$HOME")" -eq "/home" ] || ln -s /home $(dirname "$HOME")) && \
   mkdir -p /gpg && chown ${USER_ID}:${GROUP_ID} /gpg && chmod 700 /gpg
 ENV  HOME /home/${USER_NAME}
 UserSpecificDocker
@@ -104,7 +105,8 @@ echo ' \$ cp ~/.gitconfig ~/.gitconfig.bak.\$(date -I)'
 echo ' // remove any previous credential helper configuration'
 echo ' \$ git config --global -l --name-only | grep credential | uniq | xargs -i{} git config --global --unset-all {}'
 echo ' // fix permission warning with git in docker on MacOS'
-echo ' \$ git config --global safe.directory $PWD'
+echo ' \$ git config --global --add safe.directory $PWD'
+echo ' \$ git config --global --add safe.directory \$PWD'
 echo ' // configure credential helper to cache your github password for 1 hr during the whole release process '
 echo ' \$ git config --global credential.helper \"cache --timeout=3600\" '
 echo ' // in another terminal get a GitHub token to be used as a password for the release process, assuming you are using GitHub CLI.'

--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -79,7 +79,8 @@ cp -Rdp \$HOME/.gnupg /gpg
 rm -rf /gpg/.gnupg/S.*
 # set GNUPGHOME to /gpg/.gnupg
 export GNUPGHOME=/gpg/.gnupg
-gpg-agent --daemon --pinentry-program /usr/bin/pinentry
+echo 'pinentry-mode loopback' >> /gpg/.gnupg/gpg.conf
+gpg-agent --daemon --pinentry-program /usr/bin/pinentry --allow-loopback-pinentry
 echo
 echo 'Welcome to Apache BookKeeper Release Build Env'
 echo

--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -79,8 +79,7 @@ cp -Rdp \$HOME/.gnupg /gpg
 rm -rf /gpg/.gnupg/S.*
 # set GNUPGHOME to /gpg/.gnupg
 export GNUPGHOME=/gpg/.gnupg
-echo 'pinentry-mode loopback' >> /gpg/.gnupg/gpg.conf
-gpg-agent --daemon --pinentry-program /usr/bin/pinentry --allow-loopback-pinentry
+gpg-agent --daemon --pinentry-program /usr/bin/pinentry --allow-loopback-pinentry --default-cache-ttl 3600
 echo
 echo 'Welcome to Apache BookKeeper Release Build Env'
 echo
@@ -112,6 +111,8 @@ echo ' // in another terminal get a GitHub token to be used as a password for th
 echo ' \$ gh auth token '
 echo ' // attempt to push to apache remote to cache your password'
 echo ' \$ git push apache HEAD:test --dry-run '
+echo ' // cache gpg password by signing a dummy file'
+echo ' \$ echo dummy > /tmp/dummy && gpg -sa /tmp/dummy'
 echo
 bash
 "

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -18,6 +18,8 @@
 #
 
 FROM --platform=linux/amd64 maven:3.9.0-eclipse-temurin-8
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+  apt-get dist-upgrade -y && \
+  apt-get install -y g++ cmake gnupg2 vim subversion less zip unzip
 
-RUN apt-get update
-RUN apt-get install -y g++ cmake gnupg2 vim subversion less

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -20,4 +20,4 @@
 FROM --platform=linux/amd64 maven:3.9.0-eclipse-temurin-8
 
 RUN apt-get update
-RUN apt-get install -y g++ cmake gnupg2 vim subversion
+RUN apt-get install -y g++ cmake gnupg2 vim subversion less


### PR DESCRIPTION
### Motivation

While testing the dev/release/000-run-docker.sh I ran into several problems. 
- My ~/.gitconfig settings collided with the configuration used in 000-run-docker.sh
  - I'm using GitHub CLI `gh auth login` to manage git credentials for GitHub
- The git commit failed because of some unsafe directory warning
- gpg-agent failed to run and gpg signing failed

### Changes

- add more instructions when the script starts
- add workaround for gpg-agent and gpg issue