### PR TITLE
[fix] fix Auditor ignoring bookies shut down before Auditor start

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
@@ -386,7 +388,12 @@ public class Auditor implements AutoCloseable {
 
             try {
                 watchBookieChanges();
-                knownBookies = getAvailableBookies();
+                // Start with all available bookies
+                // to handle situations where the auditor
+                // is started after some bookies have already failed
+                knownBookies = admin.getAllBookies().stream()
+                        .map(BookieId::toString)
+                        .collect(Collectors.toList());
                 this.ledgerUnderreplicationManager
                         .notifyLostBookieRecoveryDelayChanged(new LostBookieRecoveryDelayChangedCb());
             } catch (BKException bke) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -117,9 +117,6 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         mFactory = metadataClientDriver.getLedgerManagerFactory();
         underReplicationManager = mFactory.newLedgerUnderreplicationManager();
         ledgerManager = mFactory.newLedgerManager();
-
-        // ensure Auditor runs and updates known bookies
-        getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get();
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -117,6 +117,9 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
         mFactory = metadataClientDriver.getLedgerManagerFactory();
         underReplicationManager = mFactory.newLedgerUnderreplicationManager();
         ledgerManager = mFactory.newLedgerManager();
+
+        // ensure Auditor runs and updates known bookies
+        getAuditor(10, TimeUnit.SECONDS).submitAuditTask().get();
     }
 
     @Override


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fix #4411
Fix #4410

### Motivation

BookieAutoRecoveryTest is flaky on the CI

### Changes

I cannot reproduce the test failures/timeouts locally, even by running the test in the loop 100+ times.
After experimenting with a few changes and running this on CI the fix is: 

Making sure that Auditor start with all bookies in the knownBookies list, not just running ones, thus fixing situation when bookie goes down before Auditor startup completes. 