### PR TITLE
add metric for rocksdb getLastEntryInLedger to help find out bottleneck

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -117,8 +117,16 @@ public class EntryLocationIndex implements Closeable {
     private long getLastEntryInLedgerInternal(long ledgerId) throws IOException {
         LongPairWrapper maxEntryId = LongPairWrapper.get(ledgerId, Long.MAX_VALUE);
 
+        long startTimeNanos = MathUtils.nowInNano();
         // Search the last entry in storage
         Entry<byte[], byte[]> entry = locationsDb.getFloor(maxEntryId.array);
+        if (entry != null) {
+            stats.getGetLastEntryInLedgerStats()
+                    .registerSuccessfulEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+        } else {
+            stats.getGetLastEntryInLedgerStats()
+                    .registerFailedEvent(MathUtils.elapsedNanos(startTimeNanos), TimeUnit.NANOSECONDS);
+        }
         maxEntryId.recycle();
 
         if (entry == null) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexStats.java
@@ -42,6 +42,7 @@ class EntryLocationIndexStats {
 
     private static final String ENTRIES_COUNT = "entries-count";
     private static final String LOOKUP_ENTRY_LOCATION = "lookup-entry-location";
+    private static final String GET_LAST_ENTRY_IN_LEDGER = "get-last-entry-in-ledger";
 
     @StatsDoc(
         name = ENTRIES_COUNT,
@@ -54,6 +55,12 @@ class EntryLocationIndexStats {
             help = "operation stats of looking up entry location"
     )
     private final OpStatsLogger lookupEntryLocationStats;
+
+    @StatsDoc(
+            name = GET_LAST_ENTRY_IN_LEDGER,
+            help = "operation stats of get last entry in ledger"
+    )
+    private final OpStatsLogger getLastEntryInLedgerStats;
 
     EntryLocationIndexStats(StatsLogger statsLogger,
                             Supplier<Long> entriesCountSupplier) {
@@ -70,6 +77,7 @@ class EntryLocationIndexStats {
         };
         statsLogger.registerGauge(ENTRIES_COUNT, entriesCountGauge);
         lookupEntryLocationStats = statsLogger.getOpStatsLogger(LOOKUP_ENTRY_LOCATION);
+        getLastEntryInLedgerStats = statsLogger.getOpStatsLogger(GET_LAST_ENTRY_IN_LEDGER);
     }
 
 }


### PR DESCRIPTION
### Motivation

One of our cluster occur a case that read ledger LAC timeout and ledger can not recover, which make topic unavailable. After adding extra log in bookie-server, we finally found the bottleneck is in EntryLocationIndex#getLastEntryInLedgerInternal, it spend 2.5 minute to scan the rocksdb.  

![企业微信截图_ccc8453e-19b6-4c6a-8d7c-d63f2b7bf09e](https://github.com/user-attachments/assets/23d5e04c-1886-44ce-9a2d-78e02e7dcc97)

Currently it may be hard to find out the bottleneck is in getLastEntryInLedgerInternal. Because if getLastEntryInLedgerInternal throw noEntry exception, the read-locations-index-time is not able to record the long latency. There is no way to know the bottleneck is in getLastEntryInLedgerInternal.

![企业微信截图_599c4094-1e4e-4edb-8c64-35bed13e0917](https://github.com/user-attachments/assets/ff4b7a08-3683-473b-b392-985334424855)
![企业微信截图_8d312886-7c02-4ef7-9e3a-a94525a1c8e1](https://github.com/user-attachments/assets/934064b4-8aee-4f8c-a748-e2b1eac3a040)


Because once the bottleneck in getLastEntry occur, the worst it would cause ledger unavailable and pulsar topic unavailable, I think is important to add this metric




### Changes

add metric.

