### PR TITLE
[test][fix] trying to reduce or fix test flakiness

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -215,7 +215,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         startNewBookie();
         int newBookieIndex = lastBookieIndex();
         BookieServer newBookieServer = serverByIndex(newBookieIndex);
-        forceAuditorRun();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Waiting to finish the replication of failed bookie : "
@@ -273,7 +272,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         startNewBookie();
         int newBookieIndex = lastBookieIndex();
         BookieServer newBookieServer = serverByIndex(newBookieIndex);
-        forceAuditorRun();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Waiting to finish the replication of failed bookie : "
@@ -344,7 +342,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         startNewBookie();
         int newBookieIndex = lastBookieIndex();
         BookieServer newBookieServer = serverByIndex(newBookieIndex);
-        forceAuditorRun();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Waiting to finish the replication of failed bookie : "
@@ -533,7 +530,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
         int newBookieIndex = lastBookieIndex();
         BookieServer newBookieServer = serverByIndex(newBookieIndex);
-        forceAuditorRun();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Waiting to finish the replication of failed bookie : "
@@ -613,7 +609,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
 
         int newBookieIndex = lastBookieIndex();
         BookieServer newBookieServer = serverByIndex(newBookieIndex);
-        forceAuditorRun();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Waiting to finish the replication of failed bookie : "

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -179,7 +179,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         // waiting to publish urLedger znode by Auditor
         latch.await(100, TimeUnit.SECONDS);
     }
-    
+
     /**
      * Test verifies publish urLedger by Auditor and replication worker is
      * picking up the entries and finishing the rereplication of open ledger.
@@ -700,7 +700,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
             }
         });
     }
-    
+
     private void forceAuditorRun() throws Exception {
         getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get();
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fix #4411
Fix #4410

### Motivation

BookieAutoRecoveryTest is flaky on the CI

### Changes

I cannot reproduce the test failures/timeouts locally, even by running the test in the loop 100+ times.

To reduce flakiness on the CI I did the following:
* forced Auditor run in the tests before the moments when the timeouts typically occur, to avoid multiple longer waits for it to kick in by itself
* limited time to wait for latch to fail faster/not delay CI
* added a separate test that checks that auditor runs on cluster changes, with longer waits for the latches

At least this should provide more info on where the test fails (auditor didn't do something or auditor didn't run) + speed up the test + either reduce or fix the flakyness.