### PR TITLE
build: fix JAVA_HOME not properly set in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@
 FROM ubuntu:22.04
 MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
+ARG TARGETARCH
 ARG BK_VERSION=4.15.1
 ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
 ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
@@ -61,12 +62,14 @@ RUN set -x \
     && tar -xzf "$DISTRO_NAME.tar.gz" \
     && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
     && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
-    && pip install zk-shell \
-    && JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java)))) \
-    && echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security \
-    && echo networkaddress.cache.negative.ttl=1 >> $JAVA_HOME/conf/security/java.security
+    && pip install zk-shell
 
 WORKDIR /opt/bookkeeper
+
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
+
+RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security \
+    && echo networkaddress.cache.negative.ttl=1 >> $JAVA_HOME/conf/security/java.security
 
 COPY scripts /opt/bookkeeper/scripts
 RUN chmod +x -R /opt/bookkeeper/scripts/


### PR DESCRIPTION
### Motivation
`JAVA_HOME` env variable is not properly set.

I have tested `ARG TARGETARCH` works well, when we run `docker build`, it will automatically set the value.

error log below:
```
bookie3_1    | JAVA_HOME not set, using java from PATH. (/usr/bin/java)
bookie1_1    | JAVA_HOME not set, using java from PATH. (/usr/bin/java)
bookie3_1    | Unrecognized VM option 'PrintGCApplicationStoppedTime'
bookie3_1    | Error: Could not create the Java Virtual Machine.
```
