### PR TITLE
Fix typo-check in CI, run only for pull requests because of security reasons

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -485,11 +485,14 @@ jobs:
 
   typo-check:
     name: Typo Check
+    # only run on pull requests because of security reasons
+    # we shouldn't trust external actions for builds within the repository
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.22.4
 
   owasp-dependency-check:
     name: OWASP Dependency Check
@@ -551,11 +554,19 @@ jobs:
       'windows-build'
     ]
     steps:
-      - name: Check build-and-license-check and typo-check success
+      - name: Check build-and-license-check success
         run: |
           if [[ ! ( \
                    "${{ needs.build-and-license-check.result }}" == "success" \
-                && "${{ needs.typo-check.result }}" == "success" \
+               ) ]]; then
+            echo "Required jobs haven't been completed successfully."
+            exit 1
+          fi
+      - name: Check typo-check success for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ ! ( \
+                   "${{ needs.typo-check.result }}" == "success" \
                ) ]]; then
             echo "Required jobs haven't been completed successfully."
             exit 1


### PR DESCRIPTION
### Motivation

typo-check is currently broken in CI, 
```
Downloading 'typos' v1.22.5
--[20](https://github.com/apache/bookkeeper/actions/runs/9485228747/job/26136650763?pr=4426#step:3:22)24-06-12 15:31:09--  https://github.com/crate-ci/typos/releases/download/v1.[22](https://github.com/apache/bookkeeper/actions/runs/9485228747/job/26136650763?pr=4426#step:3:24).5/typos-v1.22.5-x86_64-unknown-linux-musl.tar.gz
Resolving github.com (github.com)... 140.82.112.3
Connecting to github.com (github.com)|140.82.112.3|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
20[24](https://github.com/apache/bookkeeper/actions/runs/9485228747/job/26136650763?pr=4426#step:3:26)-06-12 15:31:09 ERROR 404: Not Found.
```
example: https://github.com/apache/bookkeeper/actions/runs/9485228747/job/26136651150?pr=4426#step:3:21

### Changes

- use v1.22.4 which contains the binary for linux-musl
- limit running typos check for pull requests because of security reasons
  - we shouldn't use any external actions for builds that run in the security context of the repository