### PR TITLE
Fix incorrect metadata state in MockLedgerHandle close method

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -80,6 +80,14 @@ public class MockLedgerHandle extends LedgerHandle {
             return;
         }
 
+        LedgerMetadata metadata = getLedgerMetadata();
+        metadata = LedgerMetadataBuilder.from(metadata)
+                .withClosedState()
+                .withLastEntryId(lastEntry)
+                .withLength(length)
+                .build();
+        setLedgerMetadata(getVersionedLedgerMetadata(), new Versioned<>(metadata, new LongVersion(1L)));
+
         fenced = true;
         try {
             executeOrdered(() -> cb.closeComplete(0, this, ctx));


### PR DESCRIPTION
Fix #1413

## Changes

change ledger state to close when close metadata 