### PR TITLE
Fix typos in interface ClientAuthProvider and BookieAuthProvider

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/BookieAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/BookieAuthProvider.java
@@ -39,7 +39,7 @@ public interface BookieAuthProvider {
         /**
          * Initialize the factory with the server configuration
          * and protobuf message registry. Implementors must
-         * add any extention messages which contain the auth
+         * add any extension messages which contain the auth
          * payload, so that the server can decode auth messages
          * it receives from the client.
          */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/ClientAuthProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/auth/ClientAuthProvider.java
@@ -37,7 +37,7 @@ public interface ClientAuthProvider {
         /**
          * Initialize the factory with the client configuration
          * and protobuf message registry. Implementors must
-         * add any extention messages which contain the auth
+         * add any extension messages which contain the auth
          * payload, so that the client can decode auth messages
          * it receives from the server.
          */


### PR DESCRIPTION
### Motivation

Fix typos in interface ClientAuthProvider and BookieAuthProvider

### Changes

fix typos: `extention` => `extension`