### PR TITLE
fix: reference counting (retain/release) in PerChannelBookieClient

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -261,18 +261,20 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
 
         toSend.retain();
         client.obtain((rc, pcbc) -> {
-            if (rc != BKException.Code.OK) {
-                try {
-                    executor.executeOrdered(ledgerId,
-                            () -> cb.writeLacComplete(rc, ledgerId, addr, ctx));
-                } catch (RejectedExecutionException re) {
-                    cb.writeLacComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
+            try {
+                if (rc != BKException.Code.OK) {
+                    try {
+                        executor.executeOrdered(ledgerId,
+                                () -> cb.writeLacComplete(rc, ledgerId, addr, ctx));
+                    } catch (RejectedExecutionException re) {
+                        cb.writeLacComplete(getRc(BKException.Code.InterruptedException), ledgerId, addr, ctx);
+                    }
+                } else {
+                    pcbc.writeLac(ledgerId, masterKey, lac, toSend, cb, ctx);
                 }
-            } else {
-                pcbc.writeLac(ledgerId, masterKey, lac, toSend, cb, ctx);
+            } finally {
+                ReferenceCountUtil.release(toSend);
             }
-
-            ReferenceCountUtil.release(toSend);
         }, ledgerId, useV3Enforced);
     }
 
@@ -407,14 +409,16 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         @Override
         public void operationComplete(final int rc,
                                       PerChannelBookieClient pcbc) {
-            if (rc != BKException.Code.OK) {
-                bookieClient.completeAdd(rc, ledgerId, entryId, addr, cb, ctx);
-            } else {
-                pcbc.addEntry(ledgerId, masterKey, entryId,
-                              toSend, cb, ctx, options, allowFastFail, writeFlags);
+            try {
+                if (rc != BKException.Code.OK) {
+                    bookieClient.completeAdd(rc, ledgerId, entryId, addr, cb, ctx);
+                } else {
+                    pcbc.addEntry(ledgerId, masterKey, entryId,
+                            toSend, cb, ctx, options, allowFastFail, writeFlags);
+                }
+            } finally {
+                ReferenceCountUtil.release(toSend);
             }
-
-            ReferenceCountUtil.release(toSend);
             recycle();
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
@@ -62,7 +62,7 @@ public class ByteStringUtil {
         } else {
             ByteString piece;
             if (byteBuf.hasArray()) {
-                piece = UnsafeByteOperations.unsafeWrap(byteBuf.array(), byteBuf.arrayOffset(),
+                piece = UnsafeByteOperations.unsafeWrap(byteBuf.array(), byteBuf.arrayOffset() + byteBuf.readerIndex(),
                         byteBuf.readableBytes());
             } else {
                 piece = UnsafeByteOperations.unsafeWrap(byteBuf.nioBuffer());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.proto;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
+import org.apache.bookkeeper.util.ByteBufList;
+
+public class ByteStringUtil {
+
+    /**
+     * Wrap the internal buffers of a ByteBufList into a single ByteString.
+     * The lifecycle of the wrapped ByteString is tied to the ByteBufList.
+     *
+     * @param bufList ByteBufList to wrap
+     * @return ByteString wrapping the internal buffers of the ByteBufList
+     */
+    public static ByteString byteBufListToByteString(ByteBufList bufList) {
+        ByteString aggregated = null;
+        for (int i = 0; i < bufList.size(); i++) {
+            aggregated = byteBufToByteString(aggregated, bufList.getBuffer(i));
+        }
+        return aggregated != null ? aggregated : ByteString.EMPTY;
+    }
+
+    /**
+     * Wrap the internal buffers of a ByteBuf into a single ByteString.
+     * The lifecycle of the wrapped ByteString is tied to the ByteBuf.
+     *
+     * @param byteBuf ByteBuf to wrap
+     * @return ByteString wrapping the internal buffers of the ByteBuf
+     */
+    public static ByteString byteBufToByteString(ByteBuf byteBuf) {
+        return byteBufToByteString(null, byteBuf);
+    }
+
+    // internal method to aggregate a ByteBuf into a single aggregated ByteString
+    private static ByteString byteBufToByteString(ByteString aggregated, ByteBuf byteBuf) {
+        if (byteBuf.nioBufferCount() > 1) {
+            for (ByteBuffer nioBuffer : byteBuf.nioBuffers()) {
+                ByteString piece = UnsafeByteOperations.unsafeWrap(nioBuffer);
+                aggregated = (aggregated == null) ? piece : aggregated.concat(piece);
+            }
+        } else {
+            ByteString piece;
+            if (byteBuf.hasArray()) {
+                piece = UnsafeByteOperations.unsafeWrap(byteBuf.array(), byteBuf.arrayOffset(),
+                        byteBuf.readableBytes());
+            } else {
+                piece = UnsafeByteOperations.unsafeWrap(byteBuf.nioBuffer());
+            }
+            aggregated = (aggregated == null) ? piece : aggregated.concat(piece);
+        }
+        return aggregated;
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ByteStringUtil.java
@@ -36,7 +36,10 @@ public class ByteStringUtil {
     public static ByteString byteBufListToByteString(ByteBufList bufList) {
         ByteString aggregated = null;
         for (int i = 0; i < bufList.size(); i++) {
-            aggregated = byteBufToByteString(aggregated, bufList.getBuffer(i));
+            ByteBuf buffer = bufList.getBuffer(i);
+            if (buffer.readableBytes() > 0) {
+                aggregated = byteBufToByteString(aggregated, buffer);
+            }
         }
         return aggregated != null ? aggregated : ByteString.EMPTY;
     }
@@ -54,6 +57,9 @@ public class ByteStringUtil {
 
     // internal method to aggregate a ByteBuf into a single aggregated ByteString
     private static ByteString byteBufToByteString(ByteString aggregated, ByteBuf byteBuf) {
+        if (byteBuf.readableBytes() == 0) {
+            return ByteString.EMPTY;
+        }
         if (byteBuf.nioBufferCount() > 1) {
             for (ByteBuffer nioBuffer : byteBuf.nioBuffers()) {
                 ByteString piece = UnsafeByteOperations.unsafeWrap(nioBuffer);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -789,7 +789,8 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                 request = byteBuf;
                 cleanupActionFailedBeforeWrite = byteBuf::release;
             } else {
-                ByteBufList byteBufList = ByteBufList.clone((ByteBufList) toSend);
+                ByteBufList byteBufList = (ByteBufList) toSend;
+                byteBufList.retain();
                 request = byteBufList;
                 cleanupActionFailedBeforeWrite = byteBufList::release;
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -291,7 +291,7 @@ public class ByteBufList extends AbstractReferenceCounted {
                     // release the ByteBufList after the write operation is completed
                     ReferenceCountUtil.safeRelease(b);
                     // complete the promise passed as an argument unless it's a void promise
-                    if (!promise.isVoid()) {
+                    if (promise != null && !promise.isVoid()) {
                         if (future.isSuccess()) {
                             promise.setSuccess();
                         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -286,19 +286,29 @@ public class ByteBufList extends AbstractReferenceCounted {
             if (msg instanceof ByteBufList) {
                 ByteBufList b = (ByteBufList) msg;
 
-                try {
-                    // Write each buffer individually on the socket. The retain() here is needed to preserve the fact
-                    // that ByteBuf are automatically released after a write. If the ByteBufPair ref count is increased
-                    // and it gets written multiple times, the individual buffers refcount should be reflected as well.
-                    int buffersCount = b.buffers.size();
-                    for (int i = 0; i < buffersCount; i++) {
-                        ByteBuf bx = b.buffers.get(i);
-                        // Last buffer will carry on the final promise to notify when everything was written on the
-                        // socket
-                        ctx.write(bx.retainedDuplicate(), i == (buffersCount - 1) ? promise : ctx.voidPromise());
+                ChannelPromise compositePromise = ctx.newPromise();
+                compositePromise.addListener(future -> {
+                    // release the ByteBufList after the write operation is completed
+                    ReferenceCountUtil.safeRelease(b);
+                    // complete the promise passed as an argument unless it's a void promise
+                    if (!promise.isVoid()) {
+                        if (future.isSuccess()) {
+                            promise.setSuccess();
+                        } else {
+                            promise.setFailure(future.cause());
+                        }
                     }
-                } finally {
-                    ReferenceCountUtil.release(b);
+                });
+
+                // Write each buffer individually on the socket. The retain() here is needed to preserve the fact
+                // that ByteBuf are automatically released after a write. If the ByteBufPair ref count is increased
+                // and it gets written multiple times, the individual buffers refcount should be reflected as well.
+                int buffersCount = b.buffers.size();
+                for (int i = 0; i < buffersCount; i++) {
+                    ByteBuf bx = b.buffers.get(i);
+                    // Last buffer will carry on the final promise to notify when everything was written on the
+                    // socket
+                    ctx.write(bx.retainedDuplicate(), i == (buffersCount - 1) ? compositePromise : ctx.voidPromise());
                 }
             } else {
                 ctx.write(msg, promise);


### PR DESCRIPTION
### Motivation

This addresses the remaining gaps of #4289 in handling ByteBuf retain/release.
This PR will also address the concern about NioBuffer lifecycle brought up in the review of the original PR review: https://github.com/apache/bookkeeper/issues/791#issuecomment-383237059 .

This PR fixes several problems:
* ByteString buffer lifecycle in client, follows ByteBufList lifecycle
* ByteBufList lifecycle, moved to write promise
* Calling of write promises in AuthHandler which buffers messages while authentication is in progress. It was ignoring the promises.

### Changes

- add 2 callback parameters to writeAndFlush: cleanupActionFailedBeforeWrite and cleanupActionAfterWrite
  - use these callback actions for proper cleanup
- extract a utility class ByteStringUtil for wrapping ByteBufList or ByteBuf as concatenated zero copy ByteString
- properly handle releasing of ByteBufList in the write promise
- properly handle calling promises that are buffered while authentication is in progress