### PR TITLE
fix: miss test log in prometheus-metrics-provider module

### DIFF
--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -71,5 +71,11 @@
       <artifactId>sketches-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>testtools</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
### Motivation
fix test log in prometheus-metrics-provider module

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

### Changes

add `testtools` dependency in prometheus-metrics-provider module, it contains `log4j-slf4j2-impl`