### PR TITLE
Add Compaction Duration Settings to 4.14.0 Upgrade Docs

### DIFF
--- a/site3/website/docs/admin/upgrade.md
+++ b/site3/website/docs/admin/upgrade.md
@@ -222,6 +222,13 @@ There are no common settings whose default value are changed at 4.14.0.
 
 #### Server Configuration Changes
 
+##### New Settings
+
+| Name                         | Description                                   |
+|------------------------------|-----------------------------------------------|
+| minorCompactionMaxTimeMillis | Maximum milliseconds to run minor Compaction. |
+| majorCompactionMaxTimeMillis | Maximum milliseconds to run major Compaction. |
+
 ##### Deprecated Settings
 
 There are no setting deprecated in 4.14.0


### PR DESCRIPTION

### Motivation

4.14.0 introduce new conf `minorCompactionMaxTimeMillis` and `majorCompactionMaxTimeMillis`, but not recorded in the `upgrade.md`.

### Changes

Record the conf change in 4.14.0.
