### PR TITLE
Use vertx blockingHandlers to run Bookkeeper http handlers which could be blocking

### DIFF
--- a/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
+++ b/bookkeeper-http/vertx-http-server/src/main/java/org/apache/bookkeeper/http/vertx/VertxHttpServer.java
@@ -83,10 +83,10 @@ public class VertxHttpServer implements HttpServer {
         HttpRouter<VertxAbstractHandler> requestRouter = new HttpRouter<VertxAbstractHandler>(handlerFactory) {
             @Override
             public void bindHandler(String endpoint, VertxAbstractHandler handler) {
-                router.get(endpoint).handler(handler);
-                router.put(endpoint).handler(handler);
-                router.post(endpoint).handler(handler);
-                router.delete(endpoint).handler(handler);
+                router.get(endpoint).blockingHandler(handler);
+                router.put(endpoint).blockingHandler(handler);
+                router.post(endpoint).blockingHandler(handler);
+                router.delete(endpoint).blockingHandler(handler);
             }
         };
         requestRouter.bindAll();


### PR DESCRIPTION
### Motivation

- The http handler implementations in Bookkeeper aren't necessarily non-blocking. That's why they should be executed on the blocking thread pool in vertx.


### Changes

Executing on blocking thread pool in vertx can be achieved by registering the handlers using the `blockingHandler` method instead of the `handler` method.