### PR TITLE
Prevent race in SingleDirectoryDbLedgerStorage metrics collection

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -46,6 +46,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.StampedLock;
 import org.apache.bookkeeper.bookie.Bookie;
@@ -207,10 +209,17 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         gcThread = new GarbageCollectorThread(conf,
                 ledgerManager, ledgerDirsManager, this, entryLogger, ledgerIndexDirStatsLogger);
 
+        // Because the writeCache and the writeCacheBeingFlushed are swapped during flushes, it is
+        // safer to acquire the underlying cache size and count references and then use those for metrics.
+        final AtomicLong finalWriteCacheSize = writeCache.cacheSize;
+        final AtomicLong finalWriteCacheBeingFlushedSize = writeCacheBeingFlushed.cacheSize;
+        final LongAdder finalWriteCacheCounter = writeCache.cacheCount;
+        final LongAdder finalWriteCacheBeingFlushedCounter = writeCacheBeingFlushed.cacheCount;
+
         dbLedgerStorageStats = new DbLedgerStorageStats(
             ledgerIndexDirStatsLogger,
-            () -> writeCache.size() + writeCacheBeingFlushed.size(),
-            () -> writeCache.count() + writeCacheBeingFlushed.count(),
+            () -> finalWriteCacheSize.get() + finalWriteCacheBeingFlushedSize.get(),
+            () -> finalWriteCacheCounter.sum() + finalWriteCacheBeingFlushedCounter.sum(),
             () -> readCache.size(),
             () -> readCache.count()
         );

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/WriteCache.java
@@ -77,9 +77,9 @@ public class WriteCache implements Closeable {
     private final long segmentOffsetMask;
     private final long segmentOffsetBits;
 
-    private final AtomicLong cacheSize = new AtomicLong(0);
+    final AtomicLong cacheSize = new AtomicLong(0);
     private final AtomicLong cacheOffset = new AtomicLong(0);
-    private final LongAdder cacheCount = new LongAdder();
+    final LongAdder cacheCount = new LongAdder();
 
     private final ConcurrentLongHashSet deletedLedgers = ConcurrentLongHashSet.newBuilder().build();
 


### PR DESCRIPTION
### Motivation

We swap the `writeCache` and the `writeCacheBeingFlushed` on flush. Therefore, it is not safe to call each to get the size/count metrics. Instead, if we expose the underlying accumulators, we can safely get the stats.

### Changes

Expose the `AtomicLong` and the `LongAdder` objects in the `WriteCache` for safer metrics reporting.