### PR TITLE
[branch-4.17]fix: build release in ubuntu error

### DIFF
--- a/dev/release/000-run-docker.sh
+++ b/dev/release/000-run-docker.sh
@@ -51,7 +51,7 @@ docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
 FROM --platform=linux/amd64 ${IMAGE_NAME}
 RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME} && \
   useradd -l -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME} && \
-  ([ "$(dirname "$HOME")" -eq "/home" ] || ln -s /home $(dirname "$HOME")) && \
+  ([ "$(dirname "$HOME")" = "/home" ] || ln -s /home $(dirname "$HOME")) && \
   mkdir -p /gpg && chown ${USER_ID}:${GROUP_ID} /gpg && chmod 700 /gpg
 ENV  HOME /home/${USER_NAME}
 UserSpecificDocker


### PR DESCRIPTION
Descriptions of the changes in this PR:

When building in ubuntu, there will be an error prompting ```bash: [: /home: integer expression expected```, because in bash and zsh, the string equality cannot use ```-eq```, but should use ```=```