### PR TITLE
Fix ReadOnlyLedgerHandle leak issue when checkAllLedgers.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
@@ -211,6 +211,7 @@ public class AuditorCheckAllLedgersTask extends AuditorTask {
                             auditorStats.getNumFragmentsPerLedger().registerSuccessfulValue(lh.getNumFragments());
                             auditorStats.getNumBookiesPerLedger().registerSuccessfulValue(lh.getNumBookies());
                             auditorStats.getNumLedgersChecked().inc();
+                            lh.closeAsync();
                         });
                     } else if (BKException.Code.NoSuchLedgerExistsOnMetadataServerException == rc) {
                         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
When the Auditor checkAllledgers, it will open the ledger with NoRecovery mode, it will register the listeners to the AbstractZkLedgerManager#listeners. 

The listener won't be removed if we don't close the ReadOnlyLedgerHandle, so there will be lots of listeners in the heap memory.


The heap dump:

<img width="1572" alt="image" src="https://github.com/user-attachments/assets/8b4cd6d3-b7bf-4ef2-9c47-2e076bdbbba0">
