### PR TITLE
build: remove unused cpp library rt

### DIFF
--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -187,9 +187,6 @@
             <extensions>true</extensions>
             <configuration>
               <skip>false</skip>
-              <linker>
-                <libSet>rt</libSet>
-              </linker>
             </configuration>
           </plugin>
         </plugins>

--- a/cpu-affinity/pom.xml
+++ b/cpu-affinity/pom.xml
@@ -190,9 +190,6 @@
                 <rtti>false</rtti>
                 <optimize>full</optimize>
               </cpp>
-              <linker>
-                <libSet>rt</libSet>
-              </linker>
             </configuration>
           </plugin>
         </plugins>

--- a/native-io/pom.xml
+++ b/native-io/pom.xml
@@ -178,9 +178,6 @@
                 <rtti>false</rtti>
                 <optimize>full</optimize>
               </cpp>
-              <linker>
-                <libSet>rt</libSet>
-              </linker>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
### Motivation

Fix build warnings, and `librt` is not used.

```
[INFO] --- nar-maven-plugin:3.5.2:nar-compile (default-nar-compile) @ circe-checksum ---
[INFO] Compiling 2 native files
[WARNING] No file matching patterns ("librt.a, librt.so) for library name "rt" was found.
[INFO] 2 total files to be compiled.
```