### PR TITLE
Exclude tests submodule from OWASP checks in CI workflows

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -523,7 +523,9 @@ jobs:
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyway
-        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests'
+        run: |
+          exclude_list=$(find tests -name "pom.xml" | sed 's|/pom.xml||' | sed 's|^|!|' | tr '\n' ',')
+          mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests,'$exclude_list
 
       - name: Upload report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/owasp-daily-build.yml
+++ b/.github/workflows/owasp-daily-build.yml
@@ -41,4 +41,6 @@ jobs:
       - name: run "clean install verify" to trigger dependency check
         # excluding dlfs because it includes hadoop lib with
         # CVEs that we cannot patch up anyway
-        run: mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests'
+        run: |
+          exclude_list=$(find tests -name "pom.xml" | sed 's|/pom.xml||' | sed 's|^|!|' | tr '\n' ',')
+          mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests,'$exclude_list


### PR DESCRIPTION
### Changes

- Modified `.github/workflows/bk-ci.yml` and `.github/workflows/owasp-daily-build.yml` to dynamically generate an exclusion list for submodules under `tests` and include this in the Maven command to skip OWASP checks for these modules.

The updated CI command constructs a list of all subdirectories under `tests` that contain a `pom.xml`, marks them for exclusion, and appends this list to the Maven command line. This effectively skips OWASP dependency checks on any modules under `tests`, focusing security analysis on production code only.