### PR TITLE
Fix region aware placement policy disk weight dose not update.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RegionAwareEnsemblePlacementPolicy.java
@@ -663,4 +663,12 @@ public class RegionAwareEnsemblePlacementPolicy extends RackawareEnsemblePlaceme
          */
         return PlacementPolicyAdherence.MEETS_STRICT;
     }
+
+    @Override
+    public void updateBookieInfo(Map<BookieId, BookieInfoReader.BookieInfo> bookieInfoMap) {
+        super.updateBookieInfo(bookieInfoMap);
+        for (TopologyAwareEnsemblePlacementPolicy policy : perRegionPlacement.values()) {
+            policy.updateBookieInfo(bookieInfoMap);
+        }
+    }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/TestRegionAwareEnsemblePlacementPolicy.java
@@ -1848,9 +1848,40 @@ public class TestRegionAwareEnsemblePlacementPolicy {
         c3 = countMap.get(addr3.toBookieId());
         c4 = countMap.get(addr4.toBookieId());
         c5 = countMap.get(addr5.toBookieId());
-        assertTrue(Math.abs((double)c1 / c2 - 2.0) < 1.0);
-        assertTrue(Math.abs((double)c4 / c3 - 1.5) < 1.0);
-        assertTrue(Math.abs((double)c5 / c3 - 2.0) < 1.0);
+        assertTrue(Math.abs((double) c1 / c2 - 2.0) < 1.0);
+        assertTrue(Math.abs((double) c4 / c3 - 1.5) < 1.0);
+        assertTrue(Math.abs((double) c5 / c3 - 2.0) < 1.0);
+
+        // update bookie weight
+        // due to default BookieMaxWeightMultipleForWeightBasedPlacement=3, the test cases need to be in the range
+        bookieInfoMap.put(addr1.toBookieId(), new BookieInfoReader.BookieInfo(1000000, 400000));
+        bookieInfoMap.put(addr2.toBookieId(), new BookieInfoReader.BookieInfo(1000000, 800000));
+        bookieInfoMap.put(addr3.toBookieId(), new BookieInfoReader.BookieInfo(1000000, 400000));
+        bookieInfoMap.put(addr4.toBookieId(), new BookieInfoReader.BookieInfo(1000000, 300000));
+        bookieInfoMap.put(addr5.toBookieId(), new BookieInfoReader.BookieInfo(1000000, 200000));
+        repp.updateBookieInfo(bookieInfoMap);
+
+        addrs.forEach(a -> countMap.put(a, 0));
+        for (int i = 0; i < loopTimes; ++i) {
+            ensemble = repp.newEnsemble(2, 2, 2, null,
+                    new HashSet<>()).getResult();
+            for (BookieId bookieId : ensemble) {
+                countMap.put(bookieId, countMap.get(bookieId) + 1);
+            }
+        }
+
+        // c2 should be 2x than c1
+        // c4 should be 1.5x than c5
+        // c3 should be 2x than c5
+        // we allow a range of (-50%, 50%) deviation instead of the exact multiples
+        c1 = countMap.get(addr1.toBookieId());
+        c2 = countMap.get(addr2.toBookieId());
+        c3 = countMap.get(addr3.toBookieId());
+        c4 = countMap.get(addr4.toBookieId());
+        c5 = countMap.get(addr5.toBookieId());
+        assertTrue(Math.abs((double) c2 / c1 - 2.0) < 1.0);
+        assertTrue(Math.abs((double) c4 / c5 - 1.5) < 1.0);
+        assertTrue(Math.abs((double) c3 / c5 - 2.0) < 1.0);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

We are using region aware policy in our Pulsar cluster and enable the disk weight base placement feature.
> `ensemblePlacementPolicy=org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy`
> `bookkeeperDiskWeightBasedPlacementEnabled=true`

There are different CVMs with different free disk space in a region, but we found that the traffic still seems to be balanced and is not distributed according to the weight of the free disk space.

The root cause of this case is that the disk weight information actually used to allocate bookies in `RegionAwareEnsemblePlacementPolicy` has not been updated at all.

The `RegionAwareEnsemblePlacementPolicy` actually choose bookies for ensemble by `RackawareEnsemblePlacementPolicy` of each region in `perRegionPlacement`, see `org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy#newEnsemble`. `RegionAwareEnsemblePlacementPolicy.updateBookieInfo` dose not update the `bookieInfoMap` in `RackawareEnsemblePlacementPolicy` of each region in `perRegionPlacement`, which results that the disk weight information actually used to allocate bookies in `RegionAwareEnsemblePlacementPolicy` has not been updated at all.

### Changes

1. Overwrites the `updateBookieInfo` in `RegionAwareEnsemblePlacementPolicy`, update the bookie info in `RackawareEnsemblePlacementPolicy` of each region in `perRegionPlacement`.
2. Add test cases `org.apache.bookkeeper.client.TestRegionAwareEnsemblePlacementPolicy#testRegionsWithDifferentDiskWeight`.
