### PR TITLE
Adapt Checkstyle in microbenchmarks module

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java8IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java8IntHash.java
@@ -22,8 +22,6 @@ import static com.scurrilous.circe.params.CrcParameters.CRC32C;
 import com.scurrilous.circe.IncrementalIntHash;
 import com.scurrilous.circe.crc.StandardCrcProvider;
 import io.netty.buffer.ByteBuf;
-import java.nio.ByteBuffer;
-import java.util.zip.Checksum;
 
 public class Java8IntHash implements IntHash {
 

--- a/circe-checksum/src/main/java/com/scurrilous/circe/utils/NativeUtils.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/utils/NativeUtils.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;

--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -116,9 +116,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/package-info.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/bookie/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bookkeeper.bookie;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/ProtocolBenchmark.java
@@ -34,7 +34,6 @@ import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
-import org.apache.bookkeeper.util.ByteBufList;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;

--- a/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManagerBenchmark.java
+++ b/microbenchmarks/src/main/java/org/apache/bookkeeper/proto/checksum/DigestManagerBenchmark.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.DigestType;
-import org.apache.bookkeeper.util.ByteBufList;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;


### PR DESCRIPTION
### Changes

- **circe-checksum module:**
  - Removed unused imports such as `java.nio.ByteBuffer` and `java.util.zip.Checksum` in `Java8IntHash.java`.
  - Removed `java.io.IOException` import in `NativeUtils.java`.

- **microbenchmarks module:**
  - Modified the `pom.xml` to enforce Checkstyle by removing the `<skip>true</skip>` configuration.
  - Removed unused `ByteBufList` imports from `ProtocolBenchmark.java` and `DigestManagerBenchmark.java`.
