### PR TITLE
[improve] when rackaware failed to choose a bookie, print out the list of ensemble.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java
@@ -590,7 +590,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             LOG.warn("Failed to choose a bookie from network location {}, "
                     + "the bookies in the network location are {}, excluded bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
-                     networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
+                     networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble.toList());
             // randomly choose one from whole cluster, ignore the provided predicate.
             return selectRandom(1, excludeBookies, predicate, ensemble).get(0);
         }
@@ -616,7 +616,7 @@ public class RackawareEnsemblePlacementPolicyImpl extends TopologyAwareEnsembleP
             LOG.warn("Failed to choose a bookie node from network location {}, "
                     + "the bookies in the network location are {}, excluded bookies {}, "
                     + "current ensemble {}, fallback to choose bookie randomly from the cluster.",
-                networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble);
+                networkLoc, topology.getLeaves(networkLoc), excludeBookies, ensemble.toList());
             return selectFromNetworkLocation(excludeRacks, excludeBookies, predicate, ensemble, fallbackToRandom);
         }
     }


### PR DESCRIPTION
### Motivation

In file RackawareEnsemblePlacementPolicyImpl.java 
In the log.warn below, we should print out the list of ensemble, instead of the object. The “ensemble” in line-619 should be changed into “ensemble.toList()”.

https://github.com/apache/bookkeeper/blob/999cd0f2ab14404be4d6c24e388456dbe56bb1a8/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicyImpl.java#L600C3-L619C47
### Changes
The “ensemble” in line-619 changed into “ensemble.toList()”.
