### PR TITLE
improve registerMetric in orderExecutor

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -391,9 +391,9 @@ public class OrderedExecutor implements ExecutorService {
             ExecutorService thread = createSingleThreadExecutor(
                     new ThreadFactoryBuilder().setNameFormat(name + "-" + getClass().getSimpleName() + "-" + i + "-%d")
                     .setThreadFactory(threadFactory).build());
-            SingleThreadExecutor ste = null;
             if (thread instanceof SingleThreadExecutor) {
-                ste = (SingleThreadExecutor) thread;
+                SingleThreadExecutor ste = (SingleThreadExecutor) thread;
+                ste.registerMetrics(statsLogger, name, i);
             }
 
             if (traceTaskExecution || preserveMdcForTaskExecution) {
@@ -427,10 +427,6 @@ public class OrderedExecutor implements ExecutorService {
                 throw new RuntimeException("Couldn't start thread " + i, e);
             } catch (ExecutionException e) {
                 throw new RuntimeException("Couldn't start thread " + i, e);
-            }
-
-            if (ste != null) {
-                ste.registerMetrics(statsLogger);
             }
         }
 

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
@@ -225,10 +225,10 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
         }
     }
 
-    public void registerMetrics(StatsLogger statsLogger) {
+    public void registerMetrics(StatsLogger statsLogger, String name, int idx) {
         // Register gauges
-        statsLogger.scopeLabel("thread", runner.getName())
-                .registerGauge("thread_executor_queue", new Gauge<Number>() {
+        statsLogger.scopeLabel("thread", String.valueOf(idx))
+                .registerGauge(String.format("%s-queue", name), new Gauge<Number>() {
                     @Override
                     public Number getDefaultValue() {
                         return 0;
@@ -239,8 +239,8 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
                         return getQueuedTasksCount();
                     }
                 });
-        statsLogger.scopeLabel("thread", runner.getName())
-                .registerGauge("thread_executor_completed", new Gauge<Number>() {
+        statsLogger.scopeLabel("thread", String.valueOf(idx))
+                .registerGauge(String.format("%s-completed-tasks", name), new Gauge<Number>() {
                     @Override
                     public Number getDefaultValue() {
                         return 0;
@@ -251,20 +251,8 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
                         return getCompletedTasksCount();
                     }
                 });
-        statsLogger.scopeLabel("thread", runner.getName())
-                .registerGauge("thread_executor_tasks_completed", new Gauge<Number>() {
-                    @Override
-                    public Number getDefaultValue() {
-                        return 0;
-                    }
-
-                    @Override
-                    public Number getSample() {
-                        return getCompletedTasksCount();
-                    }
-                });
-        statsLogger.scopeLabel("thread", runner.getName())
-                .registerGauge("thread_executor_tasks_rejected", new Gauge<Number>() {
+        statsLogger.scopeLabel("thread", String.valueOf(idx))
+                .registerGauge(String.format("%s-rejected-tasks", name), new Gauge<Number>() {
                     @Override
                     public Number getDefaultValue() {
                         return 0;
@@ -275,8 +263,8 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
                         return getRejectedTasksCount();
                     }
                 });
-        statsLogger.scopeLabel("thread", runner.getName())
-                .registerGauge("thread_executor_tasks_failed", new Gauge<Number>() {
+        statsLogger.scopeLabel("thread", String.valueOf(idx))
+                .registerGauge(String.format("%s-failed-tasks", name), new Gauge<Number>() {
                     @Override
                     public Number getDefaultValue() {
                         return 0;

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestOrderedExecutor.java
@@ -47,12 +47,11 @@ public class TestOrderedExecutor {
                 .name("test").numThreads(1).traceTaskExecution(isTraceTaskExecution).build();
 
         TestStatsProvider.TestStatsLogger testStatsLogger = (TestStatsProvider.TestStatsLogger)
-                bookieStats.scope("thread_test_OrderedExecutor_0_0");
+                bookieStats.scope("thread_0");
 
-        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_queue").getSample());
-        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_completed").getSample());
-        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_completed").getSample());
-        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_rejected").getSample());
-        Assert.assertNotNull(testStatsLogger.getGauge("thread_executor_tasks_failed").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("test-queue").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("test-rejected-tasks").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("test-failed-tasks").getSample());
+        Assert.assertNotNull(testStatsLogger.getGauge("test-completed-tasks").getSample());
     }
 }


### PR DESCRIPTION
Main Issue: https://github.com/apache/bookkeeper/issues/4373


### Motivation

As is shown in the issue, This is the second pr to improve the registerMetric() in orderExecutor.

### Changes

1. remove the duplicate metric
2. modify the metric name format, make it compatible with previous version.

after improvement, the metric is :
![企业微信截图_be1a641e-e969-45db-b661-72122d6c1dd6](https://github.com/apache/bookkeeper/assets/13505225/5f204ceb-1caa-4d22-a567-aed3c4e41f4f)

![image](https://github.com/apache/bookkeeper/assets/13505225/22aadb95-e3ab-4916-8f32-9062b4b8dfb0)



