### PR TITLE
Bump jackson from 2.13.4.20221013 to 2.17.1 to address CVE list

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.17.1.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.17.1.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.17.1.jar [3]
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -351,9 +351,9 @@ Apache Software License, Version 2.
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.20.jar [56]
 - lib/com.lmax-disruptor-4.0.0.jar [57]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.4.2
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
 [5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
 [6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.17.1.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.17.1.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.17.1.jar [3]
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -294,9 +294,9 @@ Apache Software License, Version 2.
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 - lib/com.lmax-disruptor-4.0.0.jar [53]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.4.2
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
 [5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
 [6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -205,9 +205,9 @@
 The following bundled 3rd party jars are distributed under the
 Apache Software License, Version 2.
 
-- lib/com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar [1]
-- lib/com.fasterxml.jackson.core-jackson-core-2.13.4.jar [2]
-- lib/com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar [3]
+- lib/com.fasterxml.jackson.core-jackson-annotations-2.17.1.jar [1]
+- lib/com.fasterxml.jackson.core-jackson-core-2.17.1.jar [2]
+- lib/com.fasterxml.jackson.core-jackson-databind-2.17.1.jar [3]
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
@@ -347,9 +347,9 @@ Apache Software License, Version 2.
 - lib/org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.20.jar [55]
 - lib/com.lmax-disruptor-4.0.0.jar [56]
 
-[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.13.4
-[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.13.4
-[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.13.4.2
+[1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
+[2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
+[3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
 [5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
 [6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>32</version>
+    <version>31</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper</groupId>
@@ -140,7 +140,7 @@
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>3.3.5</hadoop.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jackson.version>2.13.4.20221013</jackson.version>
+    <jackson.version>2.17.1</jackson.version>
     <jcommander.version>1.82</jcommander.version>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <jmh.version>1.37</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>29</version>
+    <version>32</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper</groupId>
@@ -78,14 +78,14 @@
       <subscribe>user-subscribe@bookkeeper.apache.org</subscribe>
       <unsubscribe>user-unsubscribe@bookkeeper.apache.org</unsubscribe>
       <post>user@bookkeeper.apache.org</post>
-      <archive>http://www.mail-archive.com/user@bookkeeper.apache.org</archive>
+      <archive>https://www.mail-archive.com/user@bookkeeper.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>BookKeeper Dev</name>
       <subscribe>dev-subscribe@bookkeeper.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@bookkeeper.apache.org</unsubscribe>
       <post>dev@bookkeeper.apache.org</post>
-      <archive>http://www.mail-archive.com/dev@bookkeeper.apache.org</archive>
+      <archive>https://www.mail-archive.com/dev@bookkeeper.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>BookKeeper Commits</name>


### PR DESCRIPTION
### changes
- CVE-2023-5072(7.5), CVE-2022-45688(7.5)
- Also bump apache from 29 to 32, it will update some maven plugins(like maven-shade-plugin), to support jdk21