### PR TITLE
Configure maven-source-plugin to skip in OWASP check profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1118,6 +1118,18 @@
               </execution>
             </executions>
           </plugin>
+          <!-- skip maven source plugin due to
+          Error: Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0:jar-no-fork (attach-sources) on project buildtools:
+          Presumably you have configured maven-source-plugin to execute twice times in your build.
+          You have to configure a classifier for at least on of them.
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <configuration>
+              <skipSource>true</skipSource>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
       <reporting>


### PR DESCRIPTION
### Motivation

During OWASP checks, the `maven-source-plugin` raises error. It's hard to figure out try at least I try almost two hours. I think we can skip in OWASP check.

```
Error: Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0
(attach-sources) on project buildtools: Presumably you have configured maven-source-plugin to execute twice times in your build. You have to configure a classifier for at least one of them.
```

### Changes

- Configured `maven-source-plugin` to skip during OWASP checks in the `pom.xml` to prevent the error and ensure seamless build processes during security assessments.
