### PR TITLE
Bump jetcd from 0.7.7 to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <curator.version>5.1.0</curator.version>
     <disruptor.version>4.0.0</disruptor.version>
     <dropwizard.version>4.1.12.1</dropwizard.version>
-    <etcd.version>0.7.7</etcd.version>
+    <etcd.version>0.8.0</etcd.version>
     <freebuilder.version>2.8.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>


### PR DESCRIPTION
### Motivation

Bump jetcd from 0.7.7 to 0.8.0 to more compatible with grpc 1.64.0/protobuf 3.25.1. See also #3849 #4344