### PR TITLE
chore: remove dead config ensemblePlacementPolicyOrderSlowBookies

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ClientConfiguration.java
@@ -159,8 +159,6 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
     public static final String ENSEMBLE_PLACEMENT_POLICY = "ensemblePlacementPolicy";
     protected static final String NETWORK_TOPOLOGY_STABILIZE_PERIOD_SECONDS = "networkTopologyStabilizePeriodSeconds";
     protected static final String READ_REORDER_THRESHOLD_PENDING_REQUESTS = "readReorderThresholdPendingRequests";
-    protected static final String ENSEMBLE_PLACEMENT_POLICY_ORDER_SLOW_BOOKIES =
-        "ensemblePlacementPolicyOrderSlowBookies";
     protected static final String BOOKIE_ADDRESS_RESOLVER_ENABLED = "bookieAddressResolverEnabled";
     // Use hostname to resolve local placement info
     public static final String USE_HOSTNAME_RESOLVE_LOCAL_NODE_PLACEMENT_POLICY =
@@ -1287,27 +1285,6 @@ public class ClientConfiguration extends AbstractConfiguration<ClientConfigurati
      */
     public ClientConfiguration setNetworkTopologyStabilizePeriodSeconds(int seconds) {
         setProperty(NETWORK_TOPOLOGY_STABILIZE_PERIOD_SECONDS, seconds);
-        return this;
-    }
-
-    /**
-     * Whether to order slow bookies in placement policy.
-     *
-     * @return flag of whether to order slow bookies in placement policy or not.
-     */
-    public boolean getEnsemblePlacementPolicySlowBookies() {
-        return getBoolean(ENSEMBLE_PLACEMENT_POLICY_ORDER_SLOW_BOOKIES, false);
-    }
-
-    /**
-     * Enable/Disable ordering slow bookies in placement policy.
-     *
-     * @param enabled
-     *          flag to enable/disable ordering slow bookies in placement policy.
-     * @return client configuration.
-     */
-    public ClientConfiguration setEnsemblePlacementPolicySlowBookies(boolean enabled) {
-        setProperty(ENSEMBLE_PLACEMENT_POLICY_ORDER_SLOW_BOOKIES, enabled);
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeBatchRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeBatchRead.java
@@ -79,7 +79,6 @@ public class TestSpeculativeBatchRead extends BookKeeperClusterTestCase {
             .setReadTimeout(30000)
             .setUseV2WireProtocol(true)
             .setReorderReadSequenceEnabled(true)
-            .setEnsemblePlacementPolicySlowBookies(true)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         return new BookKeeperTestClient(conf, new TestStatsProvider());
     }
@@ -389,7 +388,6 @@ public class TestSpeculativeBatchRead extends BookKeeperClusterTestCase {
                 .setSpeculativeReadTimeout(1000)
                 .setEnsemblePlacementPolicy(LocalBookieEnsemblePlacementPolicy.class)
                 .setReorderReadSequenceEnabled(true)
-                .setEnsemblePlacementPolicySlowBookies(true)
                 .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkspec = new BookKeeperTestClient(conf, new TestStatsProvider());
         LedgerHandle l = bkspec.createLedger(1, 1, digestType, passwd);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestSpeculativeRead.java
@@ -78,7 +78,6 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
             .setSpeculativeReadTimeout(specTimeout)
             .setReadTimeout(30000)
             .setReorderReadSequenceEnabled(true)
-            .setEnsemblePlacementPolicySlowBookies(true)
             .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         return new BookKeeperTestClient(conf, new TestStatsProvider());
     }
@@ -391,7 +390,6 @@ public class TestSpeculativeRead extends BookKeeperClusterTestCase {
                 .setSpeculativeReadTimeout(1000)
                 .setEnsemblePlacementPolicy(LocalBookieEnsemblePlacementPolicy.class)
                 .setReorderReadSequenceEnabled(true)
-                .setEnsemblePlacementPolicySlowBookies(true)
                 .setMetadataServiceUri(zkUtil.getMetadataServiceUri());
         BookKeeper bkspec = new BookKeeperTestClient(conf, new TestStatsProvider());
         LedgerHandle l = bkspec.createLedger(1, 1, digestType, passwd);


### PR DESCRIPTION
Fix #3514

### Motivation

This configuration may have initially intended to add a switch in `slowBookies`, but it was overlooked. I reset the history to when the code was merged into the master branch; it is still only referenced in the test files. Furthermore, even if the test call is removed, the test cases still pass. Therefore, I think it is reasonable to remove it.
