### PR TITLE
Fix the issue that the data cannot be completely cleaned up under locations folder

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -233,6 +233,7 @@ public class EntryLocationIndex implements Closeable {
             }
 
             batch.flush();
+            batch.close();
             for (long ledgerId : ledgersToDelete) {
                 deletedLedgers.remove(ledgerId);
             }


### PR DESCRIPTION
Fix the issue that the data cannot be completely cleaned up because the removeOffsetFromDeletedLedgers method under EntryLocationIndex does not close after using RocksDBBatch to flush in batches.

Descriptions of the changes in this PR:

<!-- Either this PR fixes an issue, -->

Fix #4145


### Motivation

Fix the issue that the data under locations cannot be completely cleaned up when the data volume is large.

### Changes

Add `batch.close();` after `batch.flush();`. 
