### PR TITLE
docs: remove -SNAPSHOT from 4.16.5 title

### DIFF
--- a/site3/website/versioned_docs/version-4.16.5/overview/overview.md
+++ b/site3/website/versioned_docs/version-4.16.5/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Apache BookKeeper 4.16.5-SNAPSHOT
+title: Apache BookKeeper 4.16.5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
### Motivation

Honestly no idea how, but there's a -SNAPSHOT suffix in the current title after I merged the website changes for 4.16.5
https://bookkeeper.apache.org/docs/overview/


### Changes
Remove -SNAPSHOT
