### PR TITLE
build: fix OWASP GitHub daily workflow

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -507,11 +507,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Set up Maven
-        uses: apache/pulsar-test-infra/setup-maven@master
-        with:
-          maven-version: 3.8.7
-
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyway

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,11 +84,6 @@ jobs:
         distribution: 'temurin'
         java-version: 11
 
-    - name: Set up Maven
-      uses: apache/pulsar-test-infra/setup-maven@master
-      with:
-        maven-version: 3.8.7
-
     - name: Validate pull request
       if: steps.check_changes.outputs.docs_only != 'true'
       run: |

--- a/.github/workflows/owasp-daily-build.yml
+++ b/.github/workflows/owasp-daily-build.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: JDK 21 Daily Build
+name: OWASP Daily Build
 
 on:
   schedule:
@@ -35,12 +35,8 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: 21
-
-      - name: Set up Maven
-        uses: apache/pulsar-test-infra/setup-maven@master
-        with:
-          maven-version: 3.8.7
 
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with


### PR DESCRIPTION
### Changes

- Removed Maven setup steps from `.github/workflows/bk-ci.yml`, `setup-java` will set maven ready.
- Changed the name of the daily build in `.github/workflows/owasp-daily-build.yml` from "JDK 21 Daily Build" to "OWASP Daily Build"
- Added needed params distribution to 'temurin'.


test on fork repo, it works well.
https://github.com/shoothzj/bookkeeper/actions/runs/9032270409/job/24820129535
<img width="1648" alt="image" src="https://github.com/apache/bookkeeper/assets/12933197/a7387d65-ff47-4e76-8f85-071cb3b5b70d">

```
Error:  Failed to execute goal org.owasp:dependency-check-maven:9.1.0:aggregate (default) on project bookkeeper: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  amqp-client-5.5.3.jar: CVE-2023-46120(7.5)
Error:  bc-fips-1.0.2.4.jar: CVE-2024-29[8](https://github.com/shoothzj/bookkeeper/actions/runs/9032270409/job/24820129535#step:5:9)57(7.5)
Error:  bcprov-jdk15on-1.64.jar: CVE-2024-2[9](https://github.com/shoothzj/bookkeeper/actions/runs/9032270409/job/24820129535#step:5:10)857(7.5), CVE-2024-34447(7.699999809265137)
Error:  grpc-core-1.56.0.jar: CVE-2023-44487(7.5), CVE-2023-4785(7.5), CVE-2023-33953(7.5)
Error:  grpc-protobuf-1.56.0.jar: CVE-2023-44487(7.5), CVE-2023-4785(7.5), CVE-2023-33953(7.5)
Error:  okio-3.2.0.jar: CVE-2023-3635(7.5)
Error:  plexus-cipher-2.0.jar: CVE-2022-4244(7.5)
Error:  plexus-classworlds-2.7.0.jar: CVE-2022-4244(7.5)
Error:  plexus-component-annotations-2.1.0.jar: CVE-2022-4244(7.5)
Error:  plexus-interpolation-1.26.jar: CVE-2022-4244(7.5)
Error:  plexus-sec-dispatcher-2.0.jar: CVE-2022-4244(7.5)
Error:  snakeyaml-1.19.jar: CVE-20[17](https://github.com/shoothzj/bookkeeper/actions/runs/9032270409/job/24820129535#step:5:18)-18640(7.5), CVE-2022-25857(7.5)
```
