### PR TITLE
fix: permission denied in the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,39 @@
 # under the License.
 #
 
+FROM alpine:3.20 as bk-dist
+
+ARG BK_VERSION=4.17.1
+ARG DISTRO_NAME=bookkeeper-server-${BK_VERSION}-bin
+ARG DISTRO_URL=https://archive.apache.org/dist/bookkeeper/bookkeeper-${BK_VERSION}/${DISTRO_NAME}.tar.gz
+
+RUN apk update && apk add gpg gpg-agent wget \
+        && cd /opt \
+        && wget -q "${DISTRO_URL}" \
+        && wget -q "${DISTRO_URL}.asc" \
+        && wget -q "${DISTRO_URL}.sha512" \
+        && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
+        && wget -q https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
+        && gpg --import KEYS \
+        && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
+        && tar -xzf "$DISTRO_NAME.tar.gz" \
+        && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
+        && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512";
+
+COPY scripts /opt/bookkeeper/scripts
+
+RUN for SUBDIRECTORY in conf logs data; do \
+     mkdir -p /opt/bookkeeper/$SUBDIRECTORY; \
+     chmod -R ug+rwx /opt/bookkeeper/$SUBDIRECTORY; \
+     chown -R 10000:0 /opt/bookkeeper/$SUBDIRECTORY; \
+     done
+
+RUN for SUBDIRECTORY in scripts bin; do \
+     chmod -R g+rx /opt/bookkeeper/$SUBDIRECTORY; \
+     done
+
+RUN chmod -R o+rx /opt/bookkeeper
+
 FROM eclipse-temurin:17 as jre-build
 
 # Create a custom Java runtime
@@ -48,43 +81,39 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
 ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
-# Download Apache Bookkeeper, untar and clean up
 RUN set -x \
     && sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://archive.ubuntu.com/ubuntu/}|g" \
      -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
     && echo 'Acquire::http::Timeout "30";\nAcquire::http::ConnectionAttemptDelayMsec "2000";\nAcquire::https::Timeout "30";\nAcquire::https::ConnectionAttemptDelayMsec "2000";\nAcquire::ftp::Timeout "30";\nAcquire::ftp::ConnectionAttemptDelayMsec "2000";\nAcquire::Retries "15";' > /etc/apt/apt.conf.d/99timeout_and_retries \
-    && adduser "${BK_USER}" \
     && apt-get update \
     && apt-get install -y ca-certificates apt-transport-https \
     && apt-get install -y --no-install-recommends python3 pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && apt-get install -y --no-install-recommends gpg gpg-agent wget sudo \
+    && apt-get install -y --no-install-recommends wget sudo \
     && apt-get -y --purge autoremove \
     && apt-get autoclean \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -pv /opt \
-    && cd /opt \
-    && wget -q "${DISTRO_URL}" \
-    && wget -q "${DISTRO_URL}.asc" \
-    && wget -q "${DISTRO_URL}.sha512" \
-    && sha512sum -c ${DISTRO_NAME}.tar.gz.sha512 \
-    && wget https://dist.apache.org/repos/dist/release/bookkeeper/KEYS \
-    && gpg --import KEYS \
-    && gpg --batch --verify "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz" \
-    && tar -xzf "$DISTRO_NAME.tar.gz" \
-    && mv bookkeeper-server-${BK_VERSION}/ /opt/bookkeeper/ \
-    && rm -rf "$DISTRO_NAME.tar.gz" "$DISTRO_NAME.tar.gz.asc" "$DISTRO_NAME.tar.gz.sha512" \
     && pip install zk-shell
 
-WORKDIR /opt/bookkeeper
-
+# JDK
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="$PATH:$JAVA_HOME/bin"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-COPY scripts /opt/bookkeeper/scripts
-RUN chmod +x -R /opt/bookkeeper/scripts/
+# BK
+ENV ZK_dataDir=${BK_HOME}/data/zookeeper/data
+ENV ZK_dataLogDir=${BK_HOME}/data/zookeeper/txlog
+ENV BK_DATA_DIR=${BK_HOME}/data
+ENV BK_journalDirectory=${BK_HOME}/data/journal
+ENV BK_ledgerDirectories=${BK_HOME}/data/ledgers
+ENV ZK_SHELL_HOME=${BK_HOME}/data
+COPY --from=bk-dist /opt/bookkeeper ${BK_HOME}
+
+WORKDIR ${BK_HOME}
+
+RUN adduser "${BK_USER}" -u 10000 --gid 0 --home ${BK_HOME} --no-create-home --disabled-password
+USER 10000
 
 ENTRYPOINT [ "/bin/bash", "/opt/bookkeeper/scripts/entrypoint.sh" ]
 CMD ["bookie"]

--- a/docker/scripts/common.sh
+++ b/docker/scripts/common.sh
@@ -44,6 +44,8 @@ export BK_dlogRootPath=${BK_dlogRootPath:-"${BK_CLUSTER_ROOT_PATH}/distributedlo
 # stream storage
 export BK_NUM_STORAGE_CONTAINERS=${BK_NUM_STORAGE_CONTAINERS:-"32"}
 export BK_STREAM_STORAGE_ROOT_PATH=${BK_STREAM_STORAGE_ROOT_PATH:-"/stream"}
+# zk-shell
+export ZK_SHELL_HOME=${ZK_SHELL_HOME:-"${HOME}"}
 
 echo "Environment Vars for bookie:"
 echo ""


### PR DESCRIPTION
Fix #4461 

### Motivation

`$BK_USER` has been added to the image, we should use this user to run the image.

You can try this command to verify this PR.
```
gh pr checkout 4464
cd docker
docker build -t zixuan/bk .
docker run -it --rm zixuan/bk
```

### Changes

- Use `$BK_USER` with the group `root` to run the image.
- Follow up "Principle of least privilege".
- Add `ZK_SHELL_HOME` to set the zk-shell home to writing `.zk-shell` file to `BK_HOME/data`, not `BK_HOME`.

