### PR TITLE
Replace deprecated getNextTarEntry with getNextEntry in DockerUtils

### DIFF
--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/DockerUtils.java
@@ -132,7 +132,7 @@ public class DockerUtils {
 
         try (InputStream dockerStream = docker.copyArchiveFromContainerCmd(containerId, path).exec();
              TarArchiveInputStream stream = new TarArchiveInputStream(dockerStream)) {
-            TarArchiveEntry entry = stream.getNextTarEntry();
+            TarArchiveEntry entry = stream.getNextEntry();
             while (entry != null) {
                 if (entry.isFile()) {
                     File targetDir = getTargetDirectory(containerId);
@@ -149,7 +149,7 @@ public class DockerUtils {
                         }
                     }
                 }
-                entry = stream.getNextTarEntry();
+                entry = stream.getNextEntry();
             }
         } catch (RuntimeException | IOException e) {
             LOG.error("Error reading bk logs from container {}", containerId, e);


### PR DESCRIPTION
### Motivation

This PR addresses the deprecation of `getNextTarEntry()` in `TarArchiveInputStream`.  See 

https://github.com/apache/commons-compress/blob/b52fda40f4175062e8ef49f4b234d27a71ccc9ef/src/main/java/org/apache/commons/compress/archivers/tar/TarArchiveInputStream.java#L392-L402