### PR TITLE
Upgrade RocksDB to version 9.2.1

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -271,7 +271,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.53.v20231009.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.53.v20231009.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.53.v20231009.jar [22]
-- lib/org.rocksdb-rocksdbjni-7.10.2.jar [23]
+- lib/org.rocksdb-rocksdbjni-9.2.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -375,7 +375,7 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
-[23] Source available at https://github.com/facebook/rocksdb/tree/v7.10.2
+[23] Source available at https://github.com/facebook/rocksdb/tree/v9.2.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -635,7 +635,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-7.10.2.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-9.2.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -271,7 +271,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty-jetty-servlet-9.4.53.v20231009.jar [22]
 - lib/org.eclipse.jetty-jetty-util-9.4.53.v20231009.jar [22]
 - lib/org.eclipse.jetty-jetty-util-ajax-9.4.53.v20231009.jar [22]
-- lib/org.rocksdb-rocksdbjni-7.10.2.jar [23]
+- lib/org.rocksdb-rocksdbjni-9.2.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
@@ -371,7 +371,7 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/eclipse/jetty.project/tree/jetty-9.4.48.v20220622
-[23] Source available at https://github.com/facebook/rocksdb/tree/v7.10.2
+[23] Source available at https://github.com/facebook/rocksdb/tree/v9.2.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
@@ -630,7 +630,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-7.10.2.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-9.2.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -47,6 +47,7 @@ import org.rocksdb.ChecksumType;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.CompressionType;
+import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.InfoLogLevel;
@@ -154,8 +155,10 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
         DBOptions dbOptions = new DBOptions();
         final List<ColumnFamilyDescriptor> cfDescs = new ArrayList<>();
         final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
-        try {
-            OptionsUtil.loadOptionsFromFile(dbFilePath, Env.getDefault(), dbOptions, cfDescs, false);
+        try (final ConfigOptions cfgOpts = new ConfigOptions()
+                .setIgnoreUnknownOptions(false)
+                .setEnv(Env.getDefault())) {
+            OptionsUtil.loadOptionsFromFile(cfgOpts, dbFilePath, dbOptions, cfDescs);
             // Configure file path
             String logPath = conf.getString(ROCKSDB_LOG_PATH, "");
             if (!logPath.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <protoc3.version>${protobuf.version}</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>7.10.2</rocksdb.version>
+    <rocksdb.version>9.2.1</rocksdb.version>
     <shrinkwrap.version>3.3.0</shrinkwrap.version>
     <slf4j.version>2.0.12</slf4j.version>
     <snakeyaml.version>2.0</snakeyaml.version>

--- a/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDowngrade.groovy
+++ b/tests/backward-compat/upgrade-direct/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatUpgradeDowngrade.groovy
@@ -102,6 +102,16 @@ class TestCompatUpgradeDowngrade {
     @Test
     public void upgradeDowngrade_015() {
         String currentVersion = BookKeeperClusterUtils.CURRENT_VERSION
+        BookKeeperClusterUtils.appendToAllBookieConf(docker, currentVersion,
+                "dbStorage_rocksDB_format_version",
+                "2")
+        BookKeeperClusterUtils.appendToAllBookieConf(docker, currentVersion,
+                "dbStorage_rocksDB_checksum_type",
+                "kCRC32c")
+        BookKeeperClusterUtils.appendToAllBookieConf(docker, currentVersion,
+                "conf/default_rocksdb.conf.default",
+                "format_version",
+                "2")
         upgradeDowngrade("4.17.0", currentVersion)
     }
 

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
@@ -143,16 +143,28 @@ public class BookKeeperClusterUtils {
         DockerUtils.runCommand(docker, containerId, "sed", "-i", "-e", sedProgram, confFile);
     }
 
-    public static void appendToAllBookieConf(DockerClient docker, String version, String key, String value)
+    public static void appendToAllBookieConf(DockerClient docker, String version, String confFile0,
+                                             String key, String value)
             throws Exception {
         for (String b : allBookies()) {
-            appendToBookieConf(docker, b, version, key, value);
+            appendToBookieConf(docker, b, version, confFile0, key, value);
         }
+    }
+
+    public static void appendToAllBookieConf(DockerClient docker, String version,
+                                             String key, String value)
+            throws Exception {
+        appendToAllBookieConf(docker, version, "conf/bk_server.conf", key, value);
     }
 
     public static void appendToBookieConf(DockerClient docker, String containerId,
                                         String version, String key, String value) throws Exception {
-        String confFile = "/opt/bookkeeper/" + version + "/conf/bk_server.conf";
+        appendToBookieConf(docker, containerId, version, "conf/bk_server.conf", key, value);
+    }
+
+    public static void appendToBookieConf(DockerClient docker, String containerId,
+                                          String version, String confFile0, String key, String value) throws Exception {
+        String confFile = "/opt/bookkeeper/" + version + "/" + confFile0;
         String sedProgram = String.format("$a%s=%s", key, value);
         DockerUtils.runCommand(docker, containerId, "sed", "-i", "-e", sedProgram, confFile);
     }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fix #4409

### Motivation

Upgrade RocksDB to v.9.2.1 to pick up latest performance and stability improvements and fixes in deleteRanges.
Hopefully deleteRanges() is stable enough for us to try again perf improvements https://github.com/apache/bookkeeper/pull/3653 that were reverted previously.

### Changes

Changed RocksDB version, updated code to use changed API.