### PR TITLE
Remove unused code from ByteBufVisitor

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufVisitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufVisitor.java
@@ -162,12 +162,6 @@ public class ByteBufVisitor {
                     handleArray(visitBuffer.array(), visitBuffer.arrayOffset() + visitIndex, visitLength);
                 } else if (visitBuffer.hasMemoryAddress() && callback.acceptsMemoryAddress(callbackContext)) {
                     callback.visitBuffer(callbackContext, visitBuffer, visitIndex, visitLength);
-                } else if (callback.acceptsMemoryAddress(callbackContext) && visitBuffer.isDirect()
-                        && visitBuffer.alloc().isDirectBufferPooled()) {
-                    // read-only buffers need to be copied before they can be directly accessed
-                    ByteBuf copyBuffer = visitBuffer.copy(visitIndex, visitLength);
-                    callback.visitBuffer(callbackContext, copyBuffer, 0, visitLength);
-                    copyBuffer.release();
                 } else {
                     // fallback to reading the visited buffer into the copy buffer in a loop
                     byte[] copyBuffer = TL_COPY_BUFFER.get();


### PR DESCRIPTION
### Motivation

ByteBufVisitor added in #4196 contains some code that isn't used and covered by unit tests. 
It's better to remove such code since it makes it harder to reason about the solution. The ByteBufVisitor solution will unwrap all direct buffers that can be unwrapped without the code that is to be removed. I believe that I forgot this code from some earlier phase of the solution where it was necessary to include this.
I ran some local tests and didn't see that the code was used for the original purpose that it was added for (supporting read-only buffers).

### Changes

Remove the unused code.