### PR TITLE
feat: allow user config AsyncLogger in log4j2

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -349,6 +349,7 @@ Apache Software License, Version 2.
 - lib/org.jetbrains.kotlin-kotlin-stdlib-common-1.6.20.jar [56]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.6.20.jar [56]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.20.jar [56]
+- lib/com.lmax-disruptor-4.0.0.jar [57]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
@@ -401,6 +402,7 @@ Apache Software License, Version 2.
 [54] Source available at https://github.com/square/okio/releases/tag/parent-3.2.0
 [55] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
+[57] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -292,6 +292,7 @@ Apache Software License, Version 2.
 - lib/org.xerial.snappy-snappy-java-1.1.10.5.jar [50]
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
+- lib/com.lmax-disruptor-4.0.0.jar [53]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
@@ -332,6 +333,7 @@ Apache Software License, Version 2.
 [50] Source available at https://github.com/xerial/snappy-java/releases/tag/v1.1.10.5
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
+[53] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -345,6 +345,7 @@ Apache Software License, Version 2.
 - lib/org.jetbrains.kotlin-kotlin-stdlib-common-1.6.20.jar [55]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.6.20.jar [55]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.20.jar [55]
+- lib/com.lmax-disruptor-4.0.0.jar [56]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
@@ -396,6 +397,7 @@ Apache Software License, Version 2.
 [53] Source available at https://github.com/square/okio/releases/tag/parent-3.2.0
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.6.20
+[56] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -166,6 +166,10 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
     <commons-io.version>2.7</commons-io.version>
     <bouncycastle.version>1.0.2.4</bouncycastle.version>
     <curator.version>5.1.0</curator.version>
+    <disruptor.version>4.0.0</disruptor.version>
     <dropwizard.version>4.1.12.1</dropwizard.version>
     <etcd.version>0.5.11</etcd.version>
     <freebuilder.version>2.8.0</freebuilder.version>
@@ -254,6 +255,11 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.lmax</groupId>
+        <artifactId>disruptor</artifactId>
+        <version>${disruptor.version}</version>
       </dependency>
 
       <!-- commons dependencies -->


### PR DESCRIPTION
### Motivation

Adding lmax disruptor in dependency allow user to config AsyncLogger in log4j2.xml like this

```xml
    <Loggers>
        <AsyncLogger name="async" level="info">
            <AppenderRef ref="AsyncConsole"/>
        </AsyncLogger>
    </Loggers>
```

See also https://logging.apache.org/log4j/2.x/manual/async.html