### PR TITLE
Fix async log appender not print error log when bookie starting expectionally

### DIFF
--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -26,6 +26,10 @@
   <name>Apache BookKeeper :: Common</name>
   <dependencies>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.bookkeeper.stats</groupId>
       <artifactId>bookkeeper-stats-api</artifactId>
       <version>${project.parent.version}</version>

--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -26,10 +26,6 @@
   <name>Apache BookKeeper :: Common</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.bookkeeper.stats</groupId>
       <artifactId>bookkeeper-stats-api</artifactId>
       <version>${project.parent.version}</version>

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.common.component;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Utils to start components.
@@ -50,6 +51,8 @@ public class ComponentStarter {
                 log.error("Failed to close component {} in shutdown hook gracefully, Exiting anyway",
                     component.getName(), e);
                 future.completeExceptionally(e);
+            } finally {
+                LogManager.shutdown();
             }
         }
 
@@ -75,7 +78,7 @@ public class ComponentStarter {
             log.error("Triggered exceptionHandler of Component: {} because of Exception in Thread: {}",
                     component.getName(), t, e);
             // start the shutdown hook when an uncaught exception happen in the lifecycle component.
-            shutdownHookThread.start();
+            FutureUtils.complete(future, null);
         });
 
         component.publishInfo(new ComponentInfoPublisher());

--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
@@ -21,7 +21,6 @@ package org.apache.bookkeeper.common.component;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * Utils to start components.
@@ -51,8 +50,6 @@ public class ComponentStarter {
                 log.error("Failed to close component {} in shutdown hook gracefully, Exiting anyway",
                     component.getName(), e);
                 future.completeExceptionally(e);
-            } finally {
-                LogManager.shutdown();
             }
         }
 
@@ -77,8 +74,9 @@ public class ComponentStarter {
         component.setExceptionHandler((t, e) -> {
             log.error("Triggered exceptionHandler of Component: {} because of Exception in Thread: {}",
                     component.getName(), t, e);
+            System.err.println(e.getMessage());
             // start the shutdown hook when an uncaught exception happen in the lifecycle component.
-            FutureUtils.complete(future, null);
+            shutdownHookThread.start();
         });
 
         component.publishInfo(new ComponentInfoPublisher());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -56,7 +56,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.logging.log4j.LogManager;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -340,7 +339,7 @@ public class AutoRecoveryMain {
             server = buildAutoRecoveryServer(new BookieConfiguration(conf));
         } catch (Exception e) {
             LOG.error("Failed to build AutoRecovery Server", e);
-            LogManager.shutdown();
+            System.err.println(e.getMessage());
             return ExitCode.SERVER_EXCEPTION;
         }
 
@@ -351,8 +350,10 @@ public class AutoRecoveryMain {
             Thread.currentThread().interrupt();
             // the server is interrupted
             LOG.info("AutoRecovery server is interrupted. Exiting ...");
+            System.err.println(ie.getMessage());
         } catch (ExecutionException ee) {
             LOG.error("Error in bookie shutdown", ee.getCause());
+            System.err.println(ee.getMessage());
             return ExitCode.SERVER_EXCEPTION;
         }
         return ExitCode.OK;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AutoRecoveryMain.java
@@ -56,6 +56,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.logging.log4j.LogManager;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -339,6 +340,7 @@ public class AutoRecoveryMain {
             server = buildAutoRecoveryServer(new BookieConfiguration(conf));
         } catch (Exception e) {
             LOG.error("Failed to build AutoRecovery Server", e);
+            LogManager.shutdown();
             return ExitCode.SERVER_EXCEPTION;
         }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -41,7 +41,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * A bookie server is a server that run bookie and serving rpc requests.
@@ -223,7 +222,7 @@ public class Main {
             server = buildBookieServer(new BookieConfiguration(conf));
         } catch (Exception e) {
             log.error("Failed to build bookie server", e);
-            LogManager.shutdown();
+            System.err.println(e.getMessage());
             return ExitCode.SERVER_EXCEPTION;
         }
 
@@ -234,8 +233,10 @@ public class Main {
             Thread.currentThread().interrupt();
             // the server is interrupted
             log.info("Bookie server is interrupted. Exiting ...");
+            System.err.println(ie.getMessage());
         } catch (ExecutionException ee) {
             log.error("Error in bookie shutdown", ee.getCause());
+            System.err.println(ee.getMessage());
             return ExitCode.SERVER_EXCEPTION;
         }
         return ExitCode.OK;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java
@@ -41,6 +41,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * A bookie server is a server that run bookie and serving rpc requests.
@@ -222,6 +223,7 @@ public class Main {
             server = buildBookieServer(new BookieConfiguration(conf));
         } catch (Exception e) {
             log.error("Failed to build bookie server", e);
+            LogManager.shutdown();
             return ExitCode.SERVER_EXCEPTION;
         }
 

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -78,6 +78,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.distributedlog.DistributedLogConfiguration;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * A storage server is a server that run storage service and serving rpc requests.
@@ -170,6 +171,7 @@ public class StorageServer {
                 grpcUseHostname);
         } catch (Exception e) {
             log.error("Invalid storage configuration", e);
+            LogManager.shutdown();
             return ExitCode.INVALID_CONF.code();
         }
 

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/StorageServer.java
@@ -78,7 +78,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.distributedlog.DistributedLogConfiguration;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * A storage server is a server that run storage service and serving rpc requests.
@@ -171,7 +170,7 @@ public class StorageServer {
                 grpcUseHostname);
         } catch (Exception e) {
             log.error("Invalid storage configuration", e);
-            LogManager.shutdown();
+            System.err.println(e.getMessage());
             return ExitCode.INVALID_CONF.code();
         }
 
@@ -183,8 +182,10 @@ public class StorageServer {
             // the server is interrupted.
             Thread.currentThread().interrupt();
             log.info("Storage server is interrupted. Exiting ...");
+            System.err.println(e.getMessage());
         } catch (ExecutionException e) {
             log.info("Storage server is exiting ...");
+            System.err.println(e.getMessage());
         }
         return ExitCode.OK.code();
     }


### PR DESCRIPTION
### Motivation

Fix https://github.com/apache/bookkeeper/issues/4474

The root cause is that when bookie starting error,  the java runtime will exit  immediately. And the log4j can not shutdown gracefully:
https://github.com/apache/bookkeeper/blob/e5c418e06e1cdba1c4681159c7266a43fa403cb1/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/Main.java#L199-L201

### Changes

Call `LogManager#shutdown`  in jvm shutdown hook.
