### PR TITLE
test: update etcd build image version

### DIFF
--- a/.test-infra/scripts/pre-docker-tests.sh
+++ b/.test-infra/scripts/pre-docker-tests.sh
@@ -30,4 +30,4 @@ docker system prune -f
 # clean up any dangling networks from previous runs
 docker network prune -f --filter "until=12h"
 docker system events > docker.debug-info & echo $! > docker-log.pid
-docker pull quay.io/coreos/etcd:v3.3
+docker pull quay.io/coreos/etcd:v3.5.14

--- a/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/testing/EtcdContainer.java
+++ b/metadata-drivers/etcd/src/test/java/org/apache/bookkeeper/metadata/etcd/testing/EtcdContainer.java
@@ -54,7 +54,7 @@ public class EtcdContainer extends GenericContainer<EtcdContainer> {
     private final String clusterName;
 
     public EtcdContainer(String clusterName) {
-        super("quay.io/coreos/etcd:v3.3");
+        super("quay.io/coreos/etcd:v3.5.14");
         this.clusterName = clusterName;
     }
 


### PR DESCRIPTION
```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=quay.io/coreos/etcd:v3.3, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@58867cd5)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1367)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:362)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:333)
```