### PR TITLE
fix tests running when skipTests provided

### DIFF
--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -86,6 +86,7 @@
               <include>**/*.cpp</include>
             </includes>
           </cpp>
+          <skipTests>${skipTests}</skipTests>
           <!-- skip by default, enabled in OS profiles -->
           <skip>true</skip>
         </configuration>

--- a/cpu-affinity/pom.xml
+++ b/cpu-affinity/pom.xml
@@ -53,6 +53,9 @@
         <groupId>com.github.maven-nar</groupId>
         <artifactId>nar-maven-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <skipTests>${skipTests}</skipTests>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix #2261 

### Motivation

fix tests running when skipTests provided

### Changes

config skipTests flag for `nar-maven-plugin`
