### PR TITLE
[Cleanup] Definition of groupId is redundant, because it's inherited from the parent

### DIFF
--- a/bookkeeper-benchmark/pom.xml
+++ b/bookkeeper-benchmark/pom.xml
@@ -23,7 +23,6 @@
     <groupId>org.apache.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bookkeeper-benchmark</artifactId>
   <name>Apache BookKeeper :: Benchmark</name>
   <properties>

--- a/bookkeeper-slogger/pom.xml
+++ b/bookkeeper-slogger/pom.xml
@@ -22,7 +22,6 @@
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>
-    <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper-slogger-parent</artifactId>
     <name>Apache BookKeeper :: Structured Logger :: Parent</name>
 

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-    <artifactId>shaded-parent</artifactId>
+  <artifactId>shaded-parent</artifactId>
   <name>Apache BookKeeper :: Shaded :: Parent</name>
   <modules>
     <module>bookkeeper-server-shaded</module>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -23,8 +23,7 @@
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
-  <artifactId>shaded-parent</artifactId>
+    <artifactId>shaded-parent</artifactId>
   <name>Apache BookKeeper :: Shaded :: Parent</name>
   <modules>
     <module>bookkeeper-server-shaded</module>

--- a/stats/bookkeeper-stats-api/pom.xml
+++ b/stats/bookkeeper-stats-api/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.bookkeeper.stats</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>bookkeeper-stats-api</artifactId>
   <name>Apache BookKeeper :: Stats API</name>
   <url>http://maven.apache.org</url>

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.bookkeeper.stats</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>codahale-metrics-provider</artifactId>
   <name>Apache BookKeeper :: Stats Providers :: Codahale Metrics</name>
   <url>http://maven.apache.org</url>

--- a/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
@@ -22,9 +22,6 @@
     <groupId>org.apache.bookkeeper.stats</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-
-
-  <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>otel-metrics-provider</artifactId>
   <name>Apache BookKeeper :: Stats Providers :: OpenTelemetry</name>
 

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.bookkeeper.stats</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>prometheus-metrics-provider</artifactId>
   <name>Apache BookKeeper :: Stats Providers :: Prometheus</name>
   <dependencies>

--- a/stats/utils/pom.xml
+++ b/stats/utils/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.apache.bookkeeper.stats</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>bookkeeper-stats-utils</artifactId>
   <name>Apache BookKeeper :: Stats :: Utils</name>
   <dependencies>

--- a/stream/api/pom.xml
+++ b/stream/api/pom.xml
@@ -23,7 +23,6 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
   <artifactId>stream-storage-api</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: API</name>
   <dependencies>

--- a/stream/bk-grpc-name-resolver/pom.xml
+++ b/stream/bk-grpc-name-resolver/pom.xml
@@ -25,7 +25,6 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bk-grpc-name-resolver</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Common :: BK Grpc Name Resolver</name>
   <dependencies>

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -23,8 +23,7 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
-  <artifactId>stream-storage-common</artifactId>
+    <artifactId>stream-storage-common</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Common</name>
   <dependencies>
     <dependency>

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -23,7 +23,7 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-    <artifactId>stream-storage-common</artifactId>
+  <artifactId>stream-storage-common</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Common</name>
   <dependencies>
     <dependency>

--- a/stream/proto/pom.xml
+++ b/stream/proto/pom.xml
@@ -23,7 +23,6 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
   <artifactId>stream-storage-proto</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Proto</name>
 

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -24,7 +24,6 @@
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.bookkeeper</groupId>
   <artifactId>statelib</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: State Library</name>
   <dependencies>

--- a/tests/docker-images/all-released-versions-image/pom.xml
+++ b/tests/docker-images/all-released-versions-image/pom.xml
@@ -22,7 +22,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>all-released-versions-image</artifactId>
   <name>Apache BookKeeper :: Tests :: Docker Images :: All Released Versions</name>
   <packaging>pom</packaging>

--- a/tests/docker-images/all-versions-image/pom.xml
+++ b/tests/docker-images/all-versions-image/pom.xml
@@ -22,7 +22,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>all-versions-image</artifactId>
   <name>Apache BookKeeper :: Tests :: Docker Images :: All Versions</name>
   <packaging>pom</packaging>

--- a/tests/docker-images/current-version-image/pom.xml
+++ b/tests/docker-images/current-version-image/pom.xml
@@ -22,7 +22,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>current-version-image</artifactId>
   <name>Apache BookKeeper :: Tests :: Docker Images :: Current Version</name>
   <packaging>pom</packaging>

--- a/tests/docker-images/pom.xml
+++ b/tests/docker-images/pom.xml
@@ -23,7 +23,6 @@
     <artifactId>tests-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>docker-images</artifactId>
   <name>Apache BookKeeper :: Tests :: Docker Images</name>
   <modules>

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -24,7 +24,6 @@
     <relativePath>../integration-tests-base</relativePath>
   </parent>
 
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>integration-tests-base-groovy</artifactId>
   <packaging>pom</packaging>
 

--- a/tests/integration-tests-base/pom.xml
+++ b/tests/integration-tests-base/pom.xml
@@ -23,7 +23,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>integration-tests-base</artifactId>
   <packaging>pom</packaging>
 

--- a/tests/integration-tests-topologies/pom.xml
+++ b/tests/integration-tests-topologies/pom.xml
@@ -23,7 +23,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>integration-tests-topologies</artifactId>
   <packaging>jar</packaging>
 

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -22,8 +22,6 @@
     <artifactId>tests-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
-
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>integration-tests-utils</artifactId>
   <packaging>jar</packaging>
 

--- a/tests/scripts/pom.xml
+++ b/tests/scripts/pom.xml
@@ -23,7 +23,6 @@
     <version>4.18.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>scripts</artifactId>
   <packaging>jar</packaging>
   <name>Apache BookKeeper :: Tests :: Bash Scripts Test</name>


### PR DESCRIPTION
### Motivation
Clean up the pom files. Definition of groupId is redundant, because it's inherited from the parent.

### Changes
Delete redundant group id.

