### PR TITLE
doc: update documentation for releases and APIs to reflect correct versions

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -7,8 +7,8 @@ const baseUrl = process.env.BASE_URL || "/"
 const deployUrl = process.env.DEPLOY_URL || "https://bookkeeper.apache.org";
 const variables = {
   /** They are used in .md files*/
-  latest_release: "4.16.4",
-  stable_release: "4.14.8",
+  latest_release: "4.17.0",
+  stable_release: "4.16.5",
   github_repo: "https://github.com/apache/bookkeeper",
   github_master: "https://github.com/apache/bookkeeper/tree/master",
   mirror_base_url: "https://www.apache.org/dyn/closer.lua/bookkeeper",

--- a/site3/website/versioned_docs/version-4.15.5/overview/overview.md
+++ b/site3/website/versioned_docs/version-4.15.5/overview/overview.md
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This documentation is for Apache BookKeeper&trade; version {{ site.latest_release }}.
+This documentation is for Apache BookKeeper&trade; version 4.15.5.
 
 Apache BookKeeper&trade; is a scalable, fault-tolerant, low-latency storage service optimized for real-time workloads. It offers durability, replication, and strong consistency as essentials for building reliable real-time applications.
 

--- a/site3/website/versioned_docs/version-4.17.0/api/ledger-api.md
+++ b/site3/website/versioned_docs/version-4.17.0/api/ledger-api.md
@@ -21,7 +21,7 @@ If you're using [Maven](https://maven.apache.org/), add this to your [`pom.xml`]
 
 ```xml
 <!-- in your <properties> block -->
-<bookkeeper.version>4.16.4</bookkeeper.version>
+<bookkeeper.version>4.17.0</bookkeeper.version>
 
 <!-- in your <dependencies> block -->
 <dependency>
@@ -37,7 +37,7 @@ shaded library, which relocate classes of protobuf and guava into a different na
 
 ```xml
 <!-- in your <properties> block -->
-<bookkeeper.version>4.16.4</bookkeeper.version>
+<bookkeeper.version>4.17.0</bookkeeper.version>
 
 <!-- in your <dependencies> block -->
 <dependency>
@@ -53,12 +53,12 @@ If you're using [Gradle](https://gradle.org/), add this to your [`build.gradle`]
 
 ```groovy
 dependencies {
-    compile group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: '4.16.4'
+    compile group: 'org.apache.bookkeeper', name: 'bookkeeper-server', version: '4.17.0'
 }
 
 // Alternatively:
 dependencies {
-    compile 'org.apache.bookkeeper:bookkeeper-server:4.16.4'
+    compile 'org.apache.bookkeeper:bookkeeper-server:4.17.0'
 }
 ```
 

--- a/site3/website/versioned_docs/version-4.17.0/overview/overview.md
+++ b/site3/website/versioned_docs/version-4.17.0/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Apache BookKeeper 4.16.4-SNAPSHOT
+title: Apache BookKeeper 4.17.0
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This documentation is for Apache BookKeeper&trade; version 4.16.4.
+This documentation is for Apache BookKeeper&trade; version 4.17.0.
 
 Apache BookKeeper&trade; is a scalable, fault-tolerant, low-latency storage service optimized for real-time workloads. It offers durability, replication, and strong consistency as essentials for building reliable real-time applications.
 
@@ -39,7 +39,7 @@ Object/[BLOB](https://en.wikipedia.org/wiki/Binary_large_object) storage | Stori
 
 Learn more about Apache BookKeeper&trade; and what it can do for your organization:
 
-- [Apache BookKeeper 4.16.4 Release Notes](/release-notes#4164)
+- [Apache BookKeeper 4.17.0 Release Notes](/release-notes#4164)
 - [Java API docs]({{ site.javadoc_base_url }})
 
 Or start [using](../getting-started/installation) Apache BookKeeper today.

--- a/site3/website/versioned_docs/version-4.17.0/reference/config.md
+++ b/site3/website/versioned_docs/version-4.17.0/reference/config.md
@@ -280,7 +280,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | --------- | ----------- | ------- | 
 | enableStatistics | Whether statistics are enabled for the bookie. | true |
 | sanityCheckMetricsEnabled | Flag to enable sanity check metrics in bookie stats. | false |
-| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider<br /> - Twitter Finagle  : org.apache.bookkeeper.stats.twitter.finagle.FinagleStatsProvider<br /> - Twitter Ostrich  : org.apache.bookkeeper.stats.twitter.ostrich.OstrichProvider<br /> - Twitter Science  : org.apache.bookkeeper.stats.twitter.science.TwitterStatsProvider<br /> | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
+| statsProviderClass | Stats provider class.<br />Options:<br /> - Prometheus    : org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider<br /> - Codahale     : org.apache.bookkeeper.stats.codahale.CodahaleMetricsProvider | org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider | 
 | limitStatsLogging | option to limit stats logging | true | 
 
 
@@ -303,23 +303,6 @@ The table below lists parameters that you can set to configure bookies. All conf
 | codahaleStatsCSVEndpoint | the directory for reporting stats in csv format. see [csv reporter](//metrics.dropwizard.io/3.1.0/manual/core/#csv) for more details. | null | 
 | codahaleStatsSlf4jEndpoint | the slf4j endpoint for reporting stats. see [slf4j reporter](//metrics.dropwizard.io/3.1.0/manual/core/#slf4j) for more details. | null | 
 | codahaleStatsJmxEndpoint | the jmx endpoint for reporting stats. see [jmx reporter](//metrics.dropwizard.io/3.1.0/manual/core/#jmx) for more details. |  | 
-
-
-## Twitter Ostrich Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose ostrich metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing ostrich stats if `statsExport` is set to true | 9002 | 
-
-
-## Twitter Science Metrics Provider
-
-| Parameter | Description | Default
-| --------- | ----------- | ------- | 
-| statsExport | Flag to control whether to expose metrics via a http endpoint configured by `statsHttpPort`. | false | 
-| statsHttpPort | The http port of exposing stats if `statsExport` is set to true | 9002 | 
-
 
 ## AutoRecovery general settings
 


### PR DESCRIPTION
### Changes

- Fix some versions wrong in the version docs. 
- Cherry-Pick the removal of twitter metrics library to 4.17.0 doc
- Update the `latest_release` and `stable_release `