### PR TITLE
doc: update PR template to better link to issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,16 @@
 Descriptions of the changes in this PR:
 
+<!-- Either this PR fixes an issue, -->
 
+Fix #xyz
+
+<!-- or this PR is one task of an issue -->
+
+Main Issue: #xyz
+
+<!-- If the PR belongs to a BP, please add the BP link here -->
+
+BP: #xyz
 
 ### Motivation
 
@@ -10,14 +20,12 @@ Descriptions of the changes in this PR:
 
 (Describe: what changes you have made)
 
-Master Issue: #<master-issue-number>
-
 > ---
 > In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
 > checks for pull requests. A pull request can only be merged when it passes precommit checks.
 >
 > ---
-> Be sure to do all of the following to help us incorporate your contribution
+> Be sure to do all the following to help us incorporate your contribution
 > quickly and easily:
 >
 > If this PR is a BookKeeper Proposal (BP):


### PR DESCRIPTION
### Motivation

When I was dealing with issues in BookKeeper, I noticed that many issues associated with resolved PRs had already been merged, but the issues were not closed in a timely manner. Update the template to better link them.