### PR TITLE
Fix TimedRunnable log NPE

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -187,13 +187,11 @@ public class OrderedExecutor implements ExecutorService {
     protected class TimedRunnable implements Runnable {
         final Runnable runnable;
         final long initNanos;
-        final String runnableString;
         final Class<?> runnableClass;
 
         TimedRunnable(Runnable runnable) {
             this.runnable = runnable;
             this.initNanos = MathUtils.nowInNano();
-            this.runnableString = runnable.toString();
             this.runnableClass = runnable.getClass();
          }
 
@@ -207,8 +205,7 @@ public class OrderedExecutor implements ExecutorService {
                 long elapsedMicroSec = MathUtils.elapsedMicroSec(startNanos);
                 taskExecutionStats.registerSuccessfulEvent(elapsedMicroSec, TimeUnit.MICROSECONDS);
                 if (elapsedMicroSec >= warnTimeMicroSec) {
-                    log.warn("Runnable {}:{} took too long {} micros to execute.", runnableString, runnableClass,
-                            elapsedMicroSec);
+                    log.warn("Runnable {} took too long {} micros to execute.", runnableClass, elapsedMicroSec);
                 }
             }
         }
@@ -220,13 +217,11 @@ public class OrderedExecutor implements ExecutorService {
     protected class TimedCallable<T> implements Callable<T> {
         final Callable<T> callable;
         final long initNanos;
-        final String callableleString;
         final Class<?> callableClass;
 
         TimedCallable(Callable<T> callable) {
             this.callable = callable;
             this.initNanos = MathUtils.nowInNano();
-            this.callableleString = callable.toString();
             this.callableClass = callable.getClass();
         }
 
@@ -240,8 +235,7 @@ public class OrderedExecutor implements ExecutorService {
                 long elapsedMicroSec = MathUtils.elapsedMicroSec(startNanos);
                 taskExecutionStats.registerSuccessfulEvent(elapsedMicroSec, TimeUnit.MICROSECONDS);
                 if (elapsedMicroSec >= warnTimeMicroSec) {
-                    log.warn("Callable {}:{} took too long {} micros to execute.", callableleString, callableClass,
-                            elapsedMicroSec);
+                    log.warn("Callable {} took too long {} micros to execute.", callableClass, elapsedMicroSec);
                 }
             }
         }

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java
@@ -187,10 +187,14 @@ public class OrderedExecutor implements ExecutorService {
     protected class TimedRunnable implements Runnable {
         final Runnable runnable;
         final long initNanos;
+        final String runnableString;
+        final Class<?> runnableClass;
 
         TimedRunnable(Runnable runnable) {
             this.runnable = runnable;
             this.initNanos = MathUtils.nowInNano();
+            this.runnableString = runnable.toString();
+            this.runnableClass = runnable.getClass();
          }
 
         @Override
@@ -203,7 +207,7 @@ public class OrderedExecutor implements ExecutorService {
                 long elapsedMicroSec = MathUtils.elapsedMicroSec(startNanos);
                 taskExecutionStats.registerSuccessfulEvent(elapsedMicroSec, TimeUnit.MICROSECONDS);
                 if (elapsedMicroSec >= warnTimeMicroSec) {
-                    log.warn("Runnable {}:{} took too long {} micros to execute.", runnable, runnable.getClass(),
+                    log.warn("Runnable {}:{} took too long {} micros to execute.", runnableString, runnableClass,
                             elapsedMicroSec);
                 }
             }
@@ -216,10 +220,14 @@ public class OrderedExecutor implements ExecutorService {
     protected class TimedCallable<T> implements Callable<T> {
         final Callable<T> callable;
         final long initNanos;
+        final String callableleString;
+        final Class<?> callableClass;
 
         TimedCallable(Callable<T> callable) {
             this.callable = callable;
             this.initNanos = MathUtils.nowInNano();
+            this.callableleString = callable.toString();
+            this.callableClass = callable.getClass();
         }
 
         @Override
@@ -232,7 +240,7 @@ public class OrderedExecutor implements ExecutorService {
                 long elapsedMicroSec = MathUtils.elapsedMicroSec(startNanos);
                 taskExecutionStats.registerSuccessfulEvent(elapsedMicroSec, TimeUnit.MICROSECONDS);
                 if (elapsedMicroSec >= warnTimeMicroSec) {
-                    log.warn("Callable {}:{} took too long {} micros to execute.", callable, callable.getClass(),
+                    log.warn("Callable {}:{} took too long {} micros to execute.", callableleString, callableClass,
                             elapsedMicroSec);
                 }
             }


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

When the `ReadEntryProcessor` runs slow, the `TimedRunnable` will print the warn log like below:
```
Runnable xx:xx took too long xx micros to execute.
```
https://github.com/apache/bookkeeper/blob/fd2c7c6f632deb0130b9c8fc506a6b66ac02b341/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/OrderedExecutor.java#L197-L208

However we found that NPE happened in this log:
```
WARN  [BookieReadThreadPool-OrderedExecutor-1-0:OrderedExecutor$TimedRunnable@206] - Runnable [!!!org.apache.bookkeeper.proto.ReadEntryProcessor@1dd094f3=>java.lang.NullPointerException:Cannot invoke "org.apache.bookkeeper.proto.BookieProtocol$ReadRequest.getLedgerId()" because "this.request" is null!!!]:class org.apache.bookkeeper.proto.ReadEntryProcessor took too long 1125904 micros to execute.
```

The root cause is that the  `ReadEntryProcessor` will be recycled after calling `run` method,  which means we shouldn't call any method of the `ReadEntryProcessor` after calling `ReadEntryProcessor#run()`.   So line206 calling  `toString()` method  of `runnable`(`ReadEntryProcessor`) will cause NPE or any other wrong  message.


### Changes

Save runnable  string name and class when create `TimedRunnable` and `TimedCallable`
