### PR TITLE
doc: add missing parameters and reorganize existing parameters in compact settings

### DIFF
--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -172,17 +172,17 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
+| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
+| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
 | majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
-| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
-| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -182,7 +182,8 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
-
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 
 ## Garbage collection settings
 

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -185,6 +185,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
+
 ## Garbage collection settings
 
 | Parameter | Description | Default

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -178,12 +178,12 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
-| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
-| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 
 ## Garbage collection settings
 

--- a/site3/website/versioned_docs/version-4.10.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.10.0/reference/config.md
@@ -161,15 +161,15 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.11.1/reference/config.md
+++ b/site3/website/versioned_docs/version-4.11.1/reference/config.md
@@ -161,15 +161,15 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.12.1/reference/config.md
+++ b/site3/website/versioned_docs/version-4.12.1/reference/config.md
@@ -161,15 +161,15 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.13.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.13.0/reference/config.md
@@ -161,15 +161,15 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.14.8/reference/config.md
+++ b/site3/website/versioned_docs/version-4.14.8/reference/config.md
@@ -161,17 +161,17 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
+| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
+| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
 | majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
-| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
-| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.14.8/reference/config.md
+++ b/site3/website/versioned_docs/version-4.14.8/reference/config.md
@@ -167,6 +167,8 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 

--- a/site3/website/versioned_docs/version-4.15.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.15.5/reference/config.md
@@ -173,6 +173,8 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 

--- a/site3/website/versioned_docs/version-4.15.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.15.5/reference/config.md
@@ -167,17 +167,17 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
+| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
+| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
 | majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
-| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
-| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.16.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.16.5/reference/config.md
@@ -172,17 +172,17 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
+| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
+| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
 | majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
-| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
-| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.16.5/reference/config.md
+++ b/site3/website/versioned_docs/version-4.16.5/reference/config.md
@@ -178,6 +178,8 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 

--- a/site3/website/versioned_docs/version-4.17.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.17.0/reference/config.md
@@ -172,17 +172,17 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
+| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
+| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
 | majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
-| isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
-| compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 

--- a/site3/website/versioned_docs/version-4.17.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.17.0/reference/config.md
@@ -178,6 +178,8 @@ The table below lists parameters that you can set to configure bookies. All conf
 | compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
 | majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
 | majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. | -1 to run indefinitely. | 
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. | -1 to run indefinitely. |
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 

--- a/site3/website/versioned_docs/version-4.5.1/reference/config.md
+++ b/site3/website/versioned_docs/version-4.5.1/reference/config.md
@@ -161,16 +161,16 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
-| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false |  
 
 
 ## Garbage collection settings

--- a/site3/website/versioned_docs/version-4.6.2/reference/config.md
+++ b/site3/website/versioned_docs/version-4.6.2/reference/config.md
@@ -161,16 +161,16 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
-| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false |  
 
 
 ## Garbage collection settings

--- a/site3/website/versioned_docs/version-4.7.3/reference/config.md
+++ b/site3/website/versioned_docs/version-4.7.3/reference/config.md
@@ -161,16 +161,16 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
-| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false |  
 
 
 ## Garbage collection settings

--- a/site3/website/versioned_docs/version-4.8.2/reference/config.md
+++ b/site3/website/versioned_docs/version-4.8.2/reference/config.md
@@ -161,16 +161,16 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
-| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
+| useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false |  
 
 
 ## Garbage collection settings

--- a/site3/website/versioned_docs/version-4.9.2/reference/config.md
+++ b/site3/website/versioned_docs/version-4.9.2/reference/config.md
@@ -161,15 +161,15 @@ The table below lists parameters that you can set to configure bookies. All conf
 
 | Parameter | Description | Default
 | --------- | ----------- | ------- | 
-| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
-| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
-| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
-| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
-| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
-| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
+| compactionRate | The rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionMaxOutstandingRequests | Set the maximum number of entries which can be compacted without flushing. When compacting, the entries are written to the entrylog and the new offsets are cached in memory. Once the entrylog is flushed the index is updated with the new offsets. This parameter controls the number of entries added to the entrylog before a flush is forced. A higher value for this parameter means more memory will be used for offsets. Each offset consists of 3 longs. This parameter should *not* be modified unless you know what you're doing. | 100000 | 
+| minorCompactionThreshold | Threshold of minor compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a minor compaction. If it is set to less than zero, the minor compaction is disabled. | 0.2 | 
+| majorCompactionThreshold | Threshold of major compaction. For those entry log files whose remaining size percentage reaches below this threshold will be compacted in a major compaction. Those entry log files whose remaining size percentage is still higher than the threshold will never be compacted. If it is set to less than zero, the minor compaction is disabled. | 0.8 | 
+| minorCompactionInterval | Interval to run minor compaction, in seconds. If it is set to less than zero, the minor compaction is disabled. | 3600 | 
+| majorCompactionInterval | Interval to run major compaction, in seconds. If it is set to less than zero, the major compaction is disabled. | 86400 | 
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 


### PR DESCRIPTION
### Motivation
The current configuration documentation for BookKeeper lacks some important parameters. Additionally, existing parameters are not optimally organized. This update:
- Introduces missing parameters like `isThrottleByBytes`, `compactionRateByEntries`, and `compactionRateByBytes`.
- Reorganizes the configuration parameters for better clarity.

### Changes
- **Added:** New parameters that were missing in the configuration:
  - `compactionRateByEntries`: Set the rate at which compaction will read entries, measured in entries per second.
  - `compactionRateByBytes`: Set the rate at which compaction will read entries, measured in bytes per second.
  
- **Reorganized:** Adjusted the placement of existing parameters for better logical grouping and readability:
  - `minorCompactionThreshold`: Adjusted position for clarity.
  - `minorCompactionInterval`: Moved for logical grouping.