### PR TITLE
Fix RocksDB configuration path handling on Windows

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -24,6 +24,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.FileChannelProvider;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
@@ -4049,12 +4050,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return String configured default rocksdb conf.
      */
     public String getDefaultRocksDBConf() {
-        String defaultPath = "conf/default_rocksdb.conf";
-        URL defURL = getClass().getClassLoader().getResource(defaultPath);
-        if (defURL != null) {
-            defaultPath = defURL.getPath();
-        }
-        return getString(DEFAULT_ROCKSDB_CONF, defaultPath);
+        String filePath = getFilePath("conf/default_rocksdb.conf");
+        return getString(DEFAULT_ROCKSDB_CONF, filePath);
     }
 
     /**
@@ -4073,12 +4070,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return String configured entry Location rocksdb conf.
      */
     public String getEntryLocationRocksdbConf() {
-        String defaultPath = "conf/entry_location_rocksdb.conf";
-        URL defURL = getClass().getClassLoader().getResource(defaultPath);
-        if (defURL != null) {
-            defaultPath = defURL.getPath();
-        }
-        return getString(ENTRY_LOCATION_ROCKSDB_CONF, defaultPath);
+        String filePath = getFilePath("conf/entry_location_rocksdb.conf");
+        return getString(ENTRY_LOCATION_ROCKSDB_CONF, filePath);
     }
 
     /**
@@ -4097,12 +4090,8 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      * @return String configured ledger metadata rocksdb conf.
      */
     public String getLedgerMetadataRocksdbConf() {
-        String defaultPath = "conf/ledger_metadata_rocksdb.conf";
-        URL defURL = getClass().getClassLoader().getResource(defaultPath);
-        if (defURL != null) {
-            defaultPath = defURL.getPath();
-        }
-        return getString(LEDGER_METADATA_ROCKSDB_CONF, defaultPath);
+        String filePath = getFilePath("conf/ledger_metadata_rocksdb.conf");
+        return getString(LEDGER_METADATA_ROCKSDB_CONF, filePath);
     }
 
     /**
@@ -4154,5 +4143,19 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
      */
     public long getMaxBatchReadSize() {
         return this.getLong(MAX_BATCH_READ_SIZE, DEFAULT_MAX_BATCH_READ_SIZE);
+    }
+
+    /**
+     * Get the path of a file from resources.
+     *
+     * @param fileName the name of the file to get the path for.
+     * @return String the absolute path of the file.
+     */
+    private String getFilePath(String fileName) {
+        URL resourceURL = getClass().getClassLoader().getResource(fileName);
+        if (resourceURL != null) {
+            return Paths.get(resourceURL.getPath()).toString();
+        }
+        return "";
     }
 }


### PR DESCRIPTION
### Motivation

This PR addresses the issue where RocksDB configurations fail to correctly resolve paths on Windows systems in the `ServerConfiguration` class. See windows daily build failed in https://github.com/apache/bookkeeper/actions/runs/9294883674

> Note: Currently, windows is limited to some development jobs, there are still problems to be solved

### Changes

- Updated `ServerConfiguration.java` to utilize `java.nio.file.Paths` for path normalization and resolution.
- Refactored the `getDefaultRocksDBConf`, `getEntryLocationRocksdbConf`, and `getLedgerMetadataRocksdbConf` methods to use a new method `getFilePath`.
