### PR TITLE
Fixed creation of temporary dir in NativeUtils

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/utils/NativeUtils.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/utils/NativeUtils.java
@@ -26,6 +26,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 
 /**
@@ -50,13 +52,9 @@ public class NativeUtils {
         String[] parts = path.split("/");
         String filename = (parts.length > 0) ? parts[parts.length - 1] : null;
 
-        File dir = File.createTempFile("native", "");
-        dir.delete();
-        if (!(dir.mkdir())) {
-            throw new IOException("Failed to create temp directory " + dir.getAbsolutePath());
-        }
-        dir.deleteOnExit();
-        File temp = new File(dir, filename);
+        Path dir = Files.createTempDirectory("native");
+        dir.toFile().deleteOnExit();
+        File temp = new File(dir.toString(), filename);
         temp.deleteOnExit();
 
         byte[] buffer = new byte[1024];

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -24,7 +24,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -27,6 +27,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -51,12 +53,9 @@ public class NativeUtils {
         String[] parts = path.split("/");
         String filename = (parts.length > 0) ? parts[parts.length - 1] : null;
 
-        File dir = File.createTempFile("native", "");
-        if (!(dir.mkdir())) {
-            throw new IOException("Failed to create temp directory " + dir.getAbsolutePath());
-        }
-        dir.deleteOnExit();
-        File temp = new File(dir, filename);
+        Path dir = Files.createTempDirectory("native");
+        dir.toFile().deleteOnExit();
+        File temp = new File(dir.toString(), filename);
         temp.deleteOnExit();
 
         byte[] buffer = new byte[1024];

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -20,7 +20,6 @@
  */
 package org.apache.bookkeeper.common.util.affinity.impl;
 
-import com.google.common.base.Preconditions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -29,7 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -49,13 +48,13 @@ public class NativeUtils {
             value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             justification = "work around for java 9: https://github.com/spotbugs/spotbugs/issues/493")
     public static void loadLibraryFromJar(String path) throws Exception {
-        Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
+        checkArgument(path.startsWith("/"), "absolute path must start with /");
 
         String[] parts = path.split("/");
-        Preconditions.checkArgument(parts.length > 0, "absolute path must contain file name");
+        checkArgument(parts.length > 0, "absolute path must contain file name");
 
         String filename = parts[parts.length - 1];
-        Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
+        checkArgument(path.startsWith("/"), "absolute path must start with /");
 
         Path dir = Files.createTempDirectory("native");
         dir.toFile().deleteOnExit();
@@ -81,5 +80,11 @@ public class NativeUtils {
         }
 
         System.load(temp.getAbsolutePath());
+    }
+
+    private static void checkArgument(boolean expression, @NonNull Object errorMessage) {
+        if (!expression) {
+            throw new IllegalArgumentException(String.valueOf(errorMessage));
+        }
     }
 }

--- a/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
+++ b/cpu-affinity/src/main/java/org/apache/bookkeeper/common/util/affinity/impl/NativeUtils.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.common.util.affinity.impl;
 
+import com.google.common.base.Preconditions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -28,6 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -47,10 +49,13 @@ public class NativeUtils {
             value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             justification = "work around for java 9: https://github.com/spotbugs/spotbugs/issues/493")
     public static void loadLibraryFromJar(String path) throws Exception {
-        com.google.common.base.Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
+        Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
 
         String[] parts = path.split("/");
-        String filename = (parts.length > 0) ? parts[parts.length - 1] : null;
+        Preconditions.checkArgument(parts.length > 0, "absolute path must contain file name");
+
+        String filename = parts[parts.length - 1];
+        Preconditions.checkArgument(path.startsWith("/"), "absolute path must start with /");
 
         Path dir = Files.createTempDirectory("native");
         dir.toFile().deleteOnExit();


### PR DESCRIPTION
### Motivation

Creating the temp directory for unpacking the native library is failing for the affinity library.

### Changes

Use `Files.createTempDirectory()` instead.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
