### PR TITLE
[improve] Upgrade os-maven-plugin to support RISC-V 64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
-    <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <puppycrawl.checkstyle.version>9.3</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>4.7.3.2</spotbugs-maven-plugin.version>


### PR DESCRIPTION
### Motivation

Currently, when attempting to build BookKeeper on RISC-V 64-bit (riscv64) architecture, the build process fails due to the os-maven-plugin version 1.4.1, which lacks support for detecting the riscv64 architecture. This issue prevents successful builds on RISC-V 64-bit systems. To resolve this, I have upgraded the os-maven-plugin to version 1.7.1, which introduces support for RISC-V 64-bit.

### Changes

Dependency Update: Updated the os-maven-plugin from version 1.4.1 to version 1.7.1 in the project's build configuration. Version 1.7.1 includes native support for detecting the riscv64 architecture. For details see https://github.com/trustin/os-maven-plugin/releases/tag/os-maven-plugin-1.7.1
