### PR TITLE
Remove unnecessary deprecation suppression in TestCompatRecoveryNoPassword

### DIFF
--- a/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
+++ b/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy
@@ -22,7 +22,6 @@ import com.github.dockerjava.api.DockerClient
 import io.netty.buffer.ByteBuf
 import org.apache.bookkeeper.net.BookieId
 
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -39,7 +38,6 @@ import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback
 import org.apache.bookkeeper.tests.integration.utils.BookKeeperClusterUtils
 import org.apache.bookkeeper.tests.integration.utils.DockerUtils
 import org.apache.bookkeeper.tests.integration.utils.MavenClassLoader
-import org.apache.bookkeeper.versioning.Versioned
 
 import org.jboss.arquillian.junit.Arquillian
 import org.jboss.arquillian.test.api.ArquillianResource
@@ -139,7 +137,6 @@ class TestCompatRecoveryNoPassword {
      * Test that when we try to recover a ledger which doesn't have
      * the password stored in the configuration, we don't succeed.
      */
-    @SuppressWarnings("deprecation")
     @Test
     public void testRecoveryWithoutPasswordInMetadata() throws Exception {
         int numEntries = 10


### PR DESCRIPTION
See build warning
```
1. WARNING in /Users/akka/code/java/bookkeeper/tests/backward-compat/recovery-no-password/src/test/groovy/org/apache/bookkeeper/tests/backwardcompat/TestCompatRecoveryNoPassword.groovy (at line 142)
        @SuppressWarnings("deprecation")
Unnecessary @SuppressWarnings("deprecation")
1 problem (1 warning)
```