### PR TITLE
chore: fix typos in class DataIntegrityCookieValidation

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCookieValidation.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/datainteg/DataIntegrityCookieValidation.java
@@ -87,7 +87,7 @@ public class DataIntegrityCookieValidation implements CookieValidation {
 
     private void stampCookie(Cookie masterCookie, Version expectedVersion, List<File> directories)
             throws BookieException {
-        // stamp to ZK first as it's the authoritive cookie. If this fails part way through
+        // stamp to ZK first as it's the authoritative cookie. If this fails part way through
         // stamping the directories, then a data integrity check will occur.
         log.info("Stamping cookie to ZK");
         masterCookie.writeToRegistrationManager(registrationManager, conf, expectedVersion);


### PR DESCRIPTION
### Motivation

Fix typos in class DataIntegrityCookieValidation

### Changes

fix typos: `authoritive` => `authoritative`