### PR TITLE
fix guava shade error in distributedlog

### DIFF
--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -36,20 +36,8 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-reload4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.reload4j</groupId>
-          <artifactId>reload4j</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.netty</groupId>
@@ -83,6 +71,7 @@
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.fasterxml.jackson.core:jackson-databind</include>
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                  <include>com.google.guava:failureaccess</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>net.jpountz.lz4:lz4</include>


### PR DESCRIPTION
Fix #2700 

## Changes

- shade jar should include com.google.guava:failureaccess.
- remove unused exclude dependency now.