### PR TITLE
[improve] Expose asyncBatchReadUnconfirmed to ReadHandle.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -958,8 +958,8 @@ public class LedgerHandle implements WriteHandle {
         int nettyMaxFrameSizeBytes = clientCtx.getConf().nettyMaxFrameSizeBytes;
         if (maxSize > nettyMaxFrameSizeBytes) {
             LOG.info(
-                    "The max size is greater than nettyMaxFrameSizeBytes, use nettyMaxFrameSizeBytes:{} to replace it.",
-                    nettyMaxFrameSizeBytes);
+                "The max size is greater than nettyMaxFrameSizeBytes, use nettyMaxFrameSizeBytes:{} to replace it.",
+                nettyMaxFrameSizeBytes);
             maxSize = nettyMaxFrameSizeBytes;
         }
         if (maxSize <= 0) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -957,17 +957,13 @@ public class LedgerHandle implements WriteHandle {
             boolean isRecoveryRead) {
         int nettyMaxFrameSizeBytes = clientCtx.getConf().nettyMaxFrameSizeBytes;
         if (maxSize > nettyMaxFrameSizeBytes) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("The max size is greater than nettyMaxFrameSizeBytes, " +
-                                "use nettyMaxFrameSizeBytes:{} to replace it.", nettyMaxFrameSizeBytes);
-            }
+            LOG.info(
+                    "The max size is greater than nettyMaxFrameSizeBytes, use nettyMaxFrameSizeBytes:{} to replace it.",
+                    nettyMaxFrameSizeBytes);
             maxSize = nettyMaxFrameSizeBytes;
         }
         if (maxSize <= 0) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("The max size is negative, use nettyMaxFrameSizeBytes:{} to replace it.",
-                        nettyMaxFrameSizeBytes);
-            }
+            LOG.info("The max size is negative, use nettyMaxFrameSizeBytes:{} to replace it.", nettyMaxFrameSizeBytes);
             maxSize = nettyMaxFrameSizeBytes;
         }
         BatchedReadOp op = new BatchedReadOp(this, clientCtx,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -956,13 +956,17 @@ public class LedgerHandle implements WriteHandle {
             boolean isRecoveryRead) {
         int nettyMaxFrameSizeBytes = clientCtx.getConf().nettyMaxFrameSizeBytes;
         if (maxSize > nettyMaxFrameSizeBytes) {
-            LOG.info(
-                "The max size is greater than nettyMaxFrameSizeBytes, use nettyMaxFrameSizeBytes:{} to replace it.",
-                nettyMaxFrameSizeBytes);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The max size is greater than nettyMaxFrameSizeBytes, " +
+                                "use nettyMaxFrameSizeBytes:{} to replace it.", nettyMaxFrameSizeBytes);
+            }
             maxSize = nettyMaxFrameSizeBytes;
         }
         if (maxSize <= 0) {
-            LOG.info("The max size is negative, use nettyMaxFrameSizeBytes:{} to replace it.", nettyMaxFrameSizeBytes);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The max size is negative, use nettyMaxFrameSizeBytes:{} to replace it.",
+                        nettyMaxFrameSizeBytes);
+            }
             maxSize = nettyMaxFrameSizeBytes;
         }
         BatchedReadOp op = new BatchedReadOp(this, clientCtx,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -72,6 +72,7 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
+import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.common.concurrent.FutureEventListener;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -1042,6 +1043,28 @@ public class LedgerHandle implements WriteHandle {
         }
 
         return readEntriesInternalAsync(firstEntry, lastEntry, false);
+    }
+
+
+    @Override
+    public CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long firstEntry, int maxCount, int maxSize) {
+        CompletableFuture<LedgerEntries> f = new CompletableFuture<>();
+        asyncBatchReadUnconfirmedEntries(firstEntry, maxCount, maxSize, new ReadCallback() {
+            @Override
+            public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object ctx) {
+                if (rc != Code.OK) {
+                    f.completeExceptionally(BKException.create(rc));
+                } else {
+                    List<org.apache.bookkeeper.client.api.LedgerEntry> entries = new ArrayList<>(maxCount);
+                    while (seq.hasMoreElements()) {
+                        LedgerEntry entry = seq.nextElement();
+                        entries.add(LedgerEntryImpl.create(entry.ledgerId, entry.entryId, entry.length, entry.data));
+                    }
+                    f.complete(LedgerEntriesImpl.create(entries));
+                }
+            }
+        }, null);
+        return f;
     }
 
     void asyncReadEntriesInternal(long firstEntry, long lastEntry, ReadCallback cb,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -21,6 +21,8 @@
 package org.apache.bookkeeper.client.api;
 
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -131,6 +133,50 @@ public interface ReadHandle extends Handle {
             throws BKException, InterruptedException {
         return FutureUtils.<LedgerEntries, BKException>result(readUnconfirmedAsync(firstEntry, lastEntry),
                                                               BKException.HANDLER);
+    }
+
+    /**
+     * Read a sequence of entries asynchronously, allowing to read after the LastAddConfirmed range.
+     * <br>This is the same of
+     * {@link org.apache.bookkeeper.client.LedgerHandle#asyncReadEntries(long, long, AsyncCallback.ReadCallback, Object) }
+     * but it lets the client read without checking the local value of LastAddConfirmed, so that it is possible to
+     * read entries for which the writer has not received the acknowledge yet. <br>
+     * For entries which are within the range 0..LastAddConfirmed BookKeeper guarantees that the writer has successfully
+     * received the acknowledge.<br>
+     * For entries outside that range it is possible that the writer never received the acknowledge
+     * and so there is the risk that the reader is seeing entries before the writer and this could result in
+     * a consistency issue in some cases.<br>
+     * With this method you can even read entries before the LastAddConfirmed and entries after it with one call,
+     * the expected consistency will be as described above for each subrange of ids.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param maxCount
+     *          id of last entry of sequence
+     * @param maxSize
+     *          the total entries size.
+     *
+     * @see org.apache.bookkeeper.client.LedgerHandle#asyncReadEntries(long, long, AsyncCallback.ReadCallback, Object)
+     * @see org.apache.bookkeeper.client.LedgerHandle#asyncReadLastConfirmed(AsyncCallback.ReadLastConfirmedCallback, Object)
+     * @see org.apache.bookkeeper.client.LedgerHandle#readUnconfirmedEntries(long, long)
+     */
+    CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long firstEntry, int maxCount, int maxSize);
+
+    /**
+     * Read a sequence of entries synchronously.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param maxCount
+     *          id of last entry of sequence
+     * @param maxSize
+     *          the total entries size.
+     *
+     * @see #batchReadUnconfirmedAsync(long, int, int)
+     */
+    default LedgerEntries batchReadUnconfirmed(long firstEntry, int maxCount, int maxSize)
+            throws BKException, InterruptedException {
+        return FutureUtils.result(batchReadUnconfirmedAsync(firstEntry, maxCount, maxSize), BKException.HANDLER);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -21,7 +21,6 @@
 package org.apache.bookkeeper.client.api;
 
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
@@ -138,7 +137,8 @@ public interface ReadHandle extends Handle {
     /**
      * Read a sequence of entries asynchronously, allowing to read after the LastAddConfirmed range.
      * <br>This is the same of
-     * {@link org.apache.bookkeeper.client.LedgerHandle#asyncReadEntries(long, long, AsyncCallback.ReadCallback, Object) }
+     * {@link org.apache.bookkeeper.client.LedgerHandle#asyncReadEntries(
+     * long, long, AsyncCallback.ReadCallback, Object) }
      * but it lets the client read without checking the local value of LastAddConfirmed, so that it is possible to
      * read entries for which the writer has not received the acknowledge yet. <br>
      * For entries which are within the range 0..LastAddConfirmed BookKeeper guarantees that the writer has successfully
@@ -157,7 +157,8 @@ public interface ReadHandle extends Handle {
      *          the total entries size.
      *
      * @see org.apache.bookkeeper.client.LedgerHandle#asyncReadEntries(long, long, AsyncCallback.ReadCallback, Object)
-     * @see org.apache.bookkeeper.client.LedgerHandle#asyncReadLastConfirmed(AsyncCallback.ReadLastConfirmedCallback, Object)
+     * @see org.apache.bookkeeper.client.LedgerHandle#asyncReadLastConfirmed(
+     * AsyncCallback.ReadLastConfirmedCallback, Object)
      * @see org.apache.bookkeeper.client.LedgerHandle#readUnconfirmedEntries(long, long)
      */
     CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long firstEntry, int maxCount, int maxSize);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockLedgerHandle.java
@@ -260,6 +260,11 @@ public class MockLedgerHandle extends LedgerHandle {
     }
 
     @Override
+    public CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long firstEntry, int maxCount, int maxSize) {
+        return readHandle.batchReadUnconfirmedAsync(firstEntry, maxCount, maxSize);
+    }
+
+    @Override
     public CompletableFuture<Long> readLastAddConfirmedAsync() {
         return readHandle.readLastAddConfirmedAsync();
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/MockReadHandle.java
@@ -88,6 +88,11 @@ class MockReadHandle implements ReadHandle {
     }
 
     @Override
+    public CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long firstEntry, int maxCount, int maxSize) {
+        return readAsync(firstEntry, firstEntry + maxCount - 1);
+    }
+
+    @Override
     public CompletableFuture<Long> readLastAddConfirmedAsync() {
         return CompletableFuture.completedFuture(getLastAddConfirmed());
     }


### PR DESCRIPTION
### Motivation

Expose LedgerHandle#asyncBatchReadUnconfirmedEntries to ReadHandle interface.

### Changes

(Describe: what changes you have made)
1. Add `batchReadUnconfirmedAsync`, `batchReadUnconfirmed` methods to `ReadHandle`
2. Implement `ReadHandle#batchReadUnconfirmedAsync` in `LedgerHandle` class.
3. Implement `ReadHandle#batchReadUnconfirmedAsync` in `MockReadHandle`,`MockLedgerHandle`

