### PR TITLE
fix pendingDeletedLedgers do not remove ledger error

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LedgerMetadataIndex.java
@@ -339,6 +339,7 @@ public class LedgerMetadataIndex implements Closeable {
                 key.set(ledgerId);
                 ledgersDb.delete(key.array);
                 ++deletedLedgers;
+                pendingDeletedLedgers.remove(ledgerId);
             }
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

fix this pr https://github.com/apache/bookkeeper/pull/3989 cause ledger not remove in pendingDeletedLedgers.

Previous would do poll(), but later just do forEach()

### Changes

keep the same logic before pr-3989.

Alternative fix is revert previous pr.


