### PR TITLE
fix: resource leak when JournalChannel is not fully initialized

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java
@@ -192,7 +192,7 @@ class JournalChannel implements Closeable {
             writeHeader(bcBuilder, writeBufferSize);
         } else {  // open an existing file to read.
             fc = channel.getFileChannel();
-            bc = null; // readonly
+            // readonly, use fileChannel directly, no need to use BufferedChannel
 
             ByteBuffer bb = ByteBuffer.allocate(VERSION_HEADER_SIZE);
             int c = fc.read(bb);
@@ -299,6 +299,8 @@ class JournalChannel implements Closeable {
     public void close() throws IOException {
         if (bc != null) {
             bc.close();
+        } else if (fc != null) {
+            fc.close();
         }
     }
 


### PR DESCRIPTION
### Motivation

There is a resource leak in the `JournalChannel` implementation of Apache Bookkeeper when the channel is closed before it is fully initialized (specifically, before the writing of headers begins). In such cases, the buffer channel (`bc`) is not yet instantiated, but the file channel (`fc`) might already be open.

### Changes

Updated the `close()` method in `JournalChannel` to include a conditional check that closes the file channel (`fc`) if the buffer channel (`bc`) is null. This ensures that all resources are properly released, even if the `JournalChannel` is prematurely closed before full initialization.

wrie header method

https://github.com/apache/bookkeeper/blob/ba7f988f7a27b80f8d607b44b155978763678713/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/JournalChannel.java#L250-L265
