### PR TITLE
[WIP][Branch 4.16]ci: fix ci test 

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -217,32 +217,32 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar [11]
-- lib/io.netty-netty-common-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.108.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.108.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar [11]
+- lib/io.netty-netty-common-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.100.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.100.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.23.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -251,11 +251,11 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
-- lib/io.vertx-vertx-auth-common-4.5.7.jar [13]
-- lib/io.vertx-vertx-bridge-common-4.5.7.jar [14]
-- lib/io.vertx-vertx-core-4.5.7.jar [15]
-- lib/io.vertx-vertx-web-4.5.7.jar [16]
-- lib/io.vertx-vertx-web-common-4.5.7.jar [16]
+- lib/io.vertx-vertx-auth-common-4.3.8.jar [13]
+- lib/io.vertx-vertx-bridge-common-4.3.8.jar [14]
+- lib/io.vertx-vertx-core-4.3.8.jar [15]
+- lib/io.vertx-vertx-web-4.3.8.jar [16]
+- lib/io.vertx-vertx-web-common-4.3.8.jar [16]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
@@ -332,7 +332,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.108.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.100.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -372,9 +372,9 @@ Apache Software License, Version 2.
 [53] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.100.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -383,7 +383,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -391,7 +391,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -399,7 +399,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -407,7 +407,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -417,7 +417,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -425,7 +425,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -434,7 +434,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -442,7 +442,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -450,7 +450,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -458,7 +458,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -466,7 +466,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -474,7 +474,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -482,7 +482,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -490,7 +490,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -499,7 +499,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -507,7 +507,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -515,7 +515,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -523,7 +523,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -531,7 +531,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -539,7 +539,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -547,7 +547,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -555,7 +555,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -563,7 +563,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -571,7 +571,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -580,7 +580,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -588,7 +588,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -217,30 +217,30 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar [11]
-- lib/io.netty-netty-common-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.108.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar [11]
+- lib/io.netty-netty-common-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.100.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.23.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [16]
@@ -303,7 +303,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.108.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.100.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.18.0
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -334,9 +334,9 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.100.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -345,7 +345,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -353,7 +353,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -361,7 +361,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -369,7 +369,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -379,7 +379,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -387,7 +387,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -396,7 +396,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -404,7 +404,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -412,7 +412,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -420,7 +420,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -428,7 +428,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -436,7 +436,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -444,7 +444,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -452,7 +452,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -461,7 +461,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -469,7 +469,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -477,7 +477,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -485,7 +485,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -493,7 +493,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -501,7 +501,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -509,7 +509,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -517,7 +517,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -525,7 +525,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -533,7 +533,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -542,7 +542,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -550,7 +550,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -217,32 +217,32 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.7.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
-- lib/io.netty-netty-buffer-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar [11]
-- lib/io.netty-netty-common-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.108.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.108.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.108.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar [11]
-- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.25.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar [11]
+- lib/io.netty-netty-buffer-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar [11]
+- lib/io.netty-netty-common-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.100.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.100.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.100.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar [11]
+- lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.23.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -251,11 +251,11 @@ Apache Software License, Version 2.
 - lib/io.prometheus-simpleclient_tracer_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_tracer_otel_agent-0.15.0.jar [12]
-- lib/io.vertx-vertx-auth-common-4.5.7.jar [13]
-- lib/io.vertx-vertx-bridge-common-4.5.7.jar [14]
-- lib/io.vertx-vertx-core-4.5.7.jar [15]
-- lib/io.vertx-vertx-web-4.5.7.jar [16]
-- lib/io.vertx-vertx-web-common-4.5.7.jar [16]
+- lib/io.vertx-vertx-auth-common-4.3.8.jar [13]
+- lib/io.vertx-vertx-bridge-common-4.3.8.jar [14]
+- lib/io.vertx-vertx-core-4.3.8.jar [15]
+- lib/io.vertx-vertx-web-4.3.8.jar [16]
+- lib/io.vertx-vertx-web-common-4.3.8.jar [16]
 - lib/org.apache.logging.log4j-log4j-api-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-core-2.18.0.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar [17]
@@ -328,7 +328,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.7
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.108.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.100.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -367,9 +367,9 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.108.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.100.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -378,7 +378,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -386,7 +386,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -394,7 +394,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -402,7 +402,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -412,7 +412,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -420,7 +420,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -429,7 +429,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -437,7 +437,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -445,7 +445,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -453,7 +453,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -461,7 +461,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -469,7 +469,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -477,7 +477,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -485,7 +485,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -494,7 +494,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -502,7 +502,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -510,7 +510,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -518,7 +518,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -526,7 +526,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -534,7 +534,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.100.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -542,7 +542,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -550,7 +550,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -558,7 +558,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -566,7 +566,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.100.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -575,7 +575,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -583,7 +583,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.108.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.100.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,31 +23,31 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.108.Final.jar
-- lib/io.netty-netty-codec-4.1.108.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar
-- lib/io.netty-netty-common-4.1.108.Final.jar
-- lib/io.netty-netty-handler-4.1.108.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar
-- lib/io.netty-netty-resolver-4.1.108.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.108.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar
-- lib/io.netty-netty-transport-4.1.108.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar
+- lib/io.netty-netty-buffer-4.1.100.Final.jar
+- lib/io.netty-netty-codec-4.1.100.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar
+- lib/io.netty-netty-common-4.1.100.Final.jar
+- lib/io.netty-netty-handler-4.1.100.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar
+- lib/io.netty-netty-resolver-4.1.100.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.100.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
+- lib/io.netty-netty-transport-4.1.100.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,29 +5,29 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.108.Final.jar
-- lib/io.netty-netty-codec-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar
-- lib/io.netty-netty-common-4.1.108.Final.jar
-- lib/io.netty-netty-handler-4.1.108.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar
-- lib/io.netty-netty-resolver-4.1.108.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar
-- lib/io.netty-netty-transport-4.1.108.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar
+- lib/io.netty-netty-buffer-4.1.100.Final.jar
+- lib/io.netty-netty-codec-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar
+- lib/io.netty-netty-common-4.1.100.Final.jar
+- lib/io.netty-netty-handler-4.1.100.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar
+- lib/io.netty-netty-resolver-4.1.100.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
+- lib/io.netty-netty-transport-4.1.100.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,31 +5,31 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.108.Final.jar
-- lib/io.netty-netty-codec-4.1.108.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http-4.1.108.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.108.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.108.Final.jar
-- lib/io.netty-netty-common-4.1.108.Final.jar
-- lib/io.netty-netty-handler-4.1.108.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.108.Final.jar
-- lib/io.netty-netty-resolver-4.1.108.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.108.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.65.Final.jar
-- lib/io.netty-netty-transport-4.1.108.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.108.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-x86_64.jar
-- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.25.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.108.Final.jar
+- lib/io.netty-netty-buffer-4.1.100.Final.jar
+- lib/io.netty-netty-codec-4.1.100.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http-4.1.100.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.100.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.100.Final.jar
+- lib/io.netty-netty-common-4.1.100.Final.jar
+- lib/io.netty-netty-handler-4.1.100.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.100.Final.jar
+- lib/io.netty-netty-resolver-4.1.100.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.100.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.61.Final.jar
+- lib/io.netty-netty-transport-4.1.100.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.100.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-x86_64.jar
+- lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.23.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.100.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -27,6 +27,10 @@ import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.RE
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_REGIONS_TO_WRITE;
 import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeSetFromValues;
 import static org.apache.bookkeeper.feature.SettableFeatureProvider.DISABLE_ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import junit.framework.TestCase;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.feature.FeatureProvider;
@@ -58,14 +61,18 @@ import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.bookkeeper.util.StaticDNSResolver;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Test a region-aware ensemble placement policy.
  */
-public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
+public class TestRegionAwareEnsemblePlacementPolicy {
 
     static final Logger LOG = LoggerFactory.getLogger(TestRegionAwareEnsemblePlacementPolicy.class);
 
@@ -88,9 +95,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         StaticDNSResolver.addNodeToRack("localhost", rack);
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         StaticDNSResolver.reset();
         updateMyRack(NetworkTopology.DEFAULT_REGION_AND_RACK);
         LOG.info("Set up static DNS Resolver.");
@@ -122,10 +128,9 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repp.uninitalize();
-        super.tearDown();
     }
 
     static BookiesHealthInfo getBookiesHealthInfo() {
@@ -189,7 +194,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         LOG.info("reorder set : {}", reorderSet);
         LOG.info("expected set : {}", expectedSet);
         LOG.info("reorder equals {}", reorderSet.equals(writeSet));
-        assertFalse(reorderSet.equals(writeSet));
+        assertNotEquals(reorderSet, writeSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -233,7 +238,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                 ensemble, getBookiesHealthInfo(), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -263,7 +268,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                 ensemble, getBookiesHealthInfo(), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -293,7 +298,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             ensemble, getBookiesHealthInfo(new HashMap<>(), bookiePendingMap), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -325,7 +330,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             ensemble, getBookiesHealthInfo(new HashMap<>(), bookiePendingMap), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 2, 0, 1);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -354,7 +359,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                 ensemble, getBookiesHealthInfo(), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 2, 0, 1);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -385,7 +390,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             ensemble, getBookiesHealthInfo(new HashMap<>(), bookiePendingMap), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 2, 0, 1);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -419,7 +424,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             ensemble, getBookiesHealthInfo(new HashMap<>(), bookiePendingMap), writeSet);
         DistributionSchedule.WriteSet expectedSet = writeSetFromValues(3, 1, 2, 0);
         LOG.info("reorder set : {}", reorderSet);
-        assertFalse(reorderSet.equals(origWriteSet));
+        assertNotEquals(reorderSet, origWriteSet);
         assertEquals(expectedSet, reorderSet);
     }
 
@@ -471,7 +476,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
         BookieId replacedBookie = repp.replaceBookie(1, 1, 1, null,
                 new ArrayList<BookieId>(), addr2.toBookieId(), excludedAddrs).getResult();
 
-        assertFalse(addr1.toBookieId().equals(replacedBookie));
+        assertNotEquals(addr1.toBookieId(), replacedBookie);
         assertTrue(addr3.toBookieId().equals(replacedBookie)
                 || addr4.toBookieId().equals(replacedBookie));
     }
@@ -505,6 +510,7 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
     }
 
     @Test
+    @EnabledForJreRange(max = JRE.JAVA_11)
     public void testNewEnsembleBookieWithOneEmptyRegion() throws Exception {
         BookieSocketAddress addr1 = new BookieSocketAddress("127.0.0.2", 3181);
         BookieSocketAddress addr2 = new BookieSocketAddress("127.0.0.3", 3181);
@@ -1421,8 +1427,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
                                                                        .resolve(address).getHostName()));
             }
             BookieId remoteAddress = ensemble.get(readSet.get(k));
-            assertFalse(myRegion.equals(StaticDNSResolver.getRegion(repp.bookieAddressResolver
-                                                                        .resolve(remoteAddress).getHostName())));
+            assertNotEquals(myRegion, StaticDNSResolver.getRegion(repp.bookieAddressResolver
+                    .resolve(remoteAddress).getHostName()));
             k++;
             BookieId localAddress = ensemble.get(readSet.get(k));
             assertEquals(myRegion, StaticDNSResolver.getRegion(repp.bookieAddressResolver
@@ -1430,8 +1436,8 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             k++;
             for (; k < ensembleSize; k++) {
                 BookieId address = ensemble.get(readSet.get(k));
-                assertFalse(myRegion.equals(StaticDNSResolver.getRegion(repp.bookieAddressResolver
-                                                                        .resolve(address).getHostName())));
+                assertNotEquals(myRegion, StaticDNSResolver.getRegion(repp.bookieAddressResolver
+                        .resolve(address).getHostName()));
             }
         }
     }
@@ -1733,12 +1739,12 @@ public class TestRegionAwareEnsemblePlacementPolicy extends TestCase {
             List<BookieId> ensemble2 = repp.newEnsemble(3, 3, 2,
                 null, new HashSet<>()).getResult();
             ensemble1.retainAll(ensemble2);
-            assert(ensemble1.size() >= 1);
+            assert(!ensemble1.isEmpty());
 
             List<BookieId> ensemble3 = repp.newEnsemble(3, 3, 2,
                 null, new HashSet<>()).getResult();
             ensemble2.removeAll(ensemble3);
-            assert(ensemble2.size() >= 1);
+            assert(!ensemble2.isEmpty());
         } catch (BKNotEnoughBookiesException bnebe) {
             fail("Should not get not enough bookies exception even there is only one rack.");
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -84,6 +84,9 @@ import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
@@ -101,6 +104,8 @@ public abstract class BookKeeperClusterTestCase {
 
     @Rule
     public final Timeout globalTimeout;
+
+    protected String testName;
 
     // Metadata service related variables
     protected final ZooKeeperCluster zkUtil;
@@ -159,8 +164,19 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setUp("/ledgers");
+    }
+
+    @Before
+    public void setTestNameJunit4() {
+        testName = runtime.getMethodName();
+    }
+
+    @BeforeEach
+    void setTestNameJunit5(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
     }
 
     protected void setUp(String ledgersRootPath) throws Exception {
@@ -177,7 +193,7 @@ public abstract class BookKeeperClusterTestCase {
             this.metadataServiceUri = getMetadataServiceUri(ledgersRootPath);
             startBKCluster(metadataServiceUri);
             LOG.info("Setup testcase {} @ metadata service {} in {} ms.",
-                runtime.getMethodName(), metadataServiceUri,  sw.elapsed(TimeUnit.MILLISECONDS));
+                testName, metadataServiceUri,  sw.elapsed(TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             LOG.error("Error setting up", e);
             throw e;
@@ -189,6 +205,7 @@ public abstract class BookKeeperClusterTestCase {
     }
 
     @After
+    @AfterEach
     public void tearDown() throws Exception {
         boolean failed = false;
         for (Throwable e : asyncExceptions) {
@@ -220,7 +237,7 @@ public abstract class BookKeeperClusterTestCase {
             LOG.error("Got Exception while trying to cleanupTempDirs", e);
             tearDownException = e;
         }
-        LOG.info("Tearing down test {} in {} ms.", runtime.getMethodName(), sw.elapsed(TimeUnit.MILLISECONDS));
+        LOG.info("Tearing down test {} in {} ms.", testName, sw.elapsed(TimeUnit.MILLISECONDS));
         if (tearDownException != null) {
             throw tearDownException;
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -21,10 +21,10 @@
 
 package org.apache.bookkeeper.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
@@ -38,6 +38,8 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.PortManager;
 import org.junit.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * Test bookie expiration.
@@ -54,6 +56,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
     */
     @Test
     @SuppressWarnings("deprecation")
+    @EnabledForJreRange(max = JRE.JAVA_17)
     public void testBookieServerZKRequestTimeoutBehaviour() throws Exception {
         // 6000 is minimum due to default tick time
         System.setProperty("zookeeper.request.timeout", "6000");
@@ -98,7 +101,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
                     break;
                 }
             }
-            assertNotNull("Send thread not found", sendthread);
+            assertNotNull(sendthread, "Send thread not found");
 
             log.info("Suspending threads");
             sendthread.suspend();
@@ -108,8 +111,8 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
             // allow watcher thread to run
             Thread.sleep(3000);
-            assertTrue("Bookie should not shutdown on zk timeout", server.isBookieRunning());
-            assertTrue("Bookie Server should not shutdown on zk timeout", server.isRunning());
+            assertTrue(server.isBookieRunning(), "Bookie should not shutdown on zk timeout");
+            assertTrue(server.isRunning(), "Bookie Server should not shutdown on zk timeout");
         } finally {
             System.clearProperty("zookeeper.request.timeout");
             server.shutdown();
@@ -124,6 +127,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
     */
     @FlakyTest(value = "https://github.com/apache/bookkeeper/issues/4142")
     @SuppressWarnings("deprecation")
+    @EnabledForJreRange(max = JRE.JAVA_17)
     public void testBookieServerZKSessionExpireBehaviour() throws Exception {
         // 6000 is minimum due to default tick time
         System.setProperty("zookeeper.request.timeout", "0");
@@ -168,7 +172,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
                     break;
                 }
             }
-            assertNotNull("Send thread not found", sendthread);
+            assertNotNull(sendthread, "Send thread not found");
 
             log.info("Suspending threads");
             sendthread.suspend();
@@ -178,8 +182,8 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
 
             // allow watcher thread to run
             Thread.sleep(3000);
-            assertFalse("Bookie should shutdown on losing zk session", server.isBookieRunning());
-            assertFalse("Bookie Server should shutdown on losing zk session", server.isRunning());
+            assertFalse(server.isBookieRunning(), "Bookie should shutdown on losing zk session");
+            assertFalse(server.isRunning(), "Bookie Server should shutdown on losing zk session");
         } finally {
             System.clearProperty("zookeeper.request.timeout");
             server.shutdown();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookieZKExpireTest.java
@@ -37,7 +37,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.PortManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
@@ -71,7 +71,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             Thread[] threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1) {
+                if (threads[i].getName().contains("SendThread")) {
                     threadset.add(threads[i]);
                 }
             }
@@ -95,7 +95,7 @@ public class BookieZKExpireTest extends BookKeeperClusterTestCase {
             threads = new Thread[threadCount * 2];
             threadCount = Thread.enumerate(threads);
             for (int i = 0; i < threadCount; i++) {
-                if (threads[i].getName().indexOf("SendThread") != -1
+                if (threads[i].getName().contains("SendThread")
                         && !threadset.contains(threads[i])) {
                     sendthread = threads[i];
                     break;

--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
     <log4j.version>2.18.0</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>3.12.4</mockito.version>
-    <netty.version>4.1.108.Final</netty.version>
-    <netty-iouring.version>0.0.25.Final</netty-iouring.version>
+    <netty.version>4.1.100.Final</netty.version>
+    <netty-iouring.version>0.0.23.Final</netty-iouring.version>
     <ostrich.version>9.1.3</ostrich.version>
     <powermock.version>2.0.9</powermock.version>
     <prometheus.version>0.15.0</prometheus.version>
@@ -173,7 +173,7 @@
     <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <javax-annotations-api.version>1.3.2</javax-annotations-api.version>
     <testcontainers.version>1.19.4</testcontainers.version>
-    <vertx.version>4.5.7</vertx.version>
+    <vertx.version>4.3.8</vertx.version>
     <zookeeper.version>3.8.3</zookeeper.version>
     <snappy.version>1.1.10.5</snappy.version>
     <jctools.version>2.1.2</jctools.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:
- Downgraded Netty to 4.1.100.Final to match the version required by gRPC 1.54.1
- Cherry-picked #4323 and #4309 to make tests running on OpenJDK 17+

### Changes
(Describe: what changes you have made)
> I found that this exception was caused by the upgrade of netty. If you
> revert netty to 4.1.100.Final, the use case passes. Because in
> 4.1.101.Final, netty modified the Http2 related interfaces, the connection
> is as follows: https://netty.io/news/2023/11/09/4-1-101-Final.html
>
> The main reason may be incompatibility caused by (#13651). I recommended
> to roll back netty to 4.1.100.Final, which can also address some CVE
> vulnerabilities related to netty. This will allow the ci of branch-4.1.16
> to return to normal without having to upgrade the version of grpc. The
> corresponding components related to netty such as vertx also need to be
> rolled back to the version that matches netty.