### PR TITLE
fix: throw reject when SingleThreadExecutor drainTo in progress and queue is empty

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/util/SingleThreadExecutor.java
@@ -174,7 +174,7 @@ public class SingleThreadExecutor extends AbstractExecutorService implements Exe
         this.runner.interrupt();
         List<Runnable> remainingTasks = new ArrayList<>();
         int n = queue.drainTo(remainingTasks);
-        incrementPendingTaskCount(n);
+        decrementPendingTaskCount(n);
         return remainingTasks;
     }
 

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Lists;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
-import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
 import org.junit.Test;
 

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -140,7 +140,8 @@ public class TestSingleThreadExecutor {
         }
         ste.executeRunnableOrList(null, tasks);
 
-        Awaitility.await().pollDelay(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(10, ste.getPendingTaskCount()));
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(10, ste.getPendingTaskCount()));
 
         // Now the queue is really full and should reject tasks.
         assertThrows(RejectedExecutionException.class, () -> ste.execute(() -> {
@@ -154,7 +155,8 @@ public class TestSingleThreadExecutor {
         waitedLatch.countDown();
 
         // Check the tasks are completed.
-        Awaitility.await().pollDelay(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(0, ste.getPendingTaskCount()));
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(0, ste.getPendingTaskCount()));
 
         // Invalid cases - should throw IllegalArgumentException.
         assertThrows(IllegalArgumentException.class, () -> ste.executeRunnableOrList(null, null));

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -87,19 +87,22 @@ public class TestSingleThreadExecutor {
         CountDownLatch startedLatch = new CountDownLatch(1);
 
         for (int i = 0; i < 10; i++) {
+            int n = i;
             ste.execute(() -> {
-                startedLatch.countDown();
-
-                try {
-                    barrier.await();
-                } catch (InterruptedException | BrokenBarrierException e) {
-                    // ignore
+                if (n == 0) {
+                    startedLatch.countDown();
+                } else {
+                    try {
+                        barrier.await();
+                    } catch (InterruptedException | BrokenBarrierException e) {
+                        // ignore
+                    }
                 }
             });
-
-            // Wait until the first task is already running in the thread
-            startedLatch.await();
         }
+
+        // Wait until the first task is already running in the thread
+        startedLatch.await();
 
         // Next task should go through, because the runner thread has already pulled out 1 item from the
         // queue: the first tasks which is currently stuck

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/util/TestSingleThreadExecutor.java
@@ -131,7 +131,7 @@ public class TestSingleThreadExecutor {
         for (int i = 0; i < 10; i++) {
             tasks.add(() -> {
                 try {
-                    // Block remaining tasks to simulate a stuck queue.
+                    // Block task to simulate an active, long-running task.
                     waitedLatch.await();
                 } catch (Exception e) {
                     // ignored


### PR DESCRIPTION
Fix #4465

### Motivaction

In `SingleThreadExecutor`, the `runner` drains all tasks from the `queue` into `localTasks`. Although the `queue` is empty in memory at this point, the tasks are still pending execution in `localTasks`—so logically, the queue is still "full."

Calling `execute()` during this phase should *not* enqueue a new `runnable` into the `queue`, as doing so would exceed the intended capacity. This can lead to increased memory usage and potential OutOfMemory (OOM) issues.

### Changes

To address this, we introduce a variable to track the total number of pending runnables. This counter is used to control whether a new task should be added:

- The counter is incremented when a runnable is added to the queue.

- The counter is decremented when a runnable is actually executed.

This ensures accurate tracking of pending tasks and prevents overfilling the logical task queue.