### PR TITLE
Adjust Log Level for LedgerFencedException in WriteEntryProcessor

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -81,7 +81,7 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             }
         } catch (OperationRejectedException e) {
             requestProcessor.getRequestStats().getAddEntryRejectedCounter().inc();
-            // Avoid to log each occurence of this exception as this can happen when the ledger storage is
+            // Avoid to log each occurrence of this exception as this can happen when the ledger storage is
             // unable to keep up with the write rate.
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Operation rejected while writing {}", request, e);
@@ -91,7 +91,8 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
             LOG.error("Error writing {}", request, e);
             rc = BookieProtocol.EIO;
         } catch (BookieException.LedgerFencedException lfe) {
-            LOG.error("Attempt to write to fenced ledger", lfe);
+            LOG.warn("Write attempt on fenced ledger {} by client {}", request.getLedgerId(),
+                    requestHandler.ctx().channel().remoteAddress());
             rc = BookieProtocol.EFENCED;
         } catch (BookieException e) {
             LOG.error("Unauthorized access to ledger {}", request.getLedgerId(), e);


### PR DESCRIPTION
Fix #4326 
### Motivation

Currently, when a `LedgerFencedException` occurs during the write operation, it is logged at the ERROR level in `WriteEntryProcessor`. This is misleading and unnecessarily alarming for system administrators, as a fenced ledger during recovery is an expected scenario, not an actual error condition. This change aims to reduce the severity level of such log entries to make the logs more informative and less cluttered with non-critical errors.

### Changes

- Adjusted the log level for `LedgerFencedException` in `WriteEntryProcessor` from ERROR to WARN.
- Added ledger ID and client IP information to the log message for better context and tracking.
- Corrected a typo in the comment within the same file to improve code readability.

This change makes the log output more consistent with how fenced ledgers are reported on the read path and improves the overall clarity of the log messages.
