### PR TITLE
compatible fix wrong key for getHttpServerTrustStorePassword

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -3706,6 +3706,12 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return http server trustStore password
      */
     public String getHttpServerTrustStorePassword() {
+        String serverTrustStorePassword = getString(HTTP_SERVER_TRUST_STORE_PASSWORD);
+        if (serverTrustStorePassword != null) {
+            return serverTrustStorePassword;
+        }
+        // mistake introduced in https://github.com/apache/bookkeeper/pull/2995
+        // will remove in next major version
         return getString(HTTP_SERVER_KEY_STORE_PASSWORD);
     }
 


### PR DESCRIPTION
 Fix #3639 

### Motivation

Fix mistake typo, compatible code can be removed in next major version