### PR TITLE
Correct Configuration Error in OWASP Dependency Check Plugin Setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>9.1.0</dependency-check-maven.version>
+    <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -1091,6 +1091,7 @@
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
             <version>${dependency-check-maven.version}</version>
+            <inherited>false</inherited>
             <configuration>
               <suppressionFiles>
                 <suppressionFile>src/owasp-dependency-check-suppressions.xml</suppressionFile>
@@ -1120,22 +1121,6 @@
           </plugin>
         </plugins>
       </build>
-      <reporting>
-        <plugins>
-          <plugin>
-            <groupId>org.owasp</groupId>
-            <artifactId>dependency-check-maven</artifactId>
-            <version>${dependency-check-maven.version}</version>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>aggregate</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-        </plugins>
-      </reporting>
     </profile>
     <profile>
       <id>delombok</id>


### PR DESCRIPTION
### Motivation
The purpose of this update is to correct a configuration error in our OWASP Dependency Check Maven plugin setup. 
I appreciate @xiezhx9 for opening the issue on [jeremylong/DependencyCheck #6697](https://github.com/jeremylong/DependencyCheck/issues/6697). Also, a special thanks to @jeremylong for his guidance and response.

From dependency-check-plugin maintainer jeremylong
> With the setup specified ODC would run too many times - once with the specified configuration and once without. You can either put the plugin into the build/plugins or in the reporting - don't do both.
> Regarding it re-running on each child module - you likely want to specify <inherited>false</inherited>.

And I believe that cause error I meet before
```
Error: Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0
(attach-sources) on project buildtools: Presumably you have configured maven-source-plugin to execute twice times in your build. You have to configure a classifier for at least one of them.
```
#4403 is not required, I will close it after this being merged

### Changes
- **Version Update:** The `dependency-check-maven.version` in `pom.xml` has been updated from `9.1.0` to `9.2.0`. This update incorporates the latest vulnerability definitions and enhancements from OWASP.
- **Fix Configuration Inheritance:** Added `<inherited>false</inherited>` to the dependency-check plugin configuration under the build section. This correction prevents the plugin from inheriting settings unnecessarily across multi-module projects, reducing superfluous scans and speeding up builds.
- **Remove Duplicate Configuration:** Eliminated the OWASP plugin configuration from the reporting section. This change fixes a prior oversight where the plugin was configured to execute twice, once in the build and once in the reporting phase, leading to unnecessary build delays.
