### PR TITLE
build: add owasp daily build

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -514,7 +514,7 @@ jobs:
 
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
-        # CVEs that we cannot patch up anyways
+        # CVEs that we cannot patch up anyway
         run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs'
 
       - name: Upload report

--- a/.github/workflows/java21-daily-build.yml
+++ b/.github/workflows/java21-daily-build.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  jdk21-daily-build:
     name: Build on JDK 21
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/owasp-daily-build.yml
+++ b/.github/workflows/owasp-daily-build.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Windows Daily Build
+name: JDK 21 Daily Build
 
 on:
   schedule:
@@ -22,26 +22,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  windows-daily-build:
-    name: Daily Build and Test on Windows
-    runs-on: windows-latest
+  owasp-daily-build:
+    name: OWASP Dependency Check
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Build with Maven
-        run: mvn -B clean install
-      - name: Aggregates all test reports to ./test-reports and ./surefire-reports directories If failure
-        if: failure()
-        continue-on-error: true
-        uses: ./.github/actions/copy-test-reports
-      - name: Upload Surefire reports
-        uses: actions/upload-artifact@v4
-        if: failure()
-        continue-on-error: true
+          java-version: 21
+
+      - name: Set up Maven
+        uses: apache/pulsar-test-infra/setup-maven@master
         with:
-          name: windows-tests-reports
-          path: surefire-reports
+          maven-version: 3.8.7
+
+      - name: run "clean install verify" to trigger dependency check
+        # excluding dlfs because it includes hadoop lib with
+        # CVEs that we cannot patch up anyway
+        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs'

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>8.0.2</dependency-check-maven.version>
+    <dependency-check-maven.version>9.1.0</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
### Motivation

This PR aims to enhance the security posture of our project by automating the OWASP dependency checks. With increasing dependency updates and potential vulnerabilities, having a daily automated check ensures timely detection and mitigation of security risks.

### Changes

- Added a new GitHub Actions workflow (`owasp-daily-build.yml`) that triggers an OWASP dependency check every day at 00:00 UTC.
- Updated the OWASP dependency check Maven plugin version in `pom.xml` from `8.0.2` to `9.1.0` to utilize the latest features and improvements for our security checks.
- Made a minor grammatical correction in the existing workflow file (`bk-ci.yml`) for better readability.
