### PR TITLE
chore: fix some typos in package org.apache.bookkeeper.bookie.storage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/Buffer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/Buffer.java
@@ -131,7 +131,7 @@ class Buffer {
      */
     int readInt(int offset) throws IOException {
         if (!hasData(offset, Integer.BYTES)) {
-            throw new IOException(exMsg("Buffer cannot satify int read")
+            throw new IOException(exMsg("Buffer cannot satisfy int read")
                                   .kv("offset", offset)
                                   .kv("bufferSize", bufferSize).toString());
         }
@@ -150,7 +150,7 @@ class Buffer {
      */
     long readLong(int offset) throws IOException {
         if (!hasData(offset, Long.BYTES)) {
-            throw new IOException(exMsg("Buffer cannot satify long read")
+            throw new IOException(exMsg("Buffer cannot satisfy long read")
                                   .kv("offset", offset)
                                   .kv("bufferSize", bufferSize).toString());
         }
@@ -166,7 +166,7 @@ class Buffer {
 
     /**
      * Read a bytebuf of size from the buffer at the given offset.
-     * If there are not enough bytes in the buffer to satify the read, some of the bytes are read
+     * If there are not enough bytes in the buffer to satisfy the read, some of the bytes are read
      * into the byte buffer and the number of bytes read is returned.
      */
     int readByteBuf(ByteBuf buffer, int offset, int size) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -287,7 +287,7 @@ public class DirectEntryLogger implements EntryLogger {
                 f.get();
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
-                throw new IOException("Interruped while flushing", ie);
+                throw new IOException("Interrupted while flushing", ie);
             } catch (ExecutionException ee) {
                 if (ee.getCause() instanceof IOException) {
                     throw (IOException) ee.getCause();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -465,7 +465,7 @@ public class DbLedgerStorage implements LedgerStorage {
             LedgerLoggerProcessor processor) throws IOException {
 
         checkNotNull(serverConf, "ServerConfiguration can't be null");
-        checkNotNull(processor, "LedgerLoggger info processor can't null");
+        checkNotNull(processor, "LedgerLogger info processor can't null");
 
         DiskChecker diskChecker = new DiskChecker(serverConf.getDiskUsageThreshold(),
                 serverConf.getDiskUsageWarnThreshold());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -652,7 +652,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         return entry;
     }
 
-    private void fillReadAheadCache(long orginalLedgerId, long firstEntryId, long firstEntryLocation) {
+    private void fillReadAheadCache(long originalLedgerId, long firstEntryId, long firstEntryLocation) {
         long readAheadStartNano = MathUtils.nowInNano();
         int count = 0;
         long size = 0;
@@ -663,20 +663,20 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             long currentEntryLocation = firstEntryLocation;
 
             while (chargeReadAheadCache(count, size) && currentEntryLogId == firstEntryLogId) {
-                ByteBuf entry = entryLogger.readEntry(orginalLedgerId,
+                ByteBuf entry = entryLogger.readEntry(originalLedgerId,
                         firstEntryId, currentEntryLocation);
 
                 try {
                     long currentEntryLedgerId = entry.getLong(0);
                     long currentEntryId = entry.getLong(8);
 
-                    if (currentEntryLedgerId != orginalLedgerId) {
+                    if (currentEntryLedgerId != originalLedgerId) {
                         // Found an entry belonging to a different ledger, stopping read-ahead
                         break;
                     }
 
                     // Insert entry in read cache
-                    readCache.put(orginalLedgerId, currentEntryId, entry);
+                    readCache.put(originalLedgerId, currentEntryId, entry);
 
                     count++;
                     firstEntryId++;
@@ -690,7 +690,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             }
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Exception during read ahead for ledger: {}: e", orginalLedgerId, e);
+                log.debug("Exception during read ahead for ledger: {}: e", originalLedgerId, e);
             }
         } finally {
             dbLedgerStorageStats.getReadAheadBatchCountStats().registerSuccessfulValue(count);
@@ -720,7 +720,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             ByteBuf entry = writeCache.getLastEntry(ledgerId);
             if (entry != null) {
                 if (log.isDebugEnabled()) {
-                    long foundLedgerId = entry.readLong(); // ledgedId
+                    long foundLedgerId = entry.readLong(); // ledgerId
                     long entryId = entry.readLong();
                     entry.resetReaderIndex();
                     if (log.isDebugEnabled()) {
@@ -737,7 +737,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             entry = writeCacheBeingFlushed.getLastEntry(ledgerId);
             if (entry != null) {
                 if (log.isDebugEnabled()) {
-                    entry.readLong(); // ledgedId
+                    entry.readLong(); // ledgerId
                     long entryId = entry.readLong();
                     entry.resetReaderIndex();
                     if (log.isDebugEnabled()) {
@@ -856,7 +856,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
             dbLedgerStorageStats.getFlushSizeStats().registerSuccessfulValue(sizeToFlush);
         } catch (IOException e) {
             recordFailedEvent(dbLedgerStorageStats.getFlushStats(), startTime);
-            // Leave IOExecption as it is
+            // Leave IOException as it is
             throw e;
         } finally {
             try {


### PR DESCRIPTION
### Motivation

Fix some typos in package org.apache.bookkeeper.bookie.storage.

### Changes

`satify` => `satisfy`
`Interruped` => `Interrupted`
`LedgerLoggger` => `LedgerLogger`
`orginalLedgerId` => `originalLedgerId`
`IOExecption` => `IOException`