### PR TITLE
Upgrade protobuf to 3.25.5 to address CVE-2024-7254

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -676,13 +676,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
-Source available at https://github.com/google/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-3.25.5.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-util-3.25.5.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -569,13 +569,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
-Source available at https://github.com/google/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-3.25.5.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-util-3.25.5.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles Simple Logging Facade for Java, which is available under a

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -665,13 +665,13 @@ This product bundles Google Protocol Buffers, which is available under a "3-clau
 license.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-3.25.1.jar
-Source available at https://github.com/google/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-3.25.5.jar
+Source available at https://github.com/google/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.14.0/LICENSE.
 
 Bundled as
-  - lib/com.google.protobuf-protobuf-java-util-3.25.1.jar
-Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.1
+  - lib/com.google.protobuf-protobuf-java-util-3.25.5.jar
+Source available at https://github.com/protocolbuffers/protobuf/tree/v3.25.5
 For details, see deps/protobuf-3.12.0/LICENSE.
 ------------------------------------------------------------------------------------
 This product bundles the JCP Standard Java Servlet API, which is available under a

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
-    <protobuf.version>3.25.1</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <protoc3.version>${protobuf.version}</protoc3.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>


### PR DESCRIPTION
### Motivation

CVE-2024-7254

### Changes

Upgrade protobuf to 3.25.5