### PR TITLE
[fix] Fix ConcurrentLongHashMap concurrency issue

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -356,11 +356,9 @@ public class ConcurrentLongHashMap<V> {
                     int capacity = this.capacity;
                     bucket = signSafeMod(bucket, capacity);
 
-                    // First try optimistic locking
-                    long storedKey = keys[bucket];
-                    V storedValue = values[bucket];
-
                     if (!acquiredLock && validate(stamp)) {
+                        long storedKey = keys[bucket];
+                        V storedValue = values[bucket];
                         // The values we have read are consistent
                         if (storedKey == key) {
                             return storedValue != DeletedValue ? storedValue : null;
@@ -373,8 +371,6 @@ public class ConcurrentLongHashMap<V> {
                         if (!acquiredLock) {
                             stamp = readLock();
                             acquiredLock = true;
-                            storedKey = keys[bucket];
-                            storedValue = values[bucket];
                         }
 
                         if (capacity != this.capacity) {
@@ -382,6 +378,9 @@ public class ConcurrentLongHashMap<V> {
                             bucket = keyHash;
                             continue;
                         }
+
+                        long storedKey = keys[bucket];
+                        V storedValue = values[bucket];
 
                         if (storedKey == key) {
                             return storedValue != DeletedValue ? storedValue : null;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -347,16 +347,18 @@ public class ConcurrentLongHashMap<V> {
 
         V get(long key, int keyHash) {
             long stamp = readLock();
+            int bucket = signSafeMod(keyHash, this.capacity);
             try {
-                int bucket = signSafeMod(keyHash, this.capacity);
-                long storeKey = keys[bucket];
-                V storeValue = values[bucket];
-                if (storeKey == key) {
-                    return storeValue != DeletedValue ? storeValue : null;
-                } else if (storeValue == EmptyValue) {
-                    return null;
+                while (true) {
+                    long storeKey = keys[bucket];
+                    V storeValue = values[bucket];
+                    if (storeKey == key) {
+                        return storeValue != DeletedValue ? storeValue : null;
+                    } else if (storeValue == EmptyValue) {
+                        return null;
+                    }
+                    ++bucket;
                 }
-                return null;
             } finally {
                 unlockRead(stamp);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -347,9 +347,10 @@ public class ConcurrentLongHashMap<V> {
 
         V get(long key, int keyHash) {
             long stamp = readLock();
-            int bucket = signSafeMod(keyHash, this.capacity);
+            int bucket = keyHash;
             try {
                 while (true) {
+                    bucket = signSafeMod(bucket, capacity);
                     long storeKey = keys[bucket];
                     V storeValue = values[bucket];
                     if (storeKey == key) {


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Fix ConcurrentLongHashMap can be ArrayIndexOutBound when call `get`

### Changes

(Describe: what changes you have made)

Master Issue: https://github.com/apache/bookkeeper/issues/4316

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
