### PR TITLE
Fix test TestTLS for Windows compatibility in BookKeeper

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/conf/TestBKConfiguration.java
@@ -92,9 +92,7 @@ public class TestBKConfiguration {
     public static ClientConfiguration newClientConfiguration() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         clientConfiguration.setTLSEnabledProtocols("TLSv1.2,TLSv1.1");
-        /**
-         * if testcase has zk error,just try 0 time for fast running
-         */
+        // if testcase has zk error,just try 0 time for fast running
         clientConfiguration.setZkRetryBackoffMaxRetries(0);
         return clientConfiguration;
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/tls/TestTLS.java
@@ -27,6 +27,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -118,7 +119,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
     }
 
     private String getResourcePath(String resource) throws Exception {
-        return this.getClass().getClassLoader().getResource(resource).toURI().getPath();
+        return Paths.get(this.getClass().getClassLoader().getResource(resource).toURI()).toString();
     }
 
     @Before
@@ -560,7 +561,7 @@ public class TestTLS extends BookKeeperClusterTestCase {
 
         ClientConfiguration clientConf = new ClientConfiguration(baseClientConf);
         LedgerMetadata metadata = testClient(clientConf, 2);
-        assertTrue(metadata.getAllEnsembles().size() > 0);
+        assertFalse(metadata.getAllEnsembles().isEmpty());
         Collection<? extends List<BookieId>> ensembles = metadata.getAllEnsembles().values();
         try (BookKeeper client = new BookKeeper(clientConf)) {
             for (List<BookieId> bookies : ensembles) {
@@ -881,16 +882,16 @@ public class TestTLS extends BookKeeperClusterTestCase {
      */
     @Test
     public void testTLSChannelCounters() throws Exception {
-        ClientConfiguration tlsClientconf = new ClientConfiguration(baseClientConf)
+        ClientConfiguration tlsClientConf = new ClientConfiguration(baseClientConf)
                 .setNumChannelsPerBookie(1);
-        ClientConfiguration nonTlsClientconf = new ClientConfiguration(baseClientConf)
+        ClientConfiguration nonTlsClientConf = new ClientConfiguration(baseClientConf)
                 .setNumChannelsPerBookie(1)
                 .setTLSProviderFactoryClass(null);
 
         TestStatsProvider tlsStatsProvider = new TestStatsProvider();
         TestStatsProvider nonTlsStatsProvider = new TestStatsProvider();
-        BookKeeperTestClient tlsClient = new BookKeeperTestClient(tlsClientconf, tlsStatsProvider);
-        BookKeeperTestClient nonTlsClient = new BookKeeperTestClient(nonTlsClientconf, nonTlsStatsProvider);
+        BookKeeperTestClient tlsClient = new BookKeeperTestClient(tlsClientConf, tlsStatsProvider);
+        BookKeeperTestClient nonTlsClient = new BookKeeperTestClient(nonTlsClientConf, nonTlsStatsProvider);
 
         // IO load from clients
         testClient(tlsClient, numBookies);
@@ -905,9 +906,6 @@ public class TestTLS extends BookKeeperClusterTestCase {
                     .append(TestUtils.buildStatsCounterPathFromBookieID(bookie.getBookieId()))
                     .append(".");
             // check stats on TLS enabled client
-           TestStatsProvider.TestCounter cntr =  tlsClient.getTestStatsProvider().getCounter(nameBuilder
-                    + BookKeeperClientStats.ACTIVE_TLS_CHANNEL_COUNTER);
-
             assertEquals("Mismatch TLS channel count", 1,
                     tlsClient.getTestStatsProvider().getCounter(nameBuilder
                     + BookKeeperClientStats.ACTIVE_TLS_CHANNEL_COUNTER).get().longValue());


### PR DESCRIPTION
### Motivation

The tests under `bookkeeper-server` were failing on Windows due to path handling and other compatibility issues. The aim of this PR is to ensure that all tests pass on Windows as well as other operating systems by making the necessary adjustments in the test code.

### Changes

- **TestBKConfiguration**: Updated the comment style from a block comment to a single-line comment for `setZkRetryBackoffMaxRetries`.
- **TestTLS**:
  - Modified `getResourcePath` to use `Paths.get()` which handles file paths in a cross-platform manner.
  - Replaced `assertTrue` with `assertFalse` followed by `isEmpty()` to check if ensembles are present, improving the readability.
