### PR TITLE
[improve][conf] Change the default value of readOnlyModeOnAnyDiskFullEnabled to true

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -2462,12 +2462,12 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     }
 
     /**
-     * Get whether read-only mode is enable when any disk is full. The default is false.
+     * Get whether read-only mode is enable when any disk is full. The default is true.
      *
      * @return boolean
      */
     public boolean isReadOnlyModeOnAnyDiskFullEnabled() {
-        return getBoolean(READ_ONLY_MODE_ON_ANY_DISK_FULL_ENABLED, false);
+        return getBoolean(READ_ONLY_MODE_ON_ANY_DISK_FULL_ENABLED, true);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerDirsManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerDirsManagerTest.java
@@ -414,7 +414,7 @@ public class LedgerDirsManagerTest {
         // one dir usagespace above storagethreshold, another dir below storagethreshold
         // should still be writable
         setUsageAndThenVerify(curDir1, nospace + 0.02f, curDir2, nospace - 0.05f, mockDiskChecker,
-                mockLedgerDirsListener, false);
+                mockLedgerDirsListener, true);
 
         // should remain readonly
         setUsageAndThenVerify(curDir1, nospace + 0.05f, curDir2, nospace + 0.02f, mockDiskChecker,
@@ -438,7 +438,7 @@ public class LedgerDirsManagerTest {
         // overall diskusage is less than lwm
         // should goto readwrite
         setUsageAndThenVerify(curDir1, lwm - 0.17f, curDir2, nospace + 0.03f, mockDiskChecker, mockLedgerDirsListener,
-                false);
+                true);
         assertEquals("Only one LedgerDir should be writable", 1, dirsManager.getWritableLedgerDirs().size());
 
         // bring both the dirs below lwm

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/ReadOnlyBookieTest.java
@@ -103,6 +103,7 @@ public class ReadOnlyBookieTest extends BookKeeperClusterTestCase {
     public void testBookieShouldTurnWritableFromReadOnly() throws Exception {
         killBookie(0);
         baseConf.setReadOnlyModeEnabled(true);
+        baseConf.setReadOnlyModeOnAnyDiskFullEnabled(false);
         baseConf.setDiskCheckInterval(Integer.MAX_VALUE);
         startNewBookie();
         LedgerHandle ledger = bkc.createLedger(2, 2, DigestType.MAC,

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -182,7 +182,7 @@ extraServerComponents=
 # to read-only mode and serve only read requests. When all disks recovered,
 # the bookie will be converted to read-write mode.Otherwise it will obey the `readOnlyModeEnabled` behavior.
 # By default this will be disabled.
-# readOnlyModeOnAnyDiskFullEnabled=false
+# readOnlyModeOnAnyDiskFullEnabled=true
 
 #############################################################################
 ## Netty server settings

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -181,7 +181,7 @@ extraServerComponents=
 # If "readOnlyModeOnAnyDiskFullEnabled=true" then on any ledger disks full, bookie will be converted
 # to read-only mode and serve only read requests. When all disks recovered,
 # the bookie will be converted to read-write mode.Otherwise it will obey the `readOnlyModeEnabled` behavior.
-# By default this will be disabled.
+# By default this will be enable.
 # readOnlyModeOnAnyDiskFullEnabled=true
 
 #############################################################################


### PR DESCRIPTION
### Motivation
The https://github.com/apache/bookkeeper/pull/3212  import a feature: convert bookie to read-only mode when any ledger disks is full. 
In our practice, we found that when the bookie disk is full, if it is not changed to Read Only mode, a large number of messages will fail to be written to the ledger disk. And because the bookie status is still available at this time, no alarm is given to the maintenance personnel, resulting in slow access for the maintenance personnel.

That feature has been in place for some time. It is safe to enable it default.

PS: It was mentioned in the PR discussion that an email discussion should be submitted, but no follow-up was done. [0]
[0] - https://github.com/apache/bookkeeper/pull/3212/files#r857122376

### Changes
Change the default value of readOnlyModeOnAnyDiskFullEnabled to true