### PR TITLE
[fix] Fix ByteBuf release/retain in PerChannelBookClient

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1199,7 +1199,6 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        boolean calledWrite = false;
         try {
             final long startTime = MathUtils.nowInNano();
 
@@ -1214,14 +1213,13 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     nettyOpLogger.registerFailedEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
                 }
             });
-            calledWrite = true;
             channel.writeAndFlush(request, promise);
         } catch (Throwable e) {
             LOG.warn("Operation {} failed", StringUtils.requestToString(request), e);
             errorOut(key);
-            if (!calledWrite) {
-                ReferenceCountUtil.release(request);
-            }
+            // If the request goes into the writeAndFlush, it should be handled well by Netty. So all the exceptions we
+            // get here, we can release the request.
+            ReferenceCountUtil.release(request);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -845,7 +845,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
             // usually checked in writeAndFlush, but we have extra check
             // because we need to release toSend.
             errorOut(completionKey);
-            ReferenceCountUtil.release(toSend);
+            ReferenceCountUtil.release(request);
             return;
         } else {
             // addEntry times out on backpressure

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -842,8 +842,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                                                    cb, ctx, ledgerId, entryId));
         final Channel c = channel;
         if (c == null) {
-            // usually checked in writeAndFlush, but we have extra check
-            // because we need to release toSend.
+            // Manually release the binary data(variable "request") that we manually created when can not be sent out
+            // because the channel is switching.
             errorOut(completionKey);
             ReferenceCountUtil.release(request);
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -842,7 +842,7 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                                                    cb, ctx, ledgerId, entryId));
         final Channel c = channel;
         if (c == null) {
-            // Manually release the binary data(variable "request") that we manually created when can not be sent out
+            // Manually release the binary data(variable "request") that we manually created when it can not be sent out
             // because the channel is switching.
             errorOut(completionKey);
             ReferenceCountUtil.release(request);


### PR DESCRIPTION
### Thanks

This root cause was found by @codelipenghui  and I just tried to reproduce and write this PR.

### Motivation

`PerChannelBookieClient.addEntry` duplicates the binary data (`@param toSend`) and sends the binary data new to the IO out. Manually release the binary data new if can not be sent out due to the channel switching. See the explanation below.

**Issue:** it released the original data (`@param toSend`), it is wrong. Leading a memory leak and the bellow error log

```
"Apr 10, 2024 @ 16:06:49.893","2024-04-10T16:06:49,892+0000 [BookKeeperClientWorker-OrderedExecutor-0-0] ERROR org.apache.bookkeeper.common.util.SingleThreadExecutor - Error while running task: refCnt: 0, increment: 1"
"Apr 10, 2024 @ 16:06:49.893","io.netty.util.IllegalReferenceCountException: refCnt: 0, increment: 1"
"Apr 10, 2024 @ 16:06:49.893"," at io.netty.util.internal.ReferenceCountUpdater.retain(ReferenceCountUpdater.java:120) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]"
"Apr 10, 2024 @ 16:06:49.893"," at io.netty.util.AbstractReferenceCounted.retain(AbstractReferenceCounted.java:61) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]"
"Apr 10, 2024 @ 16:06:49.893"," at io.netty.util.internal.ReferenceCountUpdater.retain0(ReferenceCountUpdater.java:133) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.util.ByteBufList.retain(ByteBufList.java:61) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.util.ByteBufList.retain(ByteBufList.java:281) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.proto.BookieClientImpl.addEntry(BookieClientImpl.java:307) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.client.PendingAddOp.sendWriteRequest(PendingAddOp.java:150) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.client.PendingAddOp.initiate(PendingAddOp.java:258) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.client.LedgerHandle.doAsyncAddEntry(LedgerHandle.java:1358) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.client.LedgerHandle.asyncAddEntry(LedgerHandle.java:1056) ~[org.apache.bookkeeper-bookkeeper-server-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.mledger.impl.OpAddEntry.initiate(OpAddEntry.java:144) ~[io.streamnative-managed-ledger-3.0.2.1.jar:3.0.2.1]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalAsyncAddEntry(ManagedLedgerImpl.java:863) ~[io.streamnative-managed-ledger-3.0.2.1.jar:3.0.2.1]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.lambda$asyncAddEntry$2(ManagedLedgerImpl.java:779) ~[io.streamnative-managed-ledger-3.0.2.1.jar:3.0.2.1]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137) ~[org.apache.bookkeeper-bookkeeper-common-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:113) ~[org.apache.bookkeeper-bookkeeper-common-4.16.3.jar:4.16.3]"
"Apr 10, 2024 @ 16:06:49.893"," at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]"
"Apr 10, 2024 @ 16:06:49.893"," at java.lang.Thread.run(Thread.java:840) ~[?:?]"
```

### Explanation

**Background: stacks of `add entry`**
1. `BookieClientImpl.addEntry`.
  a.  Retain the `ByteBuf` before get `PerChannelBookieClient`. We call this `ByteBuf` as `toSend` in the following sections. `toSend.recCnf` is `2` now.
2. `Get PerChannelBookieClient` 
3. `ChannelReadyForAddEntryCallback.operationComplete`
  a. `PerChannelBookieClient.addEntry`
    a-1. Build a new ByteBuf for request command. We call this `ByteBuf` new as `request` in the following sections.
    a-2. `channle.writeAndFlush(request)` or release the ByteBuf when `channel` is switching.
 b. Release the `ByteBuf` since it has been retained at `step 1`. `toSend.recCnf` should be `1` now.

**(Highlight)** the difference of `V2` and `V3` is only in the step "3-a-1. Build a new ByteBuf for request command"

**1. The Step `3-a-1`: `V2 & Small payload`**
- `3-a-1`: Build a new ByteBuf for request command
  - `request = toSend.retainedDuplicate()`. 
- `3-a-2`: Release the ByteBuf
  - `toSend.release()` 

Explanation: regarding this case, `request` and `toSend` share the same `refCnf`, it is fine to release a random one.

**2. The Step `3-a-1`: `V2 & Large payload`**
- `3-a-1`: Build a new ByteBuf for request command
  - `request = ByteBufList.clone(toSend)`. 
- `3-a-2`: Release the ByteBuf
  - `toSend.release()` 

Explanation: regarding this case, `request` and `toSend` are using different `refCnf`. Since the request can not be send out due to the `channel` switching, BK client should release `request`. It would cause a `refCnf` incorrect error if release an incorrect one. Highlight: since the internal ByteBufs of `request` and `toSend` are the same, it will not leading a memory leak even if it releases an incorrect one.

**3. The Step `3-a-1`: `V3`**
- `3-a-1`: Build a new ByteBuf for request command
  - `request`: build a absolutely one new ByteBuf. 
- `3-a-2`: Release the ByteBuf
  - `toSend.release()` 

Explanation: regarding this case, `request` and `toSend` are using different `refCnf`. Since the request can not be send out due to the `channel` switching, BK client should release `request`. It would cause an `refCnf` incorrect error if releasing a incorrect one. Highlight: since the exactly ByteBuf of `request` and `toSend` are different, it will leading a memory leak if it releases an incorrect one.

### Changes

Correct the code
