### PR TITLE
Bump grpc from 1.56.0 to 1.64.0 to address CVE list

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -281,23 +281,24 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.63.0.jar [33]
-- lib/io.grpc-grpc-alts-1.63.0.jar [33]
-- lib/io.grpc-grpc-api-1.63.0.jar [33]
-- lib/io.grpc-grpc-auth-1.63.0.jar [33]
-- lib/io.grpc-grpc-context-1.63.0.jar [33]
-- lib/io.grpc-grpc-core-1.63.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.63.0.jar [33]
-- lib/io.grpc-grpc-inprocess-1.63.0.jar [33]
-- lib/io.grpc-grpc-netty-1.63.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.63.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [33]
-- lib/io.grpc-grpc-services-1.63.0.jar [33]
-- lib/io.grpc-grpc-stub-1.63.0.jar [33]
-- lib/io.grpc-grpc-testing-1.63.0.jar [33]
-- lib/io.grpc-grpc-util-1.63.0.jar [33]
-- lib/io.grpc-grpc-xds-1.63.0.jar [33]
-- lib/io.grpc-grpc-rls-1.63.0.jar[33]
+- lib/io.grpc-grpc-all-1.64.0.jar [33]
+- lib/io.grpc-grpc-alts-1.64.0.jar [33]
+- lib/io.grpc-grpc-api-1.64.0.jar [33]
+- lib/io.grpc-grpc-auth-1.64.0.jar [33]
+- lib/io.grpc-grpc-context-1.64.0.jar [33]
+- lib/io.grpc-grpc-core-1.64.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.64.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.64.0.jar [33]
+- lib/io.grpc-grpc-opentelemetry-1.64.0.jar [33]
+- lib/io.grpc-grpc-netty-1.64.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.64.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar [33]
+- lib/io.grpc-grpc-services-1.64.0.jar [33]
+- lib/io.grpc-grpc-stub-1.64.0.jar [33]
+- lib/io.grpc-grpc-testing-1.64.0.jar [33]
+- lib/io.grpc-grpc-util-1.64.0.jar [33]
+- lib/io.grpc-grpc-xds-1.64.0.jar [33]
+- lib/io.grpc-grpc-rls-1.64.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -381,7 +382,7 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.64.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -675,13 +675,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -276,26 +276,28 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.29.0.jar [28]
 - lib/com.google.code.gson-gson-2.10.1.jar [29]
-- lib/io.opencensus-opencensus-api-0.28.0.jar [30]
-- lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
+- lib/io.opencensus-opencensus-api-0.31.1.jar [30]
+- lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.56.0.jar [33]
-- lib/io.grpc-grpc-alts-1.56.0.jar [33]
-- lib/io.grpc-grpc-api-1.56.0.jar [33]
-- lib/io.grpc-grpc-auth-1.56.0.jar [33]
-- lib/io.grpc-grpc-context-1.56.0.jar [33]
-- lib/io.grpc-grpc-core-1.56.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [33]
-- lib/io.grpc-grpc-netty-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [33]
-- lib/io.grpc-grpc-services-1.56.0.jar [33]
-- lib/io.grpc-grpc-stub-1.56.0.jar [33]
-- lib/io.grpc-grpc-testing-1.56.0.jar [33]
-- lib/io.grpc-grpc-xds-1.56.0.jar [33]
-- lib/io.grpc-grpc-rls-1.56.0.jar[33]
+- lib/io.grpc-grpc-all-1.63.0.jar [33]
+- lib/io.grpc-grpc-alts-1.63.0.jar [33]
+- lib/io.grpc-grpc-api-1.63.0.jar [33]
+- lib/io.grpc-grpc-auth-1.63.0.jar [33]
+- lib/io.grpc-grpc-context-1.63.0.jar [33]
+- lib/io.grpc-grpc-core-1.63.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.63.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.63.0.jar [33]
+- lib/io.grpc-grpc-netty-1.63.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.63.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [33]
+- lib/io.grpc-grpc-services-1.63.0.jar [33]
+- lib/io.grpc-grpc-stub-1.63.0.jar [33]
+- lib/io.grpc-grpc-testing-1.63.0.jar [33]
+- lib/io.grpc-grpc-util-1.63.0.jar [33]
+- lib/io.grpc-grpc-xds-1.63.0.jar [33]
+- lib/io.grpc-grpc-rls-1.63.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -306,9 +308,9 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
-- lib/com.google.http-client-google-http-client-1.41.0.jar [43]
-- lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [44]
+- lib/com.google.http-client-google-http-client-1.43.3.jar [43]
+- lib/com.google.http-client-google-http-client-gson-1.43.3.jar [43]
+- lib/com.google.auto.value-auto-value-annotations-1.10.4.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
 - lib/com.google.re2j-re2j-1.7.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
@@ -376,10 +378,10 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.17.0
+[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
-[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.56.0
+[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -388,8 +390,8 @@ Apache Software License, Version 2.
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.41.0
-[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.1
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
+[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
@@ -699,9 +701,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-1.4.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-1.4.0.jar
-Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
+  - lib/com.google.auth-google-auth-library-credentials-1.22.0.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-1.22.0.jar
+Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.22.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -569,13 +569,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -251,26 +251,28 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.8.4-tests.jar [20]
 - lib/com.beust-jcommander-1.82.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [27]
+- lib/com.google.api.grpc-proto-google-common-protos-2.29.0.jar [27]
 - lib/com.google.code.gson-gson-2.10.1.jar [28]
-- lib/io.opencensus-opencensus-api-0.28.0.jar [29]
-- lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [29]
+- lib/io.opencensus-opencensus-api-0.31.1.jar [29]
+- lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/io.grpc-grpc-all-1.56.0.jar [32]
-- lib/io.grpc-grpc-alts-1.56.0.jar [32]
-- lib/io.grpc-grpc-api-1.56.0.jar [32]
-- lib/io.grpc-grpc-auth-1.56.0.jar [32]
-- lib/io.grpc-grpc-context-1.56.0.jar [32]
-- lib/io.grpc-grpc-core-1.56.0.jar [32]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [32]
-- lib/io.grpc-grpc-netty-1.56.0.jar [32]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [32]
-- lib/io.grpc-grpc-services-1.56.0.jar [32]
-- lib/io.grpc-grpc-stub-1.56.0.jar [32]
-- lib/io.grpc-grpc-testing-1.56.0.jar [32]
-- lib/io.grpc-grpc-xds-1.56.0.jar [32]
-- lib/io.grpc-grpc-rls-1.56.0.jar[32]
+- lib/io.grpc-grpc-all-1.63.0.jar [32]
+- lib/io.grpc-grpc-alts-1.63.0.jar [32]
+- lib/io.grpc-grpc-api-1.63.0.jar [32]
+- lib/io.grpc-grpc-auth-1.63.0.jar [32]
+- lib/io.grpc-grpc-context-1.63.0.jar [32]
+- lib/io.grpc-grpc-core-1.63.0.jar [32]
+- lib/io.grpc-grpc-grpclb-1.63.0.jar [32]
+- lib/io.grpc-grpc-inprocess-1.63.0.jar [32]
+- lib/io.grpc-grpc-netty-1.63.0.jar [32]
+- lib/io.grpc-grpc-protobuf-1.63.0.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [32]
+- lib/io.grpc-grpc-services-1.63.0.jar [32]
+- lib/io.grpc-grpc-stub-1.63.0.jar [32]
+- lib/io.grpc-grpc-testing-1.63.0.jar [32]
+- lib/io.grpc-grpc-util-1.63.0.jar [32]
+- lib/io.grpc-grpc-xds-1.63.0.jar [32]
+- lib/io.grpc-grpc-rls-1.63.0.jar[32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
@@ -281,9 +283,9 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [39]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [40]
 - lib/com.google.android-annotations-4.1.1.4.jar [41]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [42]
-- lib/com.google.http-client-google-http-client-1.41.0.jar [43]
-- lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
+- lib/com.google.auto.value-auto-value-annotations-1.10.4.jar [42]
+- lib/com.google.http-client-google-http-client-1.43.3.jar [43]
+- lib/com.google.http-client-google-http-client-gson-1.43.3.jar [43]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [44]
 - lib/com.google.re2j-re2j-1.7.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
@@ -311,10 +313,10 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [23] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.17.0
+[27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
-[29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[32] Source available at https://github.com/grpc/grpc-java/tree/v1.56.0
+[29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -323,8 +325,8 @@ Apache Software License, Version 2.
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [40] Source available at https://github.com/apache/thrift/tree/0.14.2
 [41] Source available at https://source.android.com/
-[42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.1
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.41.0
+[42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
 [44] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
@@ -587,9 +589,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-1.4.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-1.4.0.jar
-Source available at https://github.com/google/google-auth-library-java/tree/1.4.0
+  - lib/com.google.auth-google-auth-library-credentials-1.22.0.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-1.22.0.jar
+Source available at https://github.com/google/google-auth-library-java/tree/1.22.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -256,23 +256,24 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.31.1.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [29]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [29]
-- lib/io.grpc-grpc-all-1.63.0.jar [32]
-- lib/io.grpc-grpc-alts-1.63.0.jar [32]
-- lib/io.grpc-grpc-api-1.63.0.jar [32]
-- lib/io.grpc-grpc-auth-1.63.0.jar [32]
-- lib/io.grpc-grpc-context-1.63.0.jar [32]
-- lib/io.grpc-grpc-core-1.63.0.jar [32]
-- lib/io.grpc-grpc-grpclb-1.63.0.jar [32]
-- lib/io.grpc-grpc-inprocess-1.63.0.jar [32]
-- lib/io.grpc-grpc-netty-1.63.0.jar [32]
-- lib/io.grpc-grpc-protobuf-1.63.0.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [32]
-- lib/io.grpc-grpc-services-1.63.0.jar [32]
-- lib/io.grpc-grpc-stub-1.63.0.jar [32]
-- lib/io.grpc-grpc-testing-1.63.0.jar [32]
-- lib/io.grpc-grpc-util-1.63.0.jar [32]
-- lib/io.grpc-grpc-xds-1.63.0.jar [32]
-- lib/io.grpc-grpc-rls-1.63.0.jar[32]
+- lib/io.grpc-grpc-all-1.64.0.jar [32]
+- lib/io.grpc-grpc-alts-1.64.0.jar [32]
+- lib/io.grpc-grpc-api-1.64.0.jar [32]
+- lib/io.grpc-grpc-auth-1.64.0.jar [32]
+- lib/io.grpc-grpc-context-1.64.0.jar [32]
+- lib/io.grpc-grpc-core-1.64.0.jar [32]
+- lib/io.grpc-grpc-grpclb-1.64.0.jar [32]
+- lib/io.grpc-grpc-inprocess-1.64.0.jar [32]
+- lib/io.grpc-grpc-opentelemetry-1.64.0.jar [32]
+- lib/io.grpc-grpc-netty-1.64.0.jar [32]
+- lib/io.grpc-grpc-protobuf-1.64.0.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar [32]
+- lib/io.grpc-grpc-services-1.64.0.jar [32]
+- lib/io.grpc-grpc-stub-1.64.0.jar [32]
+- lib/io.grpc-grpc-testing-1.64.0.jar [32]
+- lib/io.grpc-grpc-util-1.64.0.jar [32]
+- lib/io.grpc-grpc-xds-1.64.0.jar [32]
+- lib/io.grpc-grpc-rls-1.64.0.jar[32]
 - lib/org.apache.curator-curator-client-5.1.0.jar [33]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [33]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [33]
@@ -295,6 +296,8 @@ Apache Software License, Version 2.
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 - lib/com.lmax-disruptor-4.0.0.jar [53]
+- lib/io.opentelemetry-opentelemetry-api-1.26.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-context-1.26.0.jar [54]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
@@ -316,7 +319,7 @@ Apache Software License, Version 2.
 [27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[32] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.64.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.1.0
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -336,6 +339,7 @@ Apache Software License, Version 2.
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
+[54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -276,26 +276,28 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.17.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.29.0.jar [28]
 - lib/com.google.code.gson-gson-2.10.1.jar [29]
-- lib/io.opencensus-opencensus-api-0.28.0.jar [30]
-- lib/io.opencensus-opencensus-contrib-http-util-0.28.0.jar [30]
+- lib/io.opencensus-opencensus-api-0.31.1.jar [30]
+- lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.56.0.jar [33]
-- lib/io.grpc-grpc-alts-1.56.0.jar [33]
-- lib/io.grpc-grpc-api-1.56.0.jar [33]
-- lib/io.grpc-grpc-auth-1.56.0.jar [33]
-- lib/io.grpc-grpc-context-1.56.0.jar [33]
-- lib/io.grpc-grpc-core-1.56.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.56.0.jar [33]
-- lib/io.grpc-grpc-netty-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.56.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar [33]
-- lib/io.grpc-grpc-services-1.56.0.jar [33]
-- lib/io.grpc-grpc-stub-1.56.0.jar [33]
-- lib/io.grpc-grpc-testing-1.56.0.jar [33]
-- lib/io.grpc-grpc-xds-1.56.0.jar [33]
-- lib/io.grpc-grpc-rls-1.56.0.jar[33]
+- lib/io.grpc-grpc-all-1.63.0.jar [33]
+- lib/io.grpc-grpc-alts-1.63.0.jar [33]
+- lib/io.grpc-grpc-api-1.63.0.jar [33]
+- lib/io.grpc-grpc-auth-1.63.0.jar [33]
+- lib/io.grpc-grpc-context-1.63.0.jar [33]
+- lib/io.grpc-grpc-core-1.63.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.63.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.63.0.jar [33]
+- lib/io.grpc-grpc-netty-1.63.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.63.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [33]
+- lib/io.grpc-grpc-services-1.63.0.jar [33]
+- lib/io.grpc-grpc-stub-1.63.0.jar [33]
+- lib/io.grpc-grpc-testing-1.63.0.jar [33]
+- lib/io.grpc-grpc-util-1.63.0.jar [33]
+- lib/io.grpc-grpc-xds-1.63.0.jar [33]
+- lib/io.grpc-grpc-rls-1.63.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -306,9 +308,9 @@ Apache Software License, Version 2.
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
-- lib/com.google.http-client-google-http-client-1.41.0.jar [43]
-- lib/com.google.http-client-google-http-client-gson-1.41.0.jar [43]
-- lib/com.google.auto.value-auto-value-annotations-1.10.1.jar [44]
+- lib/com.google.http-client-google-http-client-1.43.3.jar [43]
+- lib/com.google.http-client-google-http-client-gson-1.43.3.jar [43]
+- lib/com.google.auto.value-auto-value-annotations-1.10.4.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
 - lib/com.google.re2j-re2j-1.7.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
@@ -372,10 +374,10 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.17.0
+[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
-[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.28.0
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.56.0
+[30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -384,8 +386,8 @@ Apache Software License, Version 2.
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2
 [42] Source available at https://source.android.com/
-[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.41.0
-[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.1
+[43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
+[44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
@@ -688,9 +690,9 @@ This product bundles the Google Auth Library, which is available under a "3-clau
 license. For details, see deps/google-auth-library-credentials-0.20.0/LICENSE
 
 Bundled as
-  - lib/com.google.auth-google-auth-library-credentials-1.4.0.jar
-  - lib/com.google.auth-google-auth-library-oauth2-http-1.4.0.jar
-Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.4.0
+  - lib/com.google.auth-google-auth-library-credentials-1.22.0.jar
+  - lib/com.google.auth-google-auth-library-oauth2-http-1.22.0.jar
+Source available at https://github.com/googleapis/google-auth-library-java/releases/tag/v1.22.0
 ------------------------------------------------------------------------------------
 This product bundles the bouncycastle Library.
 For license details, see deps/bouncycastle-1.0.2.3/LICENSE.html

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -664,13 +664,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.22.3.jar
-Source available at https://github.com/google/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.22.3.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.22.3
+  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -281,23 +281,24 @@ Apache Software License, Version 2.
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-proto-0.2.0.jar [30]
-- lib/io.grpc-grpc-all-1.63.0.jar [33]
-- lib/io.grpc-grpc-alts-1.63.0.jar [33]
-- lib/io.grpc-grpc-api-1.63.0.jar [33]
-- lib/io.grpc-grpc-auth-1.63.0.jar [33]
-- lib/io.grpc-grpc-context-1.63.0.jar [33]
-- lib/io.grpc-grpc-core-1.63.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.63.0.jar [33]
-- lib/io.grpc-grpc-inprocess-1.63.0.jar [33]
-- lib/io.grpc-grpc-netty-1.63.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.63.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar [33]
-- lib/io.grpc-grpc-services-1.63.0.jar [33]
-- lib/io.grpc-grpc-stub-1.63.0.jar [33]
-- lib/io.grpc-grpc-testing-1.63.0.jar [33]
-- lib/io.grpc-grpc-util-1.63.0.jar [33]
-- lib/io.grpc-grpc-xds-1.63.0.jar [33]
-- lib/io.grpc-grpc-rls-1.63.0.jar[33]
+- lib/io.grpc-grpc-all-1.64.0.jar [33]
+- lib/io.grpc-grpc-alts-1.64.0.jar [33]
+- lib/io.grpc-grpc-api-1.64.0.jar [33]
+- lib/io.grpc-grpc-auth-1.64.0.jar [33]
+- lib/io.grpc-grpc-context-1.64.0.jar [33]
+- lib/io.grpc-grpc-core-1.64.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.64.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.64.0.jar [33]
+- lib/io.grpc-grpc-opentelemetry-1.64.0.jar [33]
+- lib/io.grpc-grpc-netty-1.64.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.64.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar [33]
+- lib/io.grpc-grpc-services-1.64.0.jar [33]
+- lib/io.grpc-grpc-stub-1.64.0.jar [33]
+- lib/io.grpc-grpc-testing-1.64.0.jar [33]
+- lib/io.grpc-grpc-util-1.64.0.jar [33]
+- lib/io.grpc-grpc-xds-1.64.0.jar [33]
+- lib/io.grpc-grpc-rls-1.64.0.jar[33]
 - lib/org.apache.curator-curator-client-5.1.0.jar [34]
 - lib/org.apache.curator-curator-framework-5.1.0.jar [34]
 - lib/org.apache.curator-curator-recipes-5.1.0.jar [34]
@@ -377,7 +378,7 @@ Apache Software License, Version 2.
 [28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.29.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.10.1
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.63.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.64.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.1.0
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -135,15 +135,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.63.0.jar
-- lib/io.grpc-grpc-auth-1.63.0.jar
-- lib/io.grpc-grpc-context-1.63.0.jar
-- lib/io.grpc-grpc-core-1.63.0.jar
-- lib/io.grpc-grpc-netty-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
-- lib/io.grpc-grpc-stub-1.63.0.jar
-- lib/io.grpc-grpc-testing-1.63.0.jar
+- lib/io.grpc-grpc-all-1.64.0.jar
+- lib/io.grpc-grpc-auth-1.64.0.jar
+- lib/io.grpc-grpc-context-1.64.0.jar
+- lib/io.grpc-grpc-core-1.64.0.jar
+- lib/io.grpc-grpc-netty-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar
+- lib/io.grpc-grpc-stub-1.64.0.jar
+- lib/io.grpc-grpc-testing-1.64.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -135,15 +135,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.63.0.jar
+- lib/io.grpc-grpc-auth-1.63.0.jar
+- lib/io.grpc-grpc-context-1.63.0.jar
+- lib/io.grpc-grpc-core-1.63.0.jar
+- lib/io.grpc-grpc-netty-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
+- lib/io.grpc-grpc-stub-1.63.0.jar
+- lib/io.grpc-grpc-testing-1.63.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -57,15 +57,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.63.0.jar
+- lib/io.grpc-grpc-auth-1.63.0.jar
+- lib/io.grpc-grpc-context-1.63.0.jar
+- lib/io.grpc-grpc-core-1.63.0.jar
+- lib/io.grpc-grpc-netty-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
+- lib/io.grpc-grpc-stub-1.63.0.jar
+- lib/io.grpc-grpc-testing-1.63.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -57,15 +57,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.63.0.jar
-- lib/io.grpc-grpc-auth-1.63.0.jar
-- lib/io.grpc-grpc-context-1.63.0.jar
-- lib/io.grpc-grpc-core-1.63.0.jar
-- lib/io.grpc-grpc-netty-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
-- lib/io.grpc-grpc-stub-1.63.0.jar
-- lib/io.grpc-grpc-testing-1.63.0.jar
+- lib/io.grpc-grpc-all-1.64.0.jar
+- lib/io.grpc-grpc-auth-1.64.0.jar
+- lib/io.grpc-grpc-context-1.64.0.jar
+- lib/io.grpc-grpc-core-1.64.0.jar
+- lib/io.grpc-grpc-netty-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar
+- lib/io.grpc-grpc-stub-1.64.0.jar
+- lib/io.grpc-grpc-testing-1.64.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -117,15 +117,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.63.0.jar
-- lib/io.grpc-grpc-auth-1.63.0.jar
-- lib/io.grpc-grpc-context-1.63.0.jar
-- lib/io.grpc-grpc-core-1.63.0.jar
-- lib/io.grpc-grpc-netty-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-1.63.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
-- lib/io.grpc-grpc-stub-1.63.0.jar
-- lib/io.grpc-grpc-testing-1.63.0.jar
+- lib/io.grpc-grpc-all-1.64.0.jar
+- lib/io.grpc-grpc-auth-1.64.0.jar
+- lib/io.grpc-grpc-context-1.64.0.jar
+- lib/io.grpc-grpc-core-1.64.0.jar
+- lib/io.grpc-grpc-netty-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-1.64.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.64.0.jar
+- lib/io.grpc-grpc-stub-1.64.0.jar
+- lib/io.grpc-grpc-testing-1.64.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -117,15 +117,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.56.0.jar
-- lib/io.grpc-grpc-auth-1.56.0.jar
-- lib/io.grpc-grpc-context-1.56.0.jar
-- lib/io.grpc-grpc-core-1.56.0.jar
-- lib/io.grpc-grpc-netty-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-1.56.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.56.0.jar
-- lib/io.grpc-grpc-stub-1.56.0.jar
-- lib/io.grpc-grpc-testing-1.56.0.jar
+- lib/io.grpc-grpc-all-1.63.0.jar
+- lib/io.grpc-grpc-auth-1.63.0.jar
+- lib/io.grpc-grpc-context-1.63.0.jar
+- lib/io.grpc-grpc-core-1.63.0.jar
+- lib/io.grpc-grpc-netty-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-1.63.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.63.0.jar
+- lib/io.grpc-grpc-stub-1.63.0.jar
+- lib/io.grpc-grpc-testing-1.63.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <freebuilder.version>2.8.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>
-    <grpc.version>1.63.0</grpc.version>
+    <grpc.version>1.64.0</grpc.version>
     <guava.version>32.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>3.3.5</hadoop.version>
@@ -162,7 +162,7 @@
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
     <protobuf.version>3.25.1</protobuf.version>
-    <protoc3.version>3.25.1</protoc3.version>
+    <protoc3.version>${protobuf.version}</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>7.9.2</rocksdb.version>
@@ -351,13 +351,10 @@
       <!-- protobuf dependencies -->
       <dependency>
         <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
+        <artifactId>protobuf-bom</artifactId>
         <version>${protobuf.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java-util</artifactId>
-        <version>${protobuf.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- libthrift dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <protobuf.version>3.22.3</protobuf.version>
-    <protoc3.version>3.22.3</protoc3.version>
+    <protobuf.version>3.25.1</protobuf.version>
+    <protoc3.version>3.25.1</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
     <rocksdb.version>7.9.2</rocksdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <freebuilder.version>2.8.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>
-    <grpc.version>1.56.0</grpc.version>
+    <grpc.version>1.63.0</grpc.version>
     <guava.version>32.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>3.3.5</hadoop.version>


### PR DESCRIPTION
CVE-2023-44487(7.5), CVE-2023-4785(7.5), CVE-2023-33953(7.5)