### PR TITLE
fix: correct the description of LedgerDirManager's methods

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsManager.java
@@ -140,7 +140,7 @@ public class LedgerDirsManager {
     /**
      * Calculate the total amount of free space available in all of the ledger directories put together.
      *
-     * @return totalDiskSpace in bytes
+     * @return freeDiskSpace in bytes
      * @throws IOException
      */
     public long getTotalFreeSpace(List<File> dirs) throws IOException {
@@ -148,9 +148,9 @@ public class LedgerDirsManager {
     }
 
     /**
-     * Calculate the total amount of free space available in all of the ledger directories put together.
+     * Calculate the total amount of disk space in all of the ledger directories put together.
      *
-     * @return freeDiskSpace in bytes
+     * @return totalDiskSpace in bytes
      * @throws IOException
      */
     public long getTotalDiskSpace(List<File> dirs) throws IOException {


### PR DESCRIPTION
Descriptions of the changes in this PR:

fix the descriptions of `getTotalFreeSpace` and `getTotalDiskSpace` which confused before.
