### PR TITLE
fix lost prometheus metric in OrderedExecutor  

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutor.java
@@ -1,0 +1,58 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.bookkeeper.common.util;
+
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test OrderedExecutor/Scheduler .
+ */
+public class TestOrderedExecutor {
+
+    @Test
+    public void testOrderExecutorPrometheusMetric() {
+        testGenerateMetric(false);
+        testGenerateMetric(true);
+    }
+
+    private void testGenerateMetric(boolean isTraceTaskExecution) {
+        TestStatsProvider provider = new TestStatsProvider();
+
+        TestStatsProvider.TestStatsLogger rootStatsLogger = provider.getStatsLogger("");
+        TestStatsProvider.TestStatsLogger bookieStats =
+                (TestStatsProvider.TestStatsLogger) rootStatsLogger.scope("bookkeeper_server");
+
+        OrderedExecutor executor = OrderedExecutor.newBuilder().statsLogger(bookieStats)
+                .name("test").numThreads(1).traceTaskExecution(isTraceTaskExecution).build();
+
+        TestStatsProvider.TestStatsLogger testStatsLogger = (TestStatsProvider.TestStatsLogger)
+                bookieStats.scope("thread_test_OrderedExecutor_0_0");
+
+        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_queue").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_completed").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_completed").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_rejected").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_failed").getSample());
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:


Fix [#4373](https://github.com/apache/bookkeeper/issues/4373)

### Motivation

As shown in the issue.

This is the first pr to fix the lost metric problem. And the other pr improve the metric in SingleThreadExecutor.


### Changes

If we only fix the problem but do not change the metric , the metric is as follow, the metric become visible, though the format is not same.

![企业微信截图_179bc46b-3d59-427b-957b-ec185eff3e38](https://github.com/apache/bookkeeper/assets/13505225/29007e31-7c86-4e2d-b555-9f21b815269e)
![企业微信截图_ac0c1ec5-6363-48e9-9378-a82d95e3af0d](https://github.com/apache/bookkeeper/assets/13505225/4ab45572-706c-4cd3-9a83-bfa5314e14cd)


