### PR TITLE
chore: remove ostrich version, it's code has been removed after 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,6 @@
     <mockito.version>4.11.0</mockito.version>
     <netty.version>4.1.108.Final</netty.version>
     <netty-iouring.version>0.0.25.Final</netty-iouring.version>
-    <ostrich.version>9.1.3</ostrich.version>
     <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -302,23 +302,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
 
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
-
-
 ## AutoRecovery general settings
 
 | Parameter | Description | Default

--- a/site3/website/versioned_docs/version-4.11.1/reference/config.md
+++ b/site3/website/versioned_docs/version-4.11.1/reference/config.md
@@ -255,7 +255,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true | 
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | false | 
 
 
@@ -278,22 +278,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings

--- a/site3/website/versioned_docs/version-4.12.1/reference/config.md
+++ b/site3/website/versioned_docs/version-4.12.1/reference/config.md
@@ -255,7 +255,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true | 
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | false | 
 
 
@@ -278,22 +278,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings

--- a/site3/website/versioned_docs/version-4.13.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.13.0/reference/config.md
@@ -255,7 +255,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true | 
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | false | 
 
 
@@ -278,22 +278,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings

--- a/site3/website/versioned_docs/version-4.14.8/reference/config.md
+++ b/site3/website/versioned_docs/version-4.14.8/reference/config.md
@@ -255,7 +255,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true | 
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | false | 
 
 
@@ -278,22 +278,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings

--- a/site3/website/versioned_docs/version-4.15.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.15.5/reference/config.md
@@ -261,7 +261,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true | 
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | false | 
 
 
@@ -284,22 +284,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings

--- a/site3/website/versioned_docs/version-4.16.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.16.5/reference/config.md
@@ -276,10 +276,9 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| enableStatistics | Whether statistics are enabled for the bookie. | true |
-| sanityCheckMetricsEnabled | Flag to enable sanity check metrics in bookie stats. | false |
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
-| limitStatsLogging | option to limit stats logging | true | 
+| enableStatistics | Whether statistics are enabled for the bookie. | true | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| limitStatsLogging | option to limit stats logging | false | 
 
 
 ## Prometheus Metrics Provider Settings
@@ -301,22 +300,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
 
 
 ## AutoRecovery general settings


### PR DESCRIPTION
### Motivation

Clean up ostrich related code、docs

### Changes

delete `ostrich` version define in `pom.xml`, wrong version docs.
