### PR TITLE
Use slf4j-bom and log4j-bom in dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,18 +242,17 @@
       <!-- logging dependencies -->
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
+        <artifactId>slf4j-bom</artifactId>
         <version>${slf4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
+        <artifactId>log4j-bom</artifactId>
         <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j2-impl</artifactId>
-        <version>${log4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>


### PR DESCRIPTION
### Motivation

When using SLF4J 2.0.x, it's useful to use slf4j-bom to align slf4j library versions. This is necessary to ensure that logging doesn't break due to mixed slf4j library versions.
Similarly, it's useful to use log4j-bom to align log4j library versions.
SLF4J 2.0.x upgrade was made in PR #4248 .

### Changes

- use slf4j-bom and log4j-bom in dependencyManagement