### PR TITLE
Replace assert statements with explicit checks

### DIFF
--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogSegmentWriter.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/BKLogSegmentWriter.java
@@ -1192,7 +1192,11 @@ class BKLogSegmentWriter implements LogSegmentWriter, AddCallback, Runnable, Siz
         }
         lastEntryId = entryId;
 
-        assert (ctx instanceof BKTransmitPacket);
+        if (!(ctx instanceof BKTransmitPacket)) {
+            LOG.error("Log segment {} received addComplete with invalid context {}",
+                    fullyQualifiedLogSegment, ctx);
+            return;
+        }
         final BKTransmitPacket transmitPacket = (BKTransmitPacket) ctx;
 
         // Time from transmit until receipt of addComplete callback

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/impl/metadata/BKDLConfig.java
@@ -73,7 +73,9 @@ public class BKDLConfig implements DLConfig {
                 dlConfig = oldDLConfig;
             }
         }
-        assert (dlConfig instanceof BKDLConfig);
+        if (!(dlConfig instanceof BKDLConfig)) {
+            throw new IllegalStateException("Invalid DLConfig type : " + dlConfig.getClass().getName());
+        }
         return (BKDLConfig) dlConfig;
     }
 

--- a/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKVersionedSetOp.java
+++ b/stream/distributedlog/core/src/main/java/org/apache/distributedlog/zk/ZKVersionedSetOp.java
@@ -55,7 +55,9 @@ public class ZKVersionedSetOp extends ZKOp {
         if (null == opResult) {
             cause = t;
         } else {
-            assert (opResult instanceof OpResult.ErrorResult);
+            if (!(opResult instanceof OpResult.ErrorResult)) {
+                throw new IllegalStateException("Invalid op result : " + opResult);
+            }
             OpResult.ErrorResult errorResult = (OpResult.ErrorResult) opResult;
             if (KeeperException.Code.OK.intValue() == errorResult.getErr()) {
                 cause = t;


### PR DESCRIPTION
Main Issue #995

### Motivation

In the current implementation, several components use `assert` statements to verify conditions. However, assert statements are not typically enabled in production environments, which means these checks can be bypassed, potentially leading to unclear errors later in the execution. Replacing these with explicit checks ensures that our error handling is active and clear during production runs.

### Changes

- **BKLogSegmentWriter.java**: Added a check to verify the context type before casting to `BKTransmitPacket`.
- **BKDLConfig.java**: Introduced a check for the type of `dlConfig` before casting to `BKDLConfig`.
- **ZKVersionedSetOp.java**: Added a check to ensure the operation result is of type `OpResult.ErrorResult`. 
