### PR TITLE
Prevent double flush due to race in SingleDirectoryDbLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -894,14 +894,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             writeCacheBeingFlushed = writeCache;
             writeCache = tmp;
 
+            // Set to true before updating hasFlushBeenTriggered to false.
+            isFlushOngoing.set(true);
             // since the cache is switched, we can allow flush to be triggered
             hasFlushBeenTriggered.set(false);
         } finally {
-            try {
-                isFlushOngoing.set(true);
-            } finally {
-                writeCacheRotationLock.unlockWrite(stamp);
-            }
+            writeCacheRotationLock.unlockWrite(stamp);
         }
     }
 


### PR DESCRIPTION
Disclaimer: I am not very familiar with this code, so please review carefully.

### Motivation

We use the `isFlushOngoing` and the `hasFlushBeenTriggered` atomic booleans to prevent concurrent flushes. See:

https://github.com/apache/bookkeeper/blob/2986e04f1057ba3da7c549b1479c187c9ba167f2/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java#L514-L530

By my reading of the code, it seems there is a brief period of time where the calling code will think it is valid to flush, even though there is a flush in progress.

### Changes

In the `SingleDirectoryDbLedgerStorage#swapWriteCache` method modified by this PR, I propose a change to set `isFlushOngoing` to true before setting `hasFlushBeenTriggered` to false.

Master Issue: none
