### PR TITLE
Check rocksdb closed before operating

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -145,7 +145,7 @@ public class EntryLocationIndex implements Closeable {
         batch.close();
     }
 
-    public Batch newBatch() {
+    public Batch newBatch() throws IOException {
         return locationsDb.newBatch();
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
@@ -134,7 +134,7 @@ public interface KeyValueStorage extends Closeable {
      *            the lastKey in the range (not included)
      *
      */
-    CloseableIterator<byte[]> keys(byte[] firstKey, byte[] lastKey) throws IOException ;
+    CloseableIterator<byte[]> keys(byte[] firstKey, byte[] lastKey) throws IOException;
 
     /**
      * Return an iterator object that can be used to sequentially scan through all

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
@@ -122,7 +122,7 @@ public interface KeyValueStorage extends Closeable {
      *
      * @return
      */
-    CloseableIterator<byte[]> keys();
+    CloseableIterator<byte[]> keys() throws IOException;
 
     /**
      * Get an iterator over to scan sequentially through all the keys within a
@@ -134,13 +134,13 @@ public interface KeyValueStorage extends Closeable {
      *            the lastKey in the range (not included)
      *
      */
-    CloseableIterator<byte[]> keys(byte[] firstKey, byte[] lastKey);
+    CloseableIterator<byte[]> keys(byte[] firstKey, byte[] lastKey) throws IOException ;
 
     /**
      * Return an iterator object that can be used to sequentially scan through all
      * the entries in the database.
      */
-    CloseableIterator<Entry<byte[], byte[]>> iterator();
+    CloseableIterator<Entry<byte[], byte[]>> iterator() throws IOException;
 
     /**
      * Commit all pending write to durable storage.
@@ -163,7 +163,7 @@ public interface KeyValueStorage extends Closeable {
         T next() throws IOException;
     }
 
-    Batch newBatch();
+    Batch newBatch() throws IOException;
 
     /**
      * Interface for a batch to be written in the storage.
@@ -175,7 +175,7 @@ public interface KeyValueStorage extends Closeable {
 
         void deleteRange(byte[] beginKey, byte[] endKey) throws IOException;
 
-        void clear();
+        void clear() throws IOException;
 
         void flush() throws IOException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageFactory.DbConfigType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.rocksdb.BlockBasedTableConfig;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -433,6 +433,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     public void compact() throws IOException {
         readLock.lock();
         try {
+            throwIfClosed();
             final long start = System.currentTimeMillis();
             final int oriRocksDBFileCount = db.getLiveFilesMetaData().size();
             final long oriRocksDBSize = getRocksDBSize();
@@ -646,9 +647,10 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     }
 
     @Override
-    public Batch newBatch() {
+    public Batch newBatch() throws IOException {
         readLock.lock();
         try {
+            throwIfClosed();
             return new RocksDBBatch(writeBatchMaxSize);
         } finally {
             readLock.unlock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/PersistentEntryLogMetadataMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/PersistentEntryLogMetadataMap.java
@@ -131,8 +131,9 @@ public class PersistentEntryLogMetadataMap implements EntryLogMetadataMap {
     @Override
     public void forEach(BiConsumer<Long, EntryLogMetadata> action) throws EntryLogMetadataMapException {
         throwIfClosed();
-        CloseableIterator<Entry<byte[], byte[]>> iterator = metadataMapDB.iterator();
+        CloseableIterator<Entry<byte[], byte[]>> iterator = null;
         try {
+            iterator = metadataMapDB.iterator();
             while (iterator.hasNext()) {
                 if (isClosed.get()) {
                     break;
@@ -151,7 +152,9 @@ public class PersistentEntryLogMetadataMap implements EntryLogMetadataMap {
             throw new EntryLogMetadataMapException(e);
         } finally {
             try {
-                iterator.close();
+                if (iterator != null) {
+                    iterator.close();
+                }
             } catch (IOException e) {
                 log.error("Failed to close entry-log metadata-map rocksDB iterator {}", e.getMessage(), e);
             }


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Fix https://github.com/apache/bookkeeper/issues/4238

From the issue above we can see that the core dump could happen when operate Rocksdb after it has been closed.  So we  should check  if closed before operating rocksdb.

### Changes

Checking if closed before operation RocksDB.

