### PR TITLE
Fix potential class conflict during jetcd-core-shaded shading process

### DIFF
--- a/metadata-drivers/jetcd-core-shaded/pom.xml
+++ b/metadata-drivers/jetcd-core-shaded/pom.xml
@@ -95,6 +95,10 @@
                   <include>io.etcd:*</include>
                   <include>io.vertx:*</include>
                 </includes>
+                <excludes>
+                  <!-- This is required for execute shade multiple times without clean -->
+                  <exclude>org.apache.bookkeeper.metadata.drivers:jetcd-core-shaded</exclude>
+                </excludes>
               </artifactSet>
               <relocations>
                 <!-- relocate vertx packages since they will be transformed to use grpc-netty-shaded packages -->


### PR DESCRIPTION
### Motivation

This a make up patch for #4526, which missed the root cause to fix potential jetcd-core shading problem.

Because the `maven-shade-plugin` [includes][4] the current project artifact during the shade process. In `jetcd-core-shaded`, we copy `io.etcd.jetcd.*` into the `jetcd-core-shaded` jar without relocation. As a result, when the `install` or `deploy` goals are executed without cleaning the `target` folder, class conflicts arise between `io.etcd.jetcd.*` inside `org.apache.bookkeeper.metadata.drivers:jetcd-core-shaded.jar` and `io.etcd:jetcd-core.jar`.

[1]: https://github.com/apache/bookkeeper/pull/4426#issuecomment-2162348232
[2]: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
[4]: https://github.com/apache/maven-shade-plugin/blob/maven-shade-plugin-3.4.1/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java#L437

### Verifying this Change

To verify this patch, follow these steps:

```shell
# Step 1: Clean and install the `jetcd-core-shaded` module.
mvn clean install -pl metadata-drivers/jetcd-core-shaded -DskipTests

# Step 2: Install without cleaning, simulating a build release process.
mvn install -pl metadata-drivers/jetcd-core-shaded -DskipTests

# Step 3: Unpack the shaded jar into a directory and verify imports.
# Ensure that the import statement for `io.netty.handler.logging.ByteBufFormat` 
# in `org/apache/pulsar/jetcd/shaded/io/vertx/core/net/NetClientOptions.class` 
# is correct. The expected import is:
# `import io.grpc.netty.shaded.io.netty.handler.logging.ByteBufFormat;`.
unzip $M2_REPO/org/apache/bookkeeper/metadata/drivers/jetcd-core-shaded/<VERSION>/jetcd-core-shaded-<VERSION>.jar \
  -d metadata-drivers/jetcd-core-shaded/target/shaded-classes
```