### PR TITLE
Upgrade Lombok to 1.18.32 for Java 22 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <assertj-core.version>3.25.3</assertj-core.version>
     <awaitility.version>4.2.0</awaitility.version>
     <libthrift.version>0.14.2</libthrift.version>
-    <lombok.version>1.18.30</lombok.version>
+    <lombok.version>1.18.32</lombok.version>
     <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>4.11.0</mockito.version>


### PR DESCRIPTION
### Motivation

Java 22 has been released. Lombok 1.18.32 comes with Java 22 support.
Lombok changelog: https://projectlombok.org/changelog

### Modifications

Upgrade Lombok to 1.18.32