### PR TITLE
Issue 4503: Added check into BufferedChannel's read to avoid endless loop

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -245,7 +245,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     public synchronized int read(ByteBuf dest, long pos, int length) throws IOException {
         if (dest.writableBytes() < length) {
             throw new IllegalArgumentException("dest buffer remaining capacity is not enough" 
-                    + "(must be at least as \"length\"=" + length +")");
+                    + "(must be at least as \"length\"=" + length + ")");
         }
 
         long prevPos = pos;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -243,9 +243,9 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
 
     @Override
     public synchronized int read(ByteBuf dest, long pos, int length) throws IOException {
-        if(dest.writableBytes() < length) {
-            throw new IllegalArgumentException("dest buffer remaining capacity is not enough" +
-                    "(must be at least as \"length\"=" + length +")");
+        if (dest.writableBytes() < length) {
+            throw new IllegalArgumentException("dest buffer remaining capacity is not enough" 
+                    + "(must be at least as \"length\"=" + length +")");
         }
 
         long prevPos = pos;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -243,6 +243,11 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
 
     @Override
     public synchronized int read(ByteBuf dest, long pos, int length) throws IOException {
+        if(dest.writableBytes() < length) {
+            throw new IllegalArgumentException("dest buffer remaining capacity is not enough" +
+                    "(must be at least as \"length\"=" + length +")");
+        }
+
         long prevPos = pos;
         while (length > 0) {
             // check if it is in the write buffer

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -244,7 +244,7 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
     @Override
     public synchronized int read(ByteBuf dest, long pos, int length) throws IOException {
         if (dest.writableBytes() < length) {
-            throw new IllegalArgumentException("dest buffer remaining capacity is not enough" 
+            throw new IllegalArgumentException("dest buffer remaining capacity is not enough"
                     + "(must be at least as \"length\"=" + length + ")");
         }
 


### PR DESCRIPTION
Fix #4503 

### Motivation

As discussed in the referred issue, this PR aims to avoid the endless loop which will happen if the dest ByteBuf passed to the BufferedChannel's read has less remaining writable bytes than the amount of bytes required to read (read's "length" parameter)

### Changes

Now, BufferedChannel.read() throws an exception if dest. buf. writableBytes is less than length
