### PR TITLE
improve: build bk and current-version-image images by docker-maven-plugin

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -238,7 +238,7 @@ jobs:
           $GITHUB_WORKSPACE/dev/ci-tool pick_ubuntu_mirror
 
       - name: Build with Maven
-        run: mvn -B -nsu clean install -Pdocker -DskipTests
+        run: mvn -B -nsu clean install -Pdocker -DskipTests -Ddocker.image=bookkeeper-$(date +%s)
 
       - name: Run metadata driver tests
         run: mvn -B -nsu -f metadata-drivers/pom.xml test -DintegrationTests
@@ -323,7 +323,7 @@ jobs:
           $GITHUB_WORKSPACE/dev/ci-tool pick_ubuntu_mirror
 
       - name: Build with Maven
-        run: mvn -B -nsu clean install -Pdocker -DskipTests
+        run: mvn -B -nsu clean install -Pdocker -DskipTests -Ddocker.image=bookkeeper-$(date +%s)
 
       - name: Test current server with old clients
         run: mvn -B -nsu -DbackwardCompatTests -DfailIfNoTests -pl :backward-compat-current-server-old-clients test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,37 @@
 # under the License.
 #
 
+FROM alpine:3.20 as bk-dist
+
+ARG BK_TARBALL
+
+ARG BK_VERSION=4.17.1
+ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
+ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
+
+COPY . /temp/
+RUN echo $BK_TARBALL
+RUN if [ -n "$BK_TARBALL" ] && [ -f "/temp/$BK_TARBALL" ]; then \
+        echo "Adding tarball: $BK_TARBALL"  \
+        && tar -xzf /temp/$BK_TARBALL -C /opt/  \
+        && mv /opt/bookkeeper-*/ /opt/bookkeeper/; \
+    else \
+        # Download Apache Bookkeeper, untar and clean up
+        echo "Downloading Apache Bookkeeper" \
+        && apk update && apk add gpg gpg-agent wget \
+        && cd /opt \
+        && wget -q "${DISTRO_URL}" \
+        && wget -q "${DISTRO_URL}.asc" \
+        && wget -q "${DISTRO_URL}.sha512" \
+        && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
+        && wget -q https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
+        && gpg --import KEYS \
+        && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
+        && tar -xzf "$DISTRO_NAME.tar.gz" \
+        && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
+        && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512"; \
+    fi
+
 FROM eclipse-temurin:17 as jre-build
 
 # Create a custom Java runtime
@@ -34,21 +65,16 @@ RUN echo networkaddress.cache.negative.ttl=1 >> /javaruntime/conf/security/java.
 FROM ubuntu:22.04
 MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
 
-ARG TARGETARCH
-ARG BK_VERSION=4.17.1
-ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
-ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
-
 ENV BOOKIE_PORT=3181
 ENV BOOKIE_HTTP_PORT=8080
-EXPOSE $BOOKIE_PORT $BOOKIE_HTTP_PORT
+ENV BOOKIE_GRPC_PORT=4181
+EXPOSE $BOOKIE_PORT $BOOKIE_HTTP_PORT $BOOKIE_GRPC_PORT
 ENV BK_USER=bookkeeper
 ENV BK_HOME=/opt/bookkeeper
 ENV DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
 ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
-# Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://archive.ubuntu.com/ubuntu/}|g" \
      -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
@@ -58,31 +84,19 @@ RUN set -x \
     && apt-get install -y ca-certificates apt-transport-https \
     && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
+    && apt-get install -y --no-install-recommends wget sudo \
     && apt-get -y --purge autoremove \
     && apt-get autoclean \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -pv /opt \
-    && cd /opt \
-    && wget -q "${DISTRO_URL}" \
-    && wget -q "${DISTRO_URL}.asc" \
-    && wget -q "${DISTRO_URL}.sha512" \
-    && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
-    && wget https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
-    && gpg --import KEYS \
-    && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
-    && tar -xzf "$DISTRO_NAME.tar.gz" \
-    && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
-    && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
     && pip install zk-shell
-
-WORKDIR /opt/bookkeeper
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
+WORKDIR /opt/bookkeeper
+COPY --from=bk-dist /opt/bookkeeper /opt/bookkeeper
 COPY scripts /opt/bookkeeper/scripts
 RUN chmod +x -R /opt/bookkeeper/scripts/
 

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,0 +1,107 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.bookkeeper</groupId>
+    <artifactId>bookkeeper</artifactId>
+    <version>4.18.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>docker-images</artifactId>
+  <name>Apache BookKeeper :: Docker Images</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-dist-server</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>bin</classifier>
+      <type>tar.gz</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <images>
+                    <image>
+                      <name>${docker.organization}/${docker.image}</name>
+                      <build>
+                        <args>
+                          <BK_VERSION>${project.version}</BK_VERSION>
+                          <BK_TARBALL>target/bookkeeper-dist-server-${project.version}-bin.tar.gz</BK_TARBALL>
+                          <UBUNTU_MIRROR>${UBUNTU_MIRROR}</UBUNTU_MIRROR>
+                          <UBUNTU_SECURITY_MIRROR>${UBUNTU_SECURITY_MIRROR}</UBUNTU_SECURITY_MIRROR>
+                        </args>
+                        <contextDir>${project.basedir}</contextDir>
+                        <tags>
+                          <tag>${docker.tag}</tag>
+                        </tags>
+                        <buildx>
+                          <platforms>
+                            <platform>${docker.platforms}</platform>
+                          </platforms>
+                        </buildx>
+                      </build>
+                    </image>
+                  </images>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-docker-dependencies</id>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                  <includeArtifactIds>bookkeeper-dist-server</includeArtifactIds>
+                  <excludeTransitive>true</excludeTransitive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <module>shaded</module>
     <module>microbenchmarks</module>
     <module>bookkeeper-slogger</module>
+    <module>docker</module>
     <module>tests</module>
     <module>native-io</module>
     <module>testtools</module>
@@ -204,6 +205,16 @@
     <otel.version>1.26.0</otel.version>
     <UBUNTU_MIRROR>http://archive.ubuntu.com/ubuntu/</UBUNTU_MIRROR>
     <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
+
+    <!-- docker -->
+    <docker-maven-plugin.version>0.44.0</docker-maven-plugin.version>
+    <docker.skip.push>true</docker.skip.push>
+    <docker.verbose>true</docker.verbose>
+    <docker.organization>apache</docker.organization>
+    <docker.image>bookkeeper:latest</docker.image>
+    <!-- create an additional tag -->
+    <docker.tag></docker.tag>
+    <docker.platforms></docker.platforms>
   </properties>
 
   <!-- dependency definitions -->
@@ -1346,6 +1357,11 @@
                 <!-- for some reason, setting maven.compiler.release property alone doesn't work -->
                 <release>${maven.compiler.release}</release>
               </configuration>
+            </plugin>
+            <plugin>
+              <groupId>io.fabric8</groupId>
+              <artifactId>docker-maven-plugin</artifactId>
+              <version>${docker-maven-plugin.version}</version>
             </plugin>
           </plugins>
         </pluginManagement>

--- a/tests/docker-images/current-version-image/Dockerfile
+++ b/tests/docker-images/current-version-image/Dockerfile
@@ -17,59 +17,12 @@
 # under the License.
 #
 
-FROM ubuntu:22.04
-MAINTAINER Apache BookKeeper <dev@bookkeeper.apache.org>
+ARG BK_IMAGE
+FROM $BK_IMAGE
 
-ARG BK_VERSION=DOESNOTEXISTS
-ARG DISTRO_NAME=bookkeeper-dist-server-${BK_VERSION}-bin
-ARG PKG_NAME=bookkeeper-server-${BK_VERSION}
-
-ENV BOOKIE_PORT=3181
-ENV BOOKIE_HTTP_PORT=8080
-ENV BOOKIE_GRPC_PORT=4181
-EXPOSE ${BOOKIE_PORT} ${BOOKIE_HTTP_PORT} ${BOOKIE_GRPC_PORT}
-ENV BK_USER=bookkeeper
-ENV BK_HOME=/opt/bookkeeper
-ENV DEBIAN_FRONTEND=noninteractive
-ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
-ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
-
-RUN set -x \
-    && sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://archive.ubuntu.com/ubuntu/}|g" \
-     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
-    && echo 'Acquire::http::Timeout "30";\nAcquire::http::ConnectionAttemptDelayMsec "2000";\nAcquire::https::Timeout "30";\nAcquire::https::ConnectionAttemptDelayMsec "2000";\nAcquire::ftp::Timeout "30";\nAcquire::ftp::ConnectionAttemptDelayMsec "2000";\nAcquire::Retries "15";' > /etc/apt/apt.conf.d/99timeout_and_retries \
-    && adduser "${BK_USER}" \
-    && apt-get update \
-    && apt-get install -y ca-certificates apt-transport-https \
-    && apt-get install -y --no-install-recommends openjdk-17-jdk \
-    && apt-get install -y --no-install-recommends python3 pip \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
-    && apt-get -y install netcat dnsutils less procps iputils-ping \
-    && apt-get -y --purge autoremove \
-    && apt-get autoclean \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install zk-shell \
-    && JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java)))) \
-    && echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security \
-    && echo networkaddress.cache.negative.ttl=1 >> $JAVA_HOME/conf/security/java.security
-
-# untar tarballs
-ADD target/${DISTRO_NAME}.tar.gz /opt
-RUN mv /opt/${PKG_NAME} /opt/bookkeeper
-
-WORKDIR /opt/bookkeeper
-
-COPY target/scripts /opt/bookkeeper/scripts
 COPY scripts/install-python-client.sh /opt/bookkeeper/scripts
 RUN chmod +x -R /opt/bookkeeper/scripts/
 
 # copy the python client
 ADD target/bookkeeper-client/ /opt/bookkeeper/bookkeeper-client
 RUN /opt/bookkeeper/scripts/install-python-client.sh
-
-ENTRYPOINT [ "/bin/bash", "/opt/bookkeeper/scripts/entrypoint.sh" ]
-CMD ["bookie"]
-
-#HEALTHCHECK --interval=10s --timeout=60s CMD /bin/bash /opt/bookkeeper/scripts/healthcheck.sh

--- a/tests/docker-images/current-version-image/pom.xml
+++ b/tests/docker-images/current-version-image/pom.xml
@@ -26,16 +26,6 @@
   <artifactId>current-version-image</artifactId>
   <name>Apache BookKeeper :: Tests :: Docker Images :: Current Version</name>
   <packaging>pom</packaging>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>bookkeeper-dist-server</artifactId>
-      <version>${project.parent.version}</version>
-      <classifier>bin</classifier>
-      <type>tar.gz</type>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
   <profiles>
     <profile>
       <id>docker</id>
@@ -81,9 +71,6 @@
                     <echo>copy python wheel file</echo>
                     <mkdir dir="${project.basedir}/target/bookkeeper-client" />
                     <copydir src="${project.basedir}/../../../stream/clients/python/dist" dest="${project.basedir}/target/bookkeeper-client" />
-                    <echo>copying docker scripts</echo>
-                    <mkdir dir="${project.basedir}/target/scripts" />
-                    <copydir src="${project.basedir}/../../../docker/scripts" dest="${project.basedir}/target/scripts" />
                   </tasks>
                 </configuration>
               </execution>
@@ -117,29 +104,9 @@
               <pullNewerImage>false</pullNewerImage>
               <noCache>true</noCache>
               <buildArgs>
-                <BK_VERSION>${project.version}</BK_VERSION>
-                <UBUNTU_MIRROR>${UBUNTU_MIRROR}</UBUNTU_MIRROR>
-                <UBUNTU_SECURITY_MIRROR>${UBUNTU_SECURITY_MIRROR}</UBUNTU_SECURITY_MIRROR>
+                <BK_IMAGE>${docker.image}</BK_IMAGE>
               </buildArgs>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-docker-dependencies</id>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/</outputDirectory>
-                  <includeArtifactIds>bookkeeper-dist-server</includeArtifactIds>
-                  <excludeTransitive>true</excludeTransitive>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### Motivation

The bookkeeper image wasn't verified in the CI, because the current-version-image image doesn't depend on the bookkeeper image.

### Changes

- Move some config to `docker/pom.xml` from `tests/docker-images/current-version-image/Dockerfile` to make the current-version-image image depend on the bookkeeper image
- Use the [docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin) to build the bookkeeper image
   - Introduces multi-arch build and images(without push images, because we are use docker-cloud to build the bookkeeper image, I don't know the detail process)
   - Custom bookkeeper image name