### PR TITLE
build: disable BookieZKExpireTest beyond jdk17

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -21,10 +21,10 @@
 
 package org.apache.bookkeeper.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
@@ -38,6 +38,8 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.PortManager;
 import org.junit.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * Test bookie expiration.
@@ -54,6 +56,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
     */
     @Test
     @SuppressWarnings("deprecation")
+    @EnabledForJreRange(max = JRE.JAVA_17)
     public void testBookieServerZKRequestTimeoutBehaviour() throws Exception {
         // 6000 is minimum due to default tick time
         System.setProperty("zookeeper.request.timeout", "6000");
@@ -98,7 +101,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
                     break;
                 }
             }
-            assertNotNull("Send thread not found", sendthread);
+            assertNotNull(sendthread, "Send thread not found");
 
             log.info("Suspending threads");
             sendthread.suspend();
@@ -108,8 +111,8 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
             // allow watcher thread to run
             Thread.sleep(3000);
-            assertTrue("Bookie should not shutdown on zk timeout", server.isBookieRunning());
-            assertTrue("Bookie Server should not shutdown on zk timeout", server.isRunning());
+            assertTrue(server.isBookieRunning(), "Bookie should not shutdown on zk timeout");
+            assertTrue(server.isRunning(), "Bookie Server should not shutdown on zk timeout");
         } finally {
             System.clearProperty("zookeeper.request.timeout");
             server.shutdown();
@@ -124,6 +127,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
     */
     @FlakyTest(value = "https://github.com/apache/bookkeeper/issues/4142")
     @SuppressWarnings("deprecation")
+    @EnabledForJreRange(max = JRE.JAVA_17)
     public void testBookieServerZKSessionExpireBehaviour() throws Exception {
         // 6000 is minimum due to default tick time
         System.setProperty("zookeeper.request.timeout", "0");
@@ -168,7 +172,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
                     break;
                 }
             }
-            assertNotNull("Send thread not found", sendthread);
+            assertNotNull(sendthread, "Send thread not found");
 
             log.info("Suspending threads");
             sendthread.suspend();
@@ -178,8 +182,8 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
             // allow watcher thread to run
             Thread.sleep(3000);
-            assertFalse("Bookie should shutdown on losing zk session", server.isBookieRunning());
-            assertFalse("Bookie Server should shutdown on losing zk session", server.isRunning());
+            assertFalse(server.isBookieRunning(), "Bookie should shutdown on losing zk session");
+            assertFalse(server.isRunning(), "Bookie Server should shutdown on losing zk session");
         } finally {
             System.clearProperty("zookeeper.request.timeout");
             server.shutdown();


### PR DESCRIPTION
### Motivation

As of JDK 21, the methods `suspend` and `resume` on the `Thread` class throw `UnsupportedOperationException`.

### Changes

1. Added junit5 annotation `@EnabledForJreRange(max = JRE.JAVA_17)`(It's modern and better than junit4) to tests that use `suspend` and `resume`, effectively disabling these tests on JDK versions higher than 17 where these methods are not supported.
2. Migrate this test file to junit5
