### PR TITLE
Add more detailed exceptions in VertxAbstractHandler

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/service/HttpServiceRequest.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/service/HttpServiceRequest.java
@@ -67,4 +67,9 @@ public class HttpServiceRequest {
         this.params = params;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "HttpServiceRequest{" + "body=" + body + ", method=" + method + ", params=" + params + '}';
+    }
 }


### PR DESCRIPTION
Fix #4424

### Motivation

Add more detailed error handling to avoid exceptions being swallowed.

### Changes

- Add more error handling logic to `VertxAbstractHandler#processRequest`
- Add `toString()` in `HttpServiceRequest`