### PR TITLE
improve: remove duplicate forceGarbageCollection setValue in run method

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -398,12 +398,6 @@ public class GarbageCollectorThread implements Runnable {
         boolean suspendMinor = suspendMinorCompaction.get();
 
         runWithFlags(force, suspendMajor, suspendMinor);
-
-        if (force) {
-            // only set force to false if it had been true when the garbage
-            // collection cycle started
-            forceGarbageCollection.set(false);
-        }
     }
 
     public void runWithFlags(boolean force, boolean suspendMajor, boolean suspendMinor) {


### PR DESCRIPTION
### Motivation
remove duplicate forceGarbageCollection setValue, it is redundant and error-prone. It's already seted in

https://github.com/apache/bookkeeper/blob/945cfa138f2b64f258d5b53a98505264085500f0/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java#L473-L478