### PR TITLE
build: disable DirectIO Tests in windows

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestBuffer.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestBuffer.java
@@ -20,9 +20,9 @@
  */
 package org.apache.bookkeeper.bookie.storage.directentrylogger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // CHECKSTYLE.OFF: IllegalImport
 import io.netty.buffer.ByteBuf;
@@ -31,7 +31,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 // CHECKSTYLE.ON: IllegalImport
 
 /**
@@ -59,19 +60,25 @@ public class TestBuffer {
         assertEquals(0x7FFFF000, Buffer.nextAlignment(0x7FFFF000));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNegativePosition() throws Exception {
-        Buffer.nextAlignment(-1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Buffer.nextAlignment(-1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMaxAlignment() throws Exception {
-        Buffer.nextAlignment(Integer.MAX_VALUE);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Buffer.nextAlignment(Integer.MAX_VALUE);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateUnaligned() throws Exception {
-        new Buffer(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1234);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new Buffer(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1234);
+        });
     }
 
     @Test
@@ -148,7 +155,7 @@ public class TestBuffer {
         assertEquals(4096, ret);
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testReadIntAtBoundary() throws Exception {
         Buffer b = new Buffer(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 4096);
 
@@ -159,10 +166,10 @@ public class TestBuffer {
         assertFalse(b.hasData(4093, Integer.BYTES));
         assertFalse(b.hasData(4096, Integer.BYTES));
 
-        b.readInt(4096 - 2);
+        Assertions.assertThrows(IOException.class, () -> b.readInt(4096 - 2));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testReadLongAtBoundary() throws Exception {
         Buffer b = new Buffer(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 4096);
 
@@ -173,7 +180,7 @@ public class TestBuffer {
         assertFalse(b.hasData(4089, Long.BYTES));
         assertFalse(b.hasData(4096, Long.BYTES));
 
-        b.readInt(4096 - 2);
+        Assertions.assertThrows(IOException.class, () -> b.readInt(4096 - 2));
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLogger.java
@@ -49,14 +49,17 @@ import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * TestDirectEntryLogger.
  */
 @Slf4j
+@DisabledOnOs(OS.WINDOWS)
 public class TestDirectEntryLogger {
     private final Slogger slog = Slogger.CONSOLE;
 
@@ -64,7 +67,7 @@ public class TestDirectEntryLogger {
 
     private final TmpDirs tmpDirs = new TmpDirs();
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
     }
@@ -327,7 +330,7 @@ public class TestDirectEntryLogger {
                 int logId = logIdFromLocation(loc1);
                 try {
                     reader.readEntryLogIndex(logId);
-                    Assert.fail("Shouldn't be there");
+                    Assertions.fail("Shouldn't be there");
                 } catch (IOException ioe) {
                     // expected
                 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLoggerCompat.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectEntryLoggerCompat.java
@@ -45,12 +45,15 @@ import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
 import org.apache.bookkeeper.util.DiskChecker;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * TestDirectEntryLoggerCompat.
  */
+@DisabledOnOs(OS.WINDOWS)
 public class TestDirectEntryLoggerCompat {
     private final Slogger slog = Slogger.CONSOLE;
 
@@ -60,7 +63,7 @@ public class TestDirectEntryLoggerCompat {
 
     private final TmpDirs tmpDirs = new TmpDirs();
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectReader.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectReader.java
@@ -44,29 +44,24 @@ import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 
 /**
  * TestDirectReader.
  */
+@DisabledOnOs(OS.WINDOWS)
 public class TestDirectReader {
 
     private final TmpDirs tmpDirs = new TmpDirs();
     private final ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
     private final OpStatsLogger opLogger = NullStatsLogger.INSTANCE.getOpStatsLogger("null");
 
-    @Before
-    public void before() {
-        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
-    }
-
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
         writeExecutor.shutdownNow();
@@ -236,17 +231,19 @@ public class TestDirectReader {
         }
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public void testReadPastEndOfFile() throws Exception {
         File ledgerDir = tmpDirs.createNew("readBuffer", "logs");
 
         writeFileWithPattern(ledgerDir, 1234, 0xbeeeeeef, 1, 1 << 13);
-        try (LogReader reader = new DirectReader(1234, logFilename(ledgerDir, 1234),
-                                                 ByteBufAllocator.DEFAULT,
-                                                 new NativeIOImpl(), Buffer.ALIGNMENT,
-                                                 1 << 20, opLogger)) {
-            reader.readBufferAt(1 << 13, Buffer.ALIGNMENT);
-        }
+        Assertions.assertThrows(EOFException.class, () -> {
+            try (LogReader reader = new DirectReader(1234, logFilename(ledgerDir, 1234),
+                                                     ByteBufAllocator.DEFAULT,
+                                                     new NativeIOImpl(), Buffer.ALIGNMENT,
+                                                     1 << 20, opLogger)) {
+                reader.readBufferAt(1 << 13, Buffer.ALIGNMENT);
+            }
+        });
     }
 
     @Test(expected = EOFException.class)
@@ -254,12 +251,14 @@ public class TestDirectReader {
         File ledgerDir = tmpDirs.createNew("readBuffer", "logs");
 
         writeFileWithPattern(ledgerDir, 1234, 0xbeeeeeef, 1, 1 << 13);
-        try (LogReader reader = new DirectReader(1234, logFilename(ledgerDir, 1234),
-                                                 ByteBufAllocator.DEFAULT,
-                                                 new NativeIOImpl(), Buffer.ALIGNMENT,
-                                                 1 << 20, opLogger)) {
-            reader.readBufferAt((1 << 13) - Buffer.ALIGNMENT / 2, Buffer.ALIGNMENT);
-        }
+        Assertions.assertThrows(EOFException.class, () -> {
+            try (LogReader reader = new DirectReader(1234, logFilename(ledgerDir, 1234),
+                                                     ByteBufAllocator.DEFAULT,
+                                                     new NativeIOImpl(), Buffer.ALIGNMENT,
+                                                     1 << 20, opLogger)) {
+                reader.readBufferAt((1 << 13) - Buffer.ALIGNMENT / 2, Buffer.ALIGNMENT);
+            }
+        });
     }
 
     @Test
@@ -329,7 +328,7 @@ public class TestDirectReader {
 
             try {
                 reader.readEntryAt(offset);
-                Assert.fail("Should have failed");
+                Assertions.fail("Should have failed");
             } catch (IOException ioe) {
                 // expected
             }
@@ -367,7 +366,7 @@ public class TestDirectReader {
 
             try {
                 reader.readEntryAt(offset);
-                Assert.fail("Should have failed");
+                Assertions.fail("Should have failed");
             } catch (IOException ioe) {
                 // expected
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectReader.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectReader.java
@@ -246,7 +246,7 @@ public class TestDirectReader {
         });
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public void testReadPastEndOfFilePartial() throws Exception {
         File ledgerDir = tmpDirs.createNew("readBuffer", "logs");
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectWriter.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectWriter.java
@@ -207,7 +207,8 @@ public class TestDirectWriter {
 
     @Test
     public void testWriteBlocksFlush() throws Exception {
-        try(ExecutorService flushExecutor = Executors.newSingleThreadExecutor()) {
+        ExecutorService flushExecutor = Executors.newSingleThreadExecutor();
+        try {
             File ledgerDir = tmpDirs.createNew("blockWrite", "logs");
             try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8);
                  LogWriter writer = new DirectWriter(1234, logFilename(ledgerDir, 1234),
@@ -239,6 +240,8 @@ public class TestDirectWriter {
                     assertThat((int) contents.readByte(), equalTo(0));
                 }
             }
+        } finally {
+            flushExecutor.shutdown();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectWriter.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestDirectWriter.java
@@ -40,50 +40,57 @@ import org.apache.bookkeeper.common.util.nativeio.NativeIOException;
 import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.test.TmpDirs;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * TestDirectWriter.
  */
+@DisabledOnOs(OS.WINDOWS)
 public class TestDirectWriter {
     private static final Slogger slog = Slogger.CONSOLE;
 
     private final TmpDirs tmpDirs = new TmpDirs();
     private final ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
         writeExecutor.shutdownNow();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteAtAlignment() throws Exception {
         File ledgerDir = tmpDirs.createNew("writeAlignment", "logs");
-        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
-             LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678),
-                                                 1 << 24, writeExecutor,
-                                                 buffers, new NativeIOImpl(), Slogger.CONSOLE)) {
-            ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT);
-            TestBuffer.fillByteBuf(bb, 0xdededede);
-            writer.writeAt(1234, bb);
-            writer.flush();
-        }
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
+                 LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678),
+                         1 << 24, writeExecutor,
+                         buffers, new NativeIOImpl(), Slogger.CONSOLE)) {
+                ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT);
+                TestBuffer.fillByteBuf(bb, 0xdededede);
+                writer.writeAt(1234, bb);
+                writer.flush();
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteAlignmentSize() throws Exception {
         File ledgerDir = tmpDirs.createNew("writeAlignment", "logs");
-        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
-             LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
-                                                 buffers, new NativeIOImpl(), Slogger.CONSOLE)) {
-            ByteBuf bb = Unpooled.buffer(123);
-            TestBuffer.fillByteBuf(bb, 0xdededede);
-            writer.writeAt(0, bb);
-            writer.flush();
-        }
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
+                 LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
+                         buffers, new NativeIOImpl(), Slogger.CONSOLE)) {
+                ByteBuf bb = Unpooled.buffer(123);
+                TestBuffer.fillByteBuf(bb, 0xdededede);
+                writer.writeAt(0, bb);
+                writer.flush();
+            }
+        });
     }
 
     @Test
@@ -100,7 +107,7 @@ public class TestDirectWriter {
     }
 
 
-    @Test(timeout = 10000)
+    @Test
     public void testFlushingWillWaitForBuffer() throws Exception {
         File ledgerDir = tmpDirs.createNew("writeFailFailsFlush", "logs");
         try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT,
@@ -114,59 +121,62 @@ public class TestDirectWriter {
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testWriteFailFailsFlush() throws Exception {
         File ledgerDir = tmpDirs.createNew("writeFailFailsFlush", "logs");
         NativeIO io = new NativeIOImpl() {
-                boolean failed = false;
-                @Override
-                public int pwrite(int fd, long pointer, int count, long offset) throws NativeIOException {
-                    synchronized (this) {
-                        if (!failed) {
-                            failed = true;
-                            throw new NativeIOException("fail for test");
-                        }
+            boolean failed = false;
+            @Override
+            public int pwrite(int fd, long pointer, int count, long offset) throws NativeIOException {
+                synchronized (this) {
+                    if (!failed) {
+                        failed = true;
+                        throw new NativeIOException("fail for test");
                     }
-                    return super.pwrite(fd, pointer, count, offset);
                 }
-            };
-        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
-             LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
-                                                 buffers, io, Slogger.CONSOLE)) {
-            for (int i = 0; i < 10; i++) {
-                ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT / 2);
-                TestBuffer.fillByteBuf(bb, 0xdededede);
-                writer.writeDelimited(bb);
+                return super.pwrite(fd, pointer, count, offset);
             }
-            writer.flush();
-        }
+        };
+        Assertions.assertThrows(IOException.class, () -> {
+            try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, Buffer.ALIGNMENT, 8);
+                 LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
+                         buffers, io, Slogger.CONSOLE)) {
+                for (int i = 0; i < 10; i++) {
+                    ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT / 2);
+                    TestBuffer.fillByteBuf(bb, 0xdededede);
+                    writer.writeDelimited(bb);
+                }
+                writer.flush();
+            }
+        });
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testWriteAtFailFailsFlush() throws Exception {
-        File ledgerDir = tmpDirs.createNew("writeFailFailsFlush", "logs");
+        File ledgerDir = tmpDirs.createNew("writeAtFailFailsFlush", "logs");
         NativeIO io = new NativeIOImpl() {
-                boolean failed = false;
-                @Override
-                public int pwrite(int fd, long pointer, int count, long offset) throws NativeIOException {
-                    synchronized (this) {
-                        if (!failed) {
-                            failed = true;
-                            throw new NativeIOException("fail for test");
-                        }
+            boolean failed = false;
+            @Override
+            public int pwrite(int fd, long pointer, int count, long offset) throws NativeIOException {
+                synchronized (this) {
+                    if (!failed) {
+                        failed = true;
+                        throw new NativeIOException("fail for test");
                     }
-                    return super.pwrite(fd, pointer, count, offset);
                 }
-            };
-
-        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8);
-             LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
-                                                 buffers, io, Slogger.CONSOLE)) {
-            ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT);
-            TestBuffer.fillByteBuf(bb, 0xdededede);
-            writer.writeAt(0, bb);
-            writer.flush();
-        }
+                return super.pwrite(fd, pointer, count, offset);
+            }
+        };
+        Assertions.assertThrows(IOException.class, () -> {
+            try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8);
+                 LogWriter writer = new DirectWriter(5678, logFilename(ledgerDir, 5678), 1 << 24, writeExecutor,
+                         buffers, io, Slogger.CONSOLE)) {
+                ByteBuf bb = Unpooled.buffer(Buffer.ALIGNMENT);
+                TestBuffer.fillByteBuf(bb, 0xdededede);
+                writer.writeAt(0, bb);
+                writer.flush();
+            }
+        });
     }
 
     @Test
@@ -197,8 +207,7 @@ public class TestDirectWriter {
 
     @Test
     public void testWriteBlocksFlush() throws Exception {
-        ExecutorService flushExecutor = Executors.newSingleThreadExecutor();
-        try {
+        try(ExecutorService flushExecutor = Executors.newSingleThreadExecutor()) {
             File ledgerDir = tmpDirs.createNew("blockWrite", "logs");
             try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8);
                  LogWriter writer = new DirectWriter(1234, logFilename(ledgerDir, 1234),
@@ -230,23 +239,20 @@ public class TestDirectWriter {
                     assertThat((int) contents.readByte(), equalTo(0));
                 }
             }
-        } finally {
-            flushExecutor.shutdownNow();
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testFailsToOpen() throws Exception {
         File ledgerDir = tmpDirs.createNew("failOpen", "logs");
         ledgerDir.delete();
 
-        BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8);
-        try {
-            new DirectWriter(1234, logFilename(ledgerDir, 1234),
-                    1 << 30, MoreExecutors.newDirectExecutorService(),
-                    buffers, new NativeIOImpl(), Slogger.CONSOLE);
-        } finally {
-            buffers.close();
+        try (BufferPool buffers = new BufferPool(new NativeIOImpl(), ByteBufAllocator.DEFAULT, 1 << 14, 8)) {
+            Assertions.assertThrows(IOException.class, () -> {
+                new DirectWriter(1234, logFilename(ledgerDir, 1234),
+                        1 << 30, MoreExecutors.newDirectExecutorService(),
+                        buffers, new NativeIOImpl(), Slogger.CONSOLE);
+            });
         }
     }
 
@@ -304,7 +310,7 @@ public class TestDirectWriter {
 
             try {
                 writer.writeDelimited(b1);
-                Assert.fail("Shouldn't be possible, we've gone past MAX_INT");
+                Assertions.fail("Shouldn't be possible, we've gone past MAX_INT");
             } catch (IOException ioe) {
                 // expected
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestEntryLogIds.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestEntryLogIds.java
@@ -27,7 +27,7 @@ import static org.apache.bookkeeper.bookie.storage.EntryLogTestUtils.newLegacyEn
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
@@ -39,8 +39,8 @@ import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.test.TmpDirs;
 import org.apache.bookkeeper.util.LedgerDirUtil;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestEntryLogIds.
@@ -50,7 +50,7 @@ public class TestEntryLogIds {
 
     private final TmpDirs tmpDirs = new TmpDirs();
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestMetadata.java
@@ -35,17 +35,19 @@ import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.WINDOWS)
 public class TestMetadata {
-    private static final Slogger slog = Slogger.CONSOLE;
     private final OpStatsLogger opLogger = NullStatsLogger.INSTANCE.getOpStatsLogger("null");
 
     private final TmpDirs tmpDirs = new TmpDirs();
     private final ExecutorService writeExecutor = Executors.newSingleThreadExecutor();
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
         writeExecutor.shutdownNow();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestTransactionalEntryLogCompactor.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/directentrylogger/TestTransactionalEntryLogCompactor.java
@@ -56,12 +56,15 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.TmpDirs;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * TestTransactionalEntryLogCompactor.
  */
+@DisabledOnOs(OS.WINDOWS)
 public class TestTransactionalEntryLogCompactor {
     private static final Slogger slog = Slogger.CONSOLE;
 
@@ -69,7 +72,7 @@ public class TestTransactionalEntryLogCompactor {
     private static final long deadLedger = 1L;
     private static final long liveLedger = 2L;
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         tmpDirs.cleanup();
     }


### PR DESCRIPTION
### Changes

1. Added junit5 annotation `@DisabledOnOs(OS.WINDOWS)`(It's modern and better than junit4) to tests that use `suspend` and `resume`, effectively disabling these tests on windows.
2. Migrate these test files to junit5

See also https://lists.apache.org/thread/hlyc722gy45s3y61q7n79hdcr6cgrx7v