### PR TITLE
[ci] Fix apache/pulsar-test-infra/paths-filter action permission in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,7 @@ jobs:
       # only required for workflows in private repositories
       actions: read
       contents: read
+      pull-requests: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Motivation

The codeql workflow needs read pull-requests permission when use action `apache/pulsar-test-infra/paths-filter@master`
![image](https://github.com/apache/bookkeeper/assets/10069311/df238e95-4710-4ef2-8e19-bc5b63a65c6d)
