### PR TITLE
SingleDirectoryDbLedgerStorage skip optimistic cache put sometimes

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -480,7 +480,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         long stamp = writeCacheRotationLock.tryOptimisticRead();
         boolean inserted = false;
 
-        // If the stamp is 0, the lock is already acquired, validation will fail, and we can skip this put.
+        // If the stamp is 0, the lock was exclusively acquired, validation will fail, and we can skip this put.
         if (stamp != 0) {
             inserted = writeCache.put(ledgerId, entryId, entry);
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -480,8 +480,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         long stamp = writeCacheRotationLock.tryOptimisticRead();
         boolean inserted = false;
 
-        inserted = writeCache.put(ledgerId, entryId, entry);
-        if (!writeCacheRotationLock.validate(stamp)) {
+        // If the stamp is 0, the lock is already acquired, validation will fail, and we can skip this put.
+        if (stamp != 0) {
+            inserted = writeCache.put(ledgerId, entryId, entry);
+        }
+
+        if (stamp == 0 || !writeCacheRotationLock.validate(stamp)) {
             // The write cache was rotated while we were inserting. We need to acquire the proper read lock and repeat
             // the operation because we might have inserted in a write cache that was already being flushed and cleared,
             // without being sure about this last entry being flushed or not.


### PR DESCRIPTION
### Motivation

When tryOptimisticRead returns 0, the lock is acquired by another thread and we will fail the validation step. We can therefore skip the eager cache insertion.

Relevant javadocs from `StampedLock`:

```java
    /**
     * Returns a stamp that can later be validated, or zero
     * if exclusively locked.
     *
     * @return a valid optimistic read stamp, or zero if exclusively locked
     */
    public long tryOptimisticRead() {
        long s;
        return (((s = state) & WBIT) == 0L) ? (s & SBITS) : 0L;
    }

    /**
     * Returns true if the lock has not been exclusively acquired
     * since issuance of the given stamp. Always returns false if the
     * stamp is zero. Always returns true if the stamp represents a
     * currently held lock. Invoking this method with a value not
     * obtained from {@link #tryOptimisticRead} or a locking method
     * for this lock has no defined effect or result.
     *
     * @param stamp a stamp
     * @return {@code true} if the lock has not been exclusively acquired
     * since issuance of the given stamp; else false
     */
    public boolean validate(long stamp) {
        VarHandle.acquireFence();
        return (stamp & SBITS) == (state & SBITS);
    }
```

### Changes

Check for `stamp == 0` since it is a special case in the `StampedLock` class.
