### PR TITLE
Update Release Script Instructions and Python Publishing Scripts

### DIFF
--- a/site3/website/src/pages/community/release-guide.md
+++ b/site3/website/src/pages/community/release-guide.md
@@ -492,7 +492,7 @@ Note: you can put the 1. and 2. in the same pull.
 Create and push a new signed for the released version by copying the tag for the final release tag, as follows
 
 ```shell
-git tag -s "${TAG}" "${RC_TAG}"
+git tag -s "${TAG}" "${RC_TAG}^{}"
 # Message: "Release ${VERSION}"
 git push apache "${TAG}"
 ```

--- a/stream/clients/python/scripts/publish.sh
+++ b/stream/clients/python/scripts/publish.sh
@@ -23,8 +23,8 @@
 BINDIR=`dirname "$0"`
 BK_HOME=`cd ${BINDIR}/..;pwd`
 
-python -m pip install --user --upgrade setuptools wheel twine
+python3 -m pip install --user --upgrade setuptools wheel twine
 
 rm ${BK_HOME}/dist/*
-python setup.py sdist bdist_wheel
+python3 setup.py sdist bdist_wheel
 twine upload dist/*


### PR DESCRIPTION
### Motivation

This PR updates the release scripts to ensure more robust and consistent release processes. The changes include modifying the git tagging instructions to prevent potential mis-tags and updating the Python scripts to use Python 3 explicitly, which aligns with best practices for Python development.

### Changes

1. **Release Guide Modification**: Using ^{} ensures that the tag is created for the commit itself, not rc tag to be deleted. 

2. **Python Publishing Script**: Changed all instances of `python` to `python3`, modern operation systems default has `python3`, but not all has `python`
