### PR TITLE
 Fix ThreadRegistry#register behavior to ensure correct Prom metrics 

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorController.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/executors/MockExecutorController.java
@@ -42,6 +42,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -172,6 +173,10 @@ public class MockExecutorController {
 
     private static Answer<Future<?>> answerNow() {
         return invocationOnMock -> {
+           // this method executes everything in the caller thread
+           // this messes up assertions that verify
+           // that a thread is part of only a threadpool
+           ThreadRegistry.forceClearRegistrationForTests(Thread.currentThread().getId());
 
            Runnable task = invocationOnMock.getArgument(0);
            task.run();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -660,7 +660,7 @@ public class BookieImpl implements Bookie {
         bookieThread = new BookieCriticalThread(() -> run(), "Bookie-" + conf.getBookiePort());
         bookieThread.setDaemon(true);
 
-        ThreadRegistry.register("BookieThread", 0);
+        ThreadRegistry.register("BookieThread");
         if (LOG.isDebugEnabled()) {
             LOG.debug("I'm starting a bookie with journal directories {}",
                     journalDirectories.stream().map(File::getName).collect(Collectors.joining(", ")));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -660,7 +660,7 @@ public class BookieImpl implements Bookie {
         bookieThread = new BookieCriticalThread(() -> run(), "Bookie-" + conf.getBookiePort());
         bookieThread.setDaemon(true);
 
-        ThreadRegistry.register("BookieThread");
+        ThreadRegistry.register("BookieThread", true);
         if (LOG.isDebugEnabled()) {
             LOG.debug("I'm starting a bookie with journal directories {}",
                     journalDirectories.stream().map(File::getName).collect(Collectors.joining(", ")));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -482,7 +482,7 @@ public class Journal implements CheckpointSource {
         @Override
         public void run() {
             LOG.info("ForceWrite Thread started");
-            ThreadRegistry.register(super.getName(), 0);
+            ThreadRegistry.register(super.getName());
 
             if (conf.isBusyWaitEnabled()) {
                 try {
@@ -955,7 +955,7 @@ public class Journal implements CheckpointSource {
      */
     public void run() {
         LOG.info("Starting journal on {}", journalDirectory);
-        ThreadRegistry.register(journalThreadName, 0);
+        ThreadRegistry.register(journalThreadName);
 
         if (conf.isBusyWaitEnabled()) {
             try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -82,7 +82,7 @@ class SyncThread implements Checkpointer {
         this.checkpointSource = checkpointSource;
         this.executor = newExecutor();
         this.syncExecutorTime = statsLogger.getThreadScopedCounter("sync-thread-time");
-        this.executor.submit(() -> ThreadRegistry.register(executorName, 0));
+        this.executor.submit(() -> ThreadRegistry.register(executorName));
     }
 
     @VisibleForTesting

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SyncThread.java
@@ -82,12 +82,16 @@ class SyncThread implements Checkpointer {
         this.checkpointSource = checkpointSource;
         this.executor = newExecutor();
         this.syncExecutorTime = statsLogger.getThreadScopedCounter("sync-thread-time");
-        this.executor.submit(() -> ThreadRegistry.register(executorName));
     }
 
     @VisibleForTesting
     static ScheduledExecutorService newExecutor() {
-        return Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory(executorName));
+        return Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory(executorName) {
+            @Override
+            protected Thread newThread(Runnable r, String name) {
+                return super.newThread(ThreadRegistry.registerThread(r, executorName), name);
+            }
+        });
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -117,7 +117,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     private static String dbStoragerExecutorName = "db-storage";
     private final ExecutorService executor = Executors.newSingleThreadExecutor(
-            new DefaultThreadFactory(dbStoragerExecutorName));
+            new DefaultThreadFactory(dbStoragerExecutorName) {
+                @Override
+                protected Thread newThread(Runnable r, String name) {
+                    return super.newThread(ThreadRegistry.registerThread(r, dbStoragerExecutorName), name);
+                }
+            });
 
     // Executor used to for db index cleanup
     private final ScheduledExecutorService cleanupExecutor = Executors
@@ -218,7 +223,6 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         flushExecutorTime = ledgerIndexDirStatsLogger.getThreadScopedCounter("db-storage-thread-time");
 
         executor.submit(() -> {
-            ThreadRegistry.register(dbStoragerExecutorName);
             // ensure the metric gets registered on start-up as this thread only executes
             // when the write cache is full which may not happen or not for a long time
             flushExecutorTime.addLatency(0, TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -218,7 +218,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         flushExecutorTime = ledgerIndexDirStatsLogger.getThreadScopedCounter("db-storage-thread-time");
 
         executor.submit(() -> {
-            ThreadRegistry.register(dbStoragerExecutorName, 0);
+            ThreadRegistry.register(dbStoragerExecutorName);
             // ensure the metric gets registered on start-up as this thread only executes
             // when the write cache is full which may not happen or not for a long time
             flushExecutorTime.addLatency(0, TimeUnit.NANOSECONDS);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -79,6 +79,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.processor.RequestProcessor;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 import org.apache.bookkeeper.util.ByteBufList;
 import org.apache.bookkeeper.util.EventLoopUtil;
 import org.apache.zookeeper.KeeperException;
@@ -122,7 +123,12 @@ class BookieNettyServer {
 
         if (!conf.isDisableServerSocketBind()) {
             this.eventLoopGroup = EventLoopUtil.getServerEventLoopGroup(conf,
-                    new DefaultThreadFactory("bookie-io"));
+                    new DefaultThreadFactory("bookie-io") {
+                        @Override
+                        protected Thread newThread(Runnable r, String name) {
+                            return super.newThread(ThreadRegistry.registerThread(r, "bookie-id"), name);
+                        }
+                    });
             this.acceptorGroup = EventLoopUtil.getServerAcceptorGroup(conf,
                     new DefaultThreadFactory("bookie-acceptor"));
             allChannels = new CleanupChannelGroup(eventLoopGroup);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerStorageCheckpointTest.java
@@ -56,6 +56,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 import org.apache.bookkeeper.test.ZooKeeperUtil;
 import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.PortManager;
@@ -97,6 +98,7 @@ public class LedgerStorageCheckpointTest {
 
     @Before
     public void setUp() throws Exception {
+        ThreadRegistry.clear();
         LOG.info("Setting up test {}", getClass());
 
         try {
@@ -128,6 +130,7 @@ public class LedgerStorageCheckpointTest {
 
     @After
     public void tearDown() throws Exception {
+        ThreadRegistry.clear();
         LOG.info("TearDown");
 
         sortedLedgerStorageMockedStatic.close();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -76,6 +76,7 @@ import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.replication.ReplicationWorker;
 import org.apache.bookkeeper.server.Main;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.ThreadRegistry;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.apache.bookkeeper.util.PortManager;
 import org.apache.zookeeper.KeeperException;
@@ -240,6 +241,11 @@ public abstract class BookKeeperClusterTestCase {
         if (tearDownException != null) {
             throw tearDownException;
         }
+    }
+
+    @After
+    public void clearMetricsThreadRegistry() throws Exception {
+        ThreadRegistry.clear();
     }
 
     /**

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
@@ -40,7 +40,8 @@ public class ThreadRegistry {
      */
     public static void register(String threadPool, int threadPoolThread, long threadId) {
         ThreadPoolThread tpt = new ThreadPoolThread(threadPool, threadPoolThread, threadId);
-        threadPoolMap.put(threadId, tpt);
+        ThreadPoolThread previous = threadPoolMap.put(threadId, tpt);
+        assert previous == null : "Thread " + threadId + " was already registered in thread pool " + previous.threadPool + " as thread " + previous.ordinal;
     }
 
     /*

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
@@ -18,6 +18,9 @@ package org.apache.bookkeeper.stats;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * For mapping thread ids to thread pools and threads within those pools
  * or just for lone named threads. Thread scoped metrics add labels to
@@ -25,6 +28,7 @@ import java.util.concurrent.ConcurrentMap;
  * For flexibility, this registry is not based on TLS.
  */
 public class ThreadRegistry {
+    private static Logger logger = LoggerFactory.getLogger(ThreadRegistry.class);
     private static ConcurrentMap<Long, ThreadPoolThread> threadPoolMap = new ConcurrentHashMap<>();
     private static ConcurrentMap<String, Integer> threadPoolThreadMap = new ConcurrentHashMap<>();
 
@@ -34,8 +38,31 @@ public class ThreadRegistry {
     for the given thread pool.
     */
     public static void register(String threadPool) {
+        register(threadPool, false);
+    }
+
+    public static void register(String threadPool, boolean force) {
         Integer threadPoolThread = threadPoolThreadMap.compute(threadPool, (k, v) -> v == null ? 0 : v + 1);
+        if (force) {
+            threadPoolMap.remove(Thread.currentThread().getId());
+        }
         register(threadPool, threadPoolThread, Thread.currentThread().getId());
+    }
+
+    /**
+     * In some tests we run in the same thread activities that should
+     * run in different threads from different thread-pools
+     * this would trigger assertions to fail.
+     * This is a convenience method to work around such cases.
+     * This method shouldn't be used in production code.
+     */
+    public static void forceClearRegistrationForTests(long threadId) {
+        threadPoolMap.compute(threadId, (id, value) -> {
+            if (value !=  null) {
+                logger.info("Forcibly clearing registry entry {} for thread id {}", value, id);
+            }
+           return null;
+        });
     }
 
     /*
@@ -48,14 +75,22 @@ public class ThreadRegistry {
 
     /*
         Thread factories can register a thread by its id.
+        The assumption is that one thread belongs only to one threadpool.
+        The doesn't hold in tests, in which we use mock Executors that
+        run the code in the same thread as the caller
      */
     public static void register(String threadPool, int threadPoolThread, long threadId) {
         ThreadPoolThread tpt = new ThreadPoolThread(threadPool, threadPoolThread, threadId);
         ThreadPoolThread previous = threadPoolMap.put(threadId, tpt);
         if (previous != null) {
             throw new IllegalStateException("Thread " + threadId + " was already registered in thread pool "
-                    + previous.threadPool + " as thread " + previous.ordinal);
+                    + previous.threadPool + " as thread " + previous.ordinal + " with threadId " + previous.threadId
+                    + " trying to overwrite with " + threadPool + " and ordinal " + threadPoolThread);
         }
+    }
+
+    public static Runnable registerThread(Runnable runnable, String threadPool) {
+        return new RegisteredRunnable(threadPool, runnable);
     }
 
     /*
@@ -93,6 +128,22 @@ public class ThreadRegistry {
 
         public int getOrdinal() {
             return ordinal;
+        }
+    }
+
+    private static class RegisteredRunnable implements Runnable {
+        private final String threadPool;
+        private final Runnable runnable;
+
+        public RegisteredRunnable(String threadPool, Runnable runnable) {
+            this.threadPool = threadPool;
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void run() {
+            register(threadPool);
+            runnable.run();
         }
     }
 }

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
@@ -26,6 +26,17 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class ThreadRegistry {
     private static ConcurrentMap<Long, ThreadPoolThread> threadPoolMap = new ConcurrentHashMap<>();
+    private static ConcurrentMap<String, Integer> threadPoolThreadMap = new ConcurrentHashMap<>();
+
+    /*
+    Threads can register themselves as their first act before carrying out
+    any work. By calling this method, the ThreadPoolThread is incremented
+    for the given thread pool.
+    */
+    public static void register(String threadPool) {
+        Integer threadPoolThread = threadPoolThreadMap.compute(threadPool, (k, v) -> v == null ? 0 : v + 1);
+        register(threadPool, threadPoolThread, Thread.currentThread().getId());
+    }
 
     /*
         Threads can register themselves as their first act before carrying out
@@ -49,6 +60,7 @@ public class ThreadRegistry {
      */
     public static void clear() {
         threadPoolMap.clear();
+        threadPoolThreadMap.clear();
     }
 
     /*

--- a/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
+++ b/stats/bookkeeper-stats-api/src/main/java/org/apache/bookkeeper/stats/ThreadRegistry.java
@@ -52,7 +52,10 @@ public class ThreadRegistry {
     public static void register(String threadPool, int threadPoolThread, long threadId) {
         ThreadPoolThread tpt = new ThreadPoolThread(threadPool, threadPoolThread, threadId);
         ThreadPoolThread previous = threadPoolMap.put(threadId, tpt);
-        assert previous == null : "Thread " + threadId + " was already registered in thread pool " + previous.threadPool + " as thread " + previous.ordinal;
+        if (previous != null) {
+            throw new IllegalStateException("Thread " + threadId + " was already registered in thread pool "
+                    + previous.threadPool + " as thread " + previous.ordinal);
+        }
     }
 
     /*

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
@@ -212,4 +212,9 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
             }
         };
     }
+
+    @Override
+    public String toString() {
+        return "DataSketchesOpStatsLogger{labels=" + labels + ", id=" + System.identityHashCode(this) + "}";
+    }
 }

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
@@ -96,9 +96,12 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
             ThreadRegistry.ThreadPoolThread tpt = ThreadRegistry.get();
             if (tpt == null) {
                 statsLoggers.set(defaultStatsLogger);
-                DataSketchesOpStatsLogger previous = provider.opStats.put(new ScopeContext(scopeContext.getScope(), originalLabels), defaultStatsLogger);
+                DataSketchesOpStatsLogger previous = provider.opStats
+                        .put(new ScopeContext(scopeContext.getScope(), originalLabels), defaultStatsLogger);
                 // If we overwrite a logger, metrics will not be collected correctly
-                assert previous == null;
+                if (previous != null) {
+                    throw new IllegalStateException("Invalid state. Overwrote a stats logger.");
+                }
                 return defaultStatsLogger;
             } else {
                 Map<String, String> threadScopedlabels = new HashMap<>(originalLabels);
@@ -106,9 +109,12 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
                 threadScopedlabels.put("thread", String.valueOf(tpt.getOrdinal()));
 
                 statsLogger.initializeThread(threadScopedlabels);
-                DataSketchesOpStatsLogger previous = provider.opStats.put(new ScopeContext(scopeContext.getScope(), threadScopedlabels), statsLogger);
+                DataSketchesOpStatsLogger previous = provider.opStats
+                        .put(new ScopeContext(scopeContext.getScope(), threadScopedlabels), statsLogger);
                 // If we overwrite a logger, metrics will not be collected correctly
-                assert previous == null;
+                if (previous != null) {
+                    throw new IllegalStateException("Invalid state. Overwrote a stats logger.");
+                }
             }
         }
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
@@ -96,7 +96,9 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
             ThreadRegistry.ThreadPoolThread tpt = ThreadRegistry.get();
             if (tpt == null) {
                 statsLoggers.set(defaultStatsLogger);
-                provider.opStats.put(new ScopeContext(scopeContext.getScope(), originalLabels), defaultStatsLogger);
+                DataSketchesOpStatsLogger previous = provider.opStats.put(new ScopeContext(scopeContext.getScope(), originalLabels), defaultStatsLogger);
+                // If we overwrite a logger, metrics will not be collected correctly
+                assert previous == null;
                 return defaultStatsLogger;
             } else {
                 Map<String, String> threadScopedlabels = new HashMap<>(originalLabels);
@@ -104,7 +106,9 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
                 threadScopedlabels.put("thread", String.valueOf(tpt.getOrdinal()));
 
                 statsLogger.initializeThread(threadScopedlabels);
-                provider.opStats.put(new ScopeContext(scopeContext.getScope(), threadScopedlabels), statsLogger);
+                DataSketchesOpStatsLogger previous = provider.opStats.put(new ScopeContext(scopeContext.getScope(), threadScopedlabels), statsLogger);
+                // If we overwrite a logger, metrics will not be collected correctly
+                assert previous == null;
             }
         }
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/ThreadScopedDataSketchesStatsLogger.java
@@ -22,12 +22,16 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.stats.OpStatsData;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.ThreadRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * OpStatsLogger implementation that lazily registers OpStatsLoggers per thread
  * with added labels for the threadpool/thresd name and thread no.
  */
 public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
+
+    private static Logger logger = LoggerFactory.getLogger(ThreadScopedDataSketchesStatsLogger.class);
 
     private ThreadLocal<DataSketchesOpStatsLogger> statsLoggers;
     private DataSketchesOpStatsLogger defaultStatsLogger;
@@ -95,11 +99,16 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
         if (!statsLogger.isThreadInitialized()) {
             ThreadRegistry.ThreadPoolThread tpt = ThreadRegistry.get();
             if (tpt == null) {
+                logger.warn("Thread {} was not registered in the thread registry. Using default stats logger {}.",
+                        Thread.currentThread(), defaultStatsLogger);
                 statsLoggers.set(defaultStatsLogger);
                 DataSketchesOpStatsLogger previous = provider.opStats
                         .put(new ScopeContext(scopeContext.getScope(), originalLabels), defaultStatsLogger);
                 // If we overwrite a logger, metrics will not be collected correctly
-                if (previous != null) {
+                if (previous != null && previous != defaultStatsLogger) {
+                    logger.error("Invalid state for thead " + Thread.currentThread() + ". Overwrote a stats logger."
+                                    + "New is {}, previous was {}",
+                            defaultStatsLogger, previous);
                     throw new IllegalStateException("Invalid state. Overwrote a stats logger.");
                 }
                 return defaultStatsLogger;
@@ -112,7 +121,10 @@ public class ThreadScopedDataSketchesStatsLogger implements OpStatsLogger {
                 DataSketchesOpStatsLogger previous = provider.opStats
                         .put(new ScopeContext(scopeContext.getScope(), threadScopedlabels), statsLogger);
                 // If we overwrite a logger, metrics will not be collected correctly
-                if (previous != null) {
+                if (previous != null && previous != statsLogger) {
+                    logger.error("Invalid state for thead " + Thread.currentThread() + ". Overwrote a stats logger."
+                                    + "New is {}, previous was {}",
+                            defaultStatsLogger, previous);
                     throw new IllegalStateException("Invalid state. Overwrote a stats logger.");
                 }
             }


### PR DESCRIPTION
Descriptions of the changes in this PR:

There is an issue in the `ThreadRegistry` that causes incomplete Prometheus metrics reporting. It is trivial to reproduce:

1. Start bookies with multiple journal directories.
2. Start multiple clients writing to the bookies.
3. Observe that the `bookkeeper_server_ADD_ENTRY_count` does not increment at a similar rate to the journal's add entry rate.

The bug can be understood abstractly by considering the following:

1. The `threadPoolMap` in `ThreadRegistry` goes from thread id to `ThreadPoolThread`.
2. The `ThreadPoolThread` is defined by the thread pool and the configured id.
3. Every time we set the id for step 2, we use `0`.
4. When we have multiple journals, we call the same `ThreadRegistry.register(journalThreadName, 0);` method multiple times.
5. The `threadPoolMap` ends up with multiple identical values for different keys.
6. `ThreadScopedDataSketchesStatsLogger#getStatsLogger` stores the identical values in the `provider.opStats` map and ultimately overwrites map values, which leads to an under-reporting of metrics.

### Motivation

Correct bookkeeper metrics reporting by ensuring that threads are properly registered in the `ThreadRegistry`.

### Changes

I replaced the static map in `ThreadRegistry#register` with a static `ThreadLocal` instance. While the original work in #2839, which was part of #2835, specifically indicated it did not want to use thread local storage (TLS) due to its complexity, I think it is worth it because of the added flexibility. Specifically, it is much simpler to handle cleanup of unnecessary metadata by using thread locals. Note that the thread id, previously used as the key in the static map, is not unique to the thread after the thread goes away, which poses problems if any threads recycle. While BK doesn't generally recycle these threads, the test framework does, so it helps to make tests pass while still being able to make useful assertions about state.

An interesting design detail that I noticed and did not change is documented in the ThreadRegistry. Specifically, it is that threads that go away will continue to report metrics. I think this is fine, but it's worth calling out.