### PR TITLE
improve: Use opstatlogger for recording more details of reading from db ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -85,16 +85,16 @@ class DbLedgerStorageStats {
     private final OpStatsLogger readEntryStats;
     @StatsDoc(
             name = READ_ENTRY_LOCATIONS_INDEX_TIME,
-            help = "time spent reading entries from the locations index of the db ledger storage engine",
+            help = "operation stats of reading entries from the locations index of the db ledger storage engine",
             parent = READ_ENTRY
     )
-    private final Counter readFromLocationIndexTime;
+    private final OpStatsLogger readFromLocationIndexTime;
     @StatsDoc(
             name = READ_ENTRYLOG_TIME,
-            help = "time spent reading entries from the entry log files of the db ledger storage engine",
+            help = "operation stats of reading entries from the entry log files of the db ledger storage engine",
             parent = READ_ENTRY
     )
-    private final Counter readFromEntryLogTime;
+    private final OpStatsLogger readFromEntryLogTime;
     @StatsDoc(
             name = WRITE_CACHE_HITS,
             help = "number of write cache hits (on reads)",
@@ -131,9 +131,9 @@ class DbLedgerStorageStats {
     private final OpStatsLogger readAheadBatchSizeStats;
     @StatsDoc(
             name = READAHEAD_TIME,
-            help = "Time spent on readahead operations"
+            help = "operation stats of readahead operations"
     )
-    private final Counter readAheadTime;
+    private final OpStatsLogger readAheadTime;
     @StatsDoc(
         name = FLUSH,
         help = "operation stats of flushing write cache to entry log files"
@@ -203,15 +203,15 @@ class DbLedgerStorageStats {
                          Supplier<Long> readCacheCountSupplier) {
         addEntryStats = stats.getThreadScopedOpStatsLogger(ADD_ENTRY);
         readEntryStats = stats.getThreadScopedOpStatsLogger(READ_ENTRY);
-        readFromLocationIndexTime = stats.getThreadScopedCounter(READ_ENTRY_LOCATIONS_INDEX_TIME);
-        readFromEntryLogTime = stats.getThreadScopedCounter(READ_ENTRYLOG_TIME);
+        readFromLocationIndexTime = stats.getThreadScopedOpStatsLogger(READ_ENTRY_LOCATIONS_INDEX_TIME);
+        readFromEntryLogTime = stats.getThreadScopedOpStatsLogger(READ_ENTRYLOG_TIME);
         readCacheHitCounter = stats.getCounter(READ_CACHE_HITS);
         readCacheMissCounter = stats.getCounter(READ_CACHE_MISSES);
         writeCacheHitCounter = stats.getCounter(WRITE_CACHE_HITS);
         writeCacheMissCounter = stats.getCounter(WRITE_CACHE_MISSES);
         readAheadBatchCountStats = stats.getOpStatsLogger(READAHEAD_BATCH_COUNT);
         readAheadBatchSizeStats = stats.getOpStatsLogger(READAHEAD_BATCH_SIZE);
-        readAheadTime = stats.getThreadScopedCounter(READAHEAD_TIME);
+        readAheadTime = stats.getThreadScopedOpStatsLogger(READAHEAD_TIME);
         flushStats = stats.getOpStatsLogger(FLUSH);
         flushEntryLogStats = stats.getOpStatsLogger(FLUSH_ENTRYLOG);
         flushLocationIndexStats = stats.getOpStatsLogger(FLUSH_LOCATIONS_INDEX);


### PR DESCRIPTION
### Motivation
In order to more accurately observe the latency distribution of reading entries from the db ledger storage engine (includes: read_locations_index, read_entrylog, readahead)

### Changes
read_locations_index, read_entrylog, and readahead metrics types are adjusted from Counter to OpStatsLogger.

Adjustment before and after as follows
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/afae1a0e-0619-4057-9b45-dc0b87e46993">
