### PR TITLE
Rename Main to BookkeeperStarter for Improved Clarity and Context

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -157,7 +157,7 @@ fi
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"
 if [ ${COMMAND} == "bookie" ]; then
-  exec "${JAVA}" ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
+  exec "${JAVA}" ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.BookkeeperStarter --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "autorecovery" ]; then
   exec "${JAVA}" ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "localbookie" ]; then

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -43,7 +43,7 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.processor.RequestProcessor;
 import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.tls.SecurityException;
 import org.apache.bookkeeper.tls.SecurityHandlerFactory;
@@ -297,7 +297,7 @@ public class BookieServer {
      * Legacy Method to run bookie server.
      */
     public static void main(String[] args) {
-        Main.main(args);
+        BookkeeperStarter.main(args);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/BookkeeperStarter.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/BookkeeperStarter.java
@@ -49,7 +49,7 @@ import org.apache.commons.configuration.ConfigurationException;
  * replacing the legacy server {@link org.apache.bookkeeper.proto.BookieServer}.
  */
 @Slf4j
-public class Main {
+public class BookkeeperStarter {
     static final Options BK_OPTS = new Options();
     static {
         BK_OPTS.addOption("c", "conf", true, "Configuration for Bookie Server");
@@ -161,8 +161,8 @@ public class Main {
             if (cmdLine.hasOption("httpport")) {
                 String sPort = cmdLine.getOptionValue("httpport");
                 log.info("Get cmdline http port: {}", sPort);
-                Integer iPort = Integer.parseInt(sPort);
-                conf.setHttpServerPort(iPort.intValue());
+                int iPort = Integer.parseInt(sPort);
+                conf.setHttpServerPort(iPort);
             }
 
             if (cmdLine.hasOption('j')) {
@@ -295,7 +295,7 @@ public class Main {
         if (journalDirs != null) {
             for (File j : journalDirs) {
                 File cur = BookieImpl.getCurrentDirectory(j);
-                if (!dirs.stream().anyMatch(f -> f.equals(cur))) {
+                if (dirs.stream().noneMatch(f -> f.equals(cur))) {
                     BookieImpl.checkDirectoryStructure(cur);
                     dirs.add(cur);
                 }
@@ -306,7 +306,7 @@ public class Main {
         if (ledgerDirs != null) {
             for (File l : ledgerDirs) {
                 File cur = BookieImpl.getCurrentDirectory(l);
-                if (!dirs.stream().anyMatch(f -> f.equals(cur))) {
+                if (dirs.stream().noneMatch(f -> f.equals(cur))) {
                     BookieImpl.checkDirectoryStructure(cur);
                     dirs.add(cur);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
@@ -29,7 +29,7 @@ import static org.apache.bookkeeper.bookie.BookieImpl.newBookieImpl;
 import static org.apache.bookkeeper.bookie.LegacyCookieValidation.newLegacyCookieValidation;
 import static org.apache.bookkeeper.client.BookKeeperClientStats.CLIENT_SCOPE;
 import static org.apache.bookkeeper.replication.ReplicationStats.REPLICATION_SCOPE;
-import static org.apache.bookkeeper.server.Main.storageDirectoriesFromConf;
+import static org.apache.bookkeeper.server.BookkeeperStarter.storageDirectoriesFromConf;
 import static org.apache.bookkeeper.server.component.ServerLifecycleComponent.loadServerComponents;
 
 import com.google.common.base.Ticker;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -18,7 +18,7 @@
 package org.apache.bookkeeper.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.bookkeeper.server.Main.storageDirectoriesFromConf;
+import static org.apache.bookkeeper.server.BookkeeperStarter.storageDirectoriesFromConf;
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -94,7 +94,7 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.replication.ReplicationStats;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.server.service.AutoRecoveryService;
 import org.apache.bookkeeper.server.service.BookieService;
@@ -801,7 +801,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         /*
          * Create LifecycleComponent for BookieServer and start it.
          */
-        LifecycleComponent server = Main.buildBookieServer(bkConf);
+        LifecycleComponent server = BookkeeperStarter.buildBookieServer(bkConf);
         CompletableFuture<Void> startFuture = ComponentStarter.startComponent(server);
 
         /*
@@ -1553,7 +1553,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setHttpServerPort(nextFreePort);
 
         // 1. building the component stack:
-        LifecycleComponent server = Main.buildBookieServer(new BookieConfiguration(conf));
+        LifecycleComponent server = BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
         // 2. start the server
         CompletableFuture<Void> stackComponentFuture = ComponentStarter.startComponent(server);
         while (server.lifecycleState() != Lifecycle.State.STARTED) {
@@ -1671,7 +1671,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         conf.setJournalDirsName(journalDirs);
         conf.setLedgerDirNames(new String[] { tmpLedgerDir.getPath() });
 
-        LifecycleComponent server = Main.buildBookieServer(new BookieConfiguration(conf));
+        LifecycleComponent server = BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
         server.start();
 
         final BookieId bookieAddress = BookieImpl.getBookieId(conf);
@@ -1686,7 +1686,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         rmCookie.getValue().deleteFromRegistrationManager(rm, conf, rmCookie.getVersion());
 
         try {
-            Main.buildBookieServer(new BookieConfiguration(conf));
+            BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
             fail("Bookie should not have been buildable. Cookie no present in metadata store.");
         } catch (Exception e) {
             LOG.info("As expected Bookie fails to be built without a cookie in metadata store.");
@@ -1753,7 +1753,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
     public void testBookieIdChange() throws Exception {
         // By default, network info is set as Bookie Id and it is stored in the Cookie.
         final ServerConfiguration conf = newServerConfiguration();
-        LifecycleComponent server = Main.buildBookieServer(new BookieConfiguration(conf));
+        LifecycleComponent server = BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
         server.start();
         server.stop();
 
@@ -1762,7 +1762,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         String customBookieId = "customId";
         conf.setBookieId(customBookieId);
         try {
-            Main.buildBookieServer(new BookieConfiguration(conf));
+            BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
         } catch (BookieException.InvalidCookieException e) {
             // This is the expected case, as the customBookieId prevails over the default one.
         } catch (Exception e) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/UpdateCookieCmdTest.java
@@ -32,7 +32,7 @@ import org.apache.bookkeeper.discover.RegistrationManager;
 import org.apache.bookkeeper.meta.MetadataBookieDriver;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.bookkeeper.versioning.Version;
@@ -70,7 +70,7 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
 
         conf = newServerConfiguration();
         LegacyCookieValidation validation = new LegacyCookieValidation(conf, rm);
-        validation.checkCookies(Main.storageDirectoriesFromConf(conf));
+        validation.checkCookies(BookkeeperStarter.storageDirectoriesFromConf(conf));
     }
 
     @Override
@@ -112,7 +112,7 @@ public class UpdateCookieCmdTest extends BookKeeperClusterTestCase {
         // start bookie to ensure everything works fine
         conf.setUseHostNameAsBookieID(false);
         LegacyCookieValidation validation = new LegacyCookieValidation(conf, rm);
-        validation.checkCookies(Main.storageDirectoriesFromConf(conf));
+        validation.checkCookies(BookkeeperStarter.storageDirectoriesFromConf(conf));
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperAdminTest.java
@@ -68,7 +68,7 @@ import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
@@ -191,7 +191,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
                 confOfExistingBookie, NullStatsLogger.INSTANCE);
              RegistrationManager rm = driver.createRegistrationManager()) {
             CookieValidation cookieValidation = new LegacyCookieValidation(confOfExistingBookie, rm);
-            cookieValidation.checkCookies(Main.storageDirectoriesFromConf(confOfExistingBookie));
+            cookieValidation.checkCookies(BookkeeperStarter.storageDirectoriesFromConf(confOfExistingBookie));
             rm.registerBookie(bookieId, false /* readOnly */, BookieServiceInfo.EMPTY);
             Assert.assertFalse(
                     "initBookie shouldn't have succeeded, since bookie is still running with that configuration",
@@ -696,7 +696,7 @@ public class BookKeeperAdminTest extends BookKeeperClusterTestCase {
                 .setBookiePort(PortManager.nextFreePort())
                 .setMetadataServiceUri(metadataServiceUri);
 
-        LifecycleComponent server = Main.buildBookieServer(new BookieConfiguration(conf));
+        LifecycleComponent server = BookkeeperStarter.buildBookieServer(new BookieConfiguration(conf));
         // 2. start the server
         CompletableFuture<Void> stackComponentFuture = ComponentStarter.startComponent(server);
         while (server.lifecycleState() != Lifecycle.State.STARTED) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/TestBookieBoot.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/TestBookieBoot.java
@@ -81,7 +81,7 @@ public class TestBookieBoot extends BookKeeperClusterTestCase {
         CompletableFuture<Integer> promise = new CompletableFuture<>();
         Thread t = new Thread(() -> {
             try {
-                int ret = Main.doMain(new String[] {"-c", confFile.toString()});
+                int ret = BookkeeperStarter.doMain(new String[] {"-c", confFile.toString()});
                 promise.complete(ret);
             } catch (Exception e) {
                 promise.completeExceptionally(e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -74,7 +74,7 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.Auditor;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.replication.ReplicationWorker;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.apache.bookkeeper.util.PortManager;
@@ -852,7 +852,7 @@ public abstract class BookKeeperClusterTestCase {
 
             LegacyCookieValidation cookieValidation = new LegacyCookieValidation(
                     conf, registrationManager);
-            cookieValidation.checkCookies(Main.storageDirectoriesFromConf(conf));
+            cookieValidation.checkCookies(BookkeeperStarter.storageDirectoriesFromConf(conf));
 
             DiskChecker diskChecker = BookieResources.createDiskChecker(conf);
             LedgerDirsManager ledgerDirsManager = BookieResources.createLedgerDirsManager(

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
@@ -46,7 +46,7 @@ import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.MetadataBookieDriver;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
-import org.apache.bookkeeper.server.Main;
+import org.apache.bookkeeper.server.BookkeeperStarter;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stream.server.conf.BookieConfiguration;
 import org.apache.bookkeeper.util.DiskChecker;
@@ -104,7 +104,7 @@ public class BookieService extends AbstractLifecycleComponent<BookieConfiguratio
         UncleanShutdownDetection uncleanShutdownDetection = new UncleanShutdownDetectionImpl(ledgerDirsManager);
 
         LegacyCookieValidation cookieValidation = new LegacyCookieValidation(serverConf, rm);
-        cookieValidation.checkCookies(Main.storageDirectoriesFromConf(serverConf));
+        cookieValidation.checkCookies(BookkeeperStarter.storageDirectoriesFromConf(serverConf));
 
         Bookie bookie;
         if (serverConf.isForceReadOnlyBookie()) {

--- a/tests/docker-images/statestore-image/bin/bookkeeper
+++ b/tests/docker-images/statestore-image/bin/bookkeeper
@@ -97,7 +97,7 @@ fi
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"
 if [ ${COMMAND} == "bookie" ]; then
-  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.Main --conf ${BOOKIE_CONF} $@
+  exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.server.BookkeeperStarter --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "autorecovery" ]; then
   exec ${JAVA} ${OPTS} ${JMX_ARGS} org.apache.bookkeeper.replication.AutoRecoveryMain --conf ${BOOKIE_CONF} $@
 elif [ ${COMMAND} == "localbookie" ]; then


### PR DESCRIPTION
Fix #2950 

### Motivation

The current class name `org.apache.bookkeeper.server.Main` is generic, which makes it less informative about the class's purpose in the context of BookKeeper. This can lead to confusion, especially for new contributors or during debugging sessions. By renaming this class to `BookkeeperStarter`, we aim to improve code clarity and express the class's role in starting the BookKeeper server more explicitly.

### Changes

- Renamed `Main` class to `BookkeeperStarter` in all occurrences within the project.
- Updated references in scripts, test cases, and Java files to reflect the new class name.
- Minor cleanups in the `BookkeeperStarter` class
