### PR TITLE
Set default format_version to 5 for RocksDB databases

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -198,7 +198,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
             int blockSize = conf.getInt(ROCKSDB_BLOCK_SIZE, 64 * 1024);
             int bloomFilterBitsPerKey = conf.getInt(ROCKSDB_BLOOM_FILTERS_BITS_PER_KEY, 10);
             boolean lz4CompressionEnabled = conf.getBoolean(ROCKSDB_LZ4_COMPRESSION_ENABLED, true);
-            int formatVersion = conf.getInt(ROCKSDB_FORMAT_VERSION, 2);
+            int formatVersion = conf.getInt(ROCKSDB_FORMAT_VERSION, 5);
 
             if (lz4CompressionEnabled) {
                 options.setCompressionType(CompressionType.LZ4_COMPRESSION);

--- a/bookkeeper-server/src/test/resources/conf/default_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/default_rocksdb.conf
@@ -30,5 +30,7 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
@@ -60,7 +60,7 @@
 # set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
  block_cache=206150041
  # set by jni: tableOptions.setFormatVersion
- format_version=2
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]

--- a/bookkeeper-server/src/test/resources/conf/ledger_metadata_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/ledger_metadata_rocksdb.conf
@@ -25,10 +25,12 @@
  keep_log_file_num=30
  # set by jni: options.setLogFileTimeToRoll
  log_file_time_to_roll=86400
- 
+
  [CFOptions "default"]
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/bookkeeper-server/src/test/resources/test_entry_location_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/test_entry_location_rocksdb.conf
@@ -60,7 +60,7 @@
 # set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
  block_cache=206150041
  # set by jni: tableOptions.setFormatVersion
- format_version=2
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -777,7 +777,7 @@ gcEntryLogMetadataCacheEnabled=false
 # dbStorage_rocksDB_numFilesInLevel0=4
 # dbStorage_rocksDB_maxSizeInLevel1MB=256
 # dbStorage_rocksDB_logPath=
-# dbStorage_rocksDB_format_version=2
+# dbStorage_rocksDB_format_version=5
 
 #############################################################################
 ## DirectIO entry logger configuration

--- a/conf/default_rocksdb.conf.default
+++ b/conf/default_rocksdb.conf.default
@@ -34,5 +34,7 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/conf/entry_location_rocksdb.conf.default
+++ b/conf/entry_location_rocksdb.conf.default
@@ -64,7 +64,7 @@
  # set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
  block_cache=206150041
  # set by jni: tableOptions.setFormatVersion
- format_version=2
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]

--- a/conf/ledger_metadata_rocksdb.conf.default
+++ b/conf/ledger_metadata_rocksdb.conf.default
@@ -29,10 +29,12 @@
  keep_log_file_num=30
  # set by jni: options.setLogFileTimeToRoll
  log_file_time_to_roll=86400
- 
+
  [CFOptions "default"]
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash


### PR DESCRIPTION
Fix #4479

### Motivation

RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
Currently the default is format_version 2 which is really old. It's better to default to a more modern version.

### Changes

- upgrade default format_version from 2 to 5
- specify format_version=5 in various configuration files