### PR TITLE
Apply WRITE_BUFFER_WATER_MARK setting to child channels in BookieNetty Server

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieNettyServer.java
@@ -314,7 +314,7 @@ class BookieNettyServer {
             bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,
                     new AdaptiveRecvByteBufAllocator(conf.getRecvByteBufAllocatorSizeMin(),
                             conf.getRecvByteBufAllocatorSizeInitial(), conf.getRecvByteBufAllocatorSizeMax()));
-            bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(
+            bootstrap.childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(
                     conf.getServerWriteBufferLowWaterMark(), conf.getServerWriteBufferHighWaterMark()));
 
             if (eventLoopGroup instanceof IOUringEventLoopGroup){


### PR DESCRIPTION
Fix #4107 

### Motivation

This PR addresses a misconfiguration in `BookieNettyServer` where the `WRITE_BUFFER_WATER_MARK` was incorrectly applied to the server channel (`option()`) instead of the child channels (`childOption()`). 
