### PR TITLE
build: remove tests module from owasp check

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -523,7 +523,7 @@ jobs:
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyway
-        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs'
+        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests'
 
       - name: Upload report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/owasp-daily-build.yml
+++ b/.github/workflows/owasp-daily-build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyway
-        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs'
+        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests'

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -22,156 +22,80 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <!-- add suppressions for known vulnerabilities detected by OWASP Dependency Check -->
 
+    <!-- jetcd higher version requires jdk 11 -->
     <suppress>
-        <notes>CVE-2021-43045 affects only .NET distro, see https://github.com/apache/avro/pull/1357</notes>
-        <gav regex="true">org\.apache\.avro:.*</gav>
-        <cve>CVE-2021-43045</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2011-1797 FP, see https://github.com/jeremylong/DependencyCheck/issues/4154</notes>
-        <filePath regex="true">.*netty-tcnative-boringssl-static.*\.jar</filePath>
-        <cve>CVE-2011-1797</cve>
-    </suppress>
-    <suppress base="true">
-        <notes><![CDATA[
-        False positive
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
-    </suppress>
-    <!-- matches against docker CVEs -->
-    <suppress>
-        <notes><![CDATA[
-   file name: arquillian-cube-docker-1.18.2.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.arquillian\.cube/arquillian\-cube\-docker@.*$</packageUrl>
-        <cpe>cpe:/a:docker:docker</cpe>
+        <notes>CVE-2020-15113</notes>
+        <filePath regex="true">.*jetcd.*\.jar</filePath>
+        <cve>CVE-2020-15113</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: arquillian-cube-docker-1.18.2.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.arquillian\.cube/arquillian\-cube\-docker@.*$</packageUrl>
-        <cpe>cpe:/a:redhat:docker</cpe>
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2023-44487</cve>
     </suppress>
-  <suppress>
-<!--    Zookkeeper false positive about Jetty and commons-io-->
-<!--    https://github.com/apache/zookeeper/pull/1824-->
-    <notes><![CDATA[
-   file name: zookeeper-3.8.0.jar
-   ]]></notes>
-    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
-    <cve>CVE-2021-28164</cve>
-  </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: zookeeper-3.8.0.jar
-   ]]></notes>
-        <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
-        <cve>CVE-2021-28165</cve>
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2017-8359</cve>
     </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-3.8.0.jar
-   ]]></notes>
-    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
-    <cve>CVE-2021-29425</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-3.8.0.jar
-   ]]></notes>
-    <sha1>e395c1d8a71557b7569cc6a83487b2e30e2e58fe</sha1>
-    <cve>CVE-2021-34429</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-prometheus-metrics-3.8.0.jar
-   ]]></notes>
-    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
-    <cve>CVE-2021-28164</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-prometheus-metrics-3.8.0.jar
-   ]]></notes>
-    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
-    <cve>CVE-2021-29425</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-prometheus-metrics-3.8.0.jar
-   ]]></notes>
-    <sha1>849e8ece2845cb0185d721233906d487a7f1e4cf</sha1>
-    <cve>CVE-2021-34429</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-jute-3.8.0.jar
-   ]]></notes>
-    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
-    <cve>CVE-2021-28164</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-jute-3.8.0.jar
-   ]]></notes>
-    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
-    <cve>CVE-2021-28165</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-jute-3.8.0.jar
-   ]]></notes>
-    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
-    <cve>CVE-2021-29425</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-jute-3.8.0.jar
-   ]]></notes>
-    <sha1>6560f966bcf1aa78d27bcfa75fb6c4463a72c6c5</sha1>
-    <cve>CVE-2021-34429</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: zookeeper-3.8.0-tests.jar
-   ]]></notes>
-     <sha1>9b78a289a3aa34eb47fac8c432f664fc140387df</sha1>
-     <cve>CVE-2021-28165</cve>
-  </suppress>
-    <!-- https://github.com/jeremylong/DependencyCheck/issues/4487 -->
     <suppress>
         <notes><![CDATA[
-   file name: google-http-client-gson-1.41.0.jar
-   ]]></notes>
-        <sha1>1a754a5dd672218a2ac667d7ff2b28df7a5a240e</sha1>
-        <cve>CVE-2022-25647</cve>
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2023-33953</cve>
     </suppress>
-    <!-- only use maven-settings for integration-test -->
     <suppress>
         <notes><![CDATA[
-   file name: maven-settings-3.3.9.jar
-   ]]></notes>
-        <sha1>68d4180c51468ae8f45869f8f9c569092262fcca</sha1>
-        <cve>CVE-2021-26291</cve>
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2020-7768</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2017-7861</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2017-9431</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+           file name: jetcd-grpc-0.7.7.jar
+           ]]></notes>
+        <sha1>0fa26f72729edb39b506efa96e119f953f59c5a3</sha1>
+        <cve>CVE-2017-7860</cve>
     </suppress>
 
-  <suppress>
-    <notes><![CDATA[
-    snakeyaml is not "fixing" CVE-2022-1471.
-    see: https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE%20&%20NIST.md
-         https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
-  </suppress>
+    <suppress>
+        <notes>CVE-2023-46120</notes>
+        <filePath regex="true">.*amqp-client.*\.jar</filePath>
+        <cve>CVE-2023-46120</cve>
+    </suppress>
 
-  <suppress>
-    <notes><![CDATA[
+    <suppress>
+        <notes><![CDATA[
    file name: testng-7.5.jar
    ]]></notes>
-    <sha1>1416a607fae667c14e390b484e8d02b5824c0674</sha1>
-    <vulnerabilityName>CVE-2022-4065</vulnerabilityName>
-  </suppress>
+        <sha1>1416a607fae667c14e390b484e8d02b5824c0674</sha1>
+        <vulnerabilityName>CVE-2022-4065</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

`integrate-tests` module depends on `arquillian-cube`, which are updates infrequently. Lastly release was in 2018, and it depends on a lot of dependency with CVEs, like `bcprov-jdk15on-1.64.jar` etc. But it still merging code frequently, my team will trying to ask for new release, I think we can remove tests module from owasp check for now.

I run the check locally, fix 7 error, and no new errors generated compared to daily build result.

#### Local Result

```
[ERROR] amqp-client-5.5.3.jar: CVE-2023-46120(7.5)
[ERROR] jetcd-core-0.7.7.jar: CVE-2020-15113(7.1)
[ERROR] jetcd-grpc-0.7.7.jar: CVE-2023-44487(7.5), CVE-2017-8359(9.8), CVE-2023-33953(7.5), CVE-2020-15113(7.1), CVE-2020-7768(9.8), CVE-2017-7861(9.8), CVE-2017-9431(9.8), CVE-2017-7860(9.8)
[ERROR] okio-3.2.0.jar: CVE-2023-3635(7.5)
```

After refresh the suppression list(jetcd required jdk11, amqp is independent dependency from dropwizard metrics. There is only, I think we can fix it though upgrading OTEL version.

```
[ERROR] okio-3.2.0.jar: CVE-2023-3635(7.5)
```

#### Daily build result 

```
Error:  amqp-client-5.5.3.jar: CVE-2023-46120(7.5)
Error:  bcprov-jdk15on-1.64.jar: CVE-2024-29857(7.5), CVE-2024-34447(7.699999809265137)
Error:  jetcd-core-0.7.7.jar: CVE-2020-151[13](https://github.com/apache/bookkeeper/actions/runs/9239112134/job/25417858696#step:5:14)(7.1)
Error:  jetcd-grpc-0.7.7.jar: CVE-2023-44487(7.5), CVE-2017-8359(9.8), CVE-2023-33953(7.5), CVE-2020-15113(7.1), CVE-2020-7768(9.8), CVE-2017-7861(9.8), CVE-2017-9431(9.8), CVE-2017-7860(9.8)
Error:  okio-3.2.0.jar: CVE-2023-3635(7.5)
Error:  plexus-cipher-2.0.jar: CVE-2022-4244(7.5)
Error:  plexus-classworlds-2.7.0.jar: CVE-2022-4244(7.5)
Error:  plexus-component-annotations-2.1.0.jar: CVE-2022-4244(7.5)
Error:  plexus-interpolation-1.26.jar: CVE-2022-4244(7.5)
Error:  plexus-sec-dispatcher-2.0.jar: CVE-2022-4244(7.5)
Error:  snakeyaml-1.19.jar: CVE-20[17](https://github.com/apache/bookkeeper/actions/runs/9239112134/job/25417858696#step:5:18)-18640(7.5), CVE-2022-25857(7.5)
```