### PR TITLE
[cli] Fix: recover command doesn't accept rate limit parameter

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -524,7 +524,7 @@ public class BookieShell implements Tool {
             opts.addOption("sk", "skipOpenLedgers", false, "Skip recovering open ledgers");
             opts.addOption("d", "deleteCookie", false, "Delete cookie node for the bookie.");
             opts.addOption("sku", "skipUnrecoverableLedgers", false, "Skip unrecoverable ledgers.");
-            opts.addOption("rate", "replicationRate", false, "Replication rate by bytes");
+            opts.addOption("rate", "replicationRate", true, "Replication rate by bytes");
         }
 
         @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Maps;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Set;
@@ -248,7 +247,7 @@ public class BookieShellTest {
                                      boolean removeCookies,
                                      String... args) throws Exception {
         final PrintStream oldPs = System.err;
-        try(ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
             System.setErr(new PrintStream(outContent));
 
             RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
@@ -337,7 +336,7 @@ public class BookieShellTest {
                                boolean skipUnrecoverableLedgers,
                                String... args) throws Exception {
         final PrintStream oldPs = System.err;
-        try(ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
             System.setErr(new PrintStream(outContent));
 
             RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieShellTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.bookie;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,6 +36,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Maps;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.Function;
@@ -189,6 +193,14 @@ public class BookieShellTest {
         verify(admin, times(1)).close();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRecoverLedgerWithRateLimit() throws Exception {
+        testRecoverCmdRecoverLedger(
+                12345, false, false, false,
+                "-force", "-l", "12345", "-rate", "10000", "127.0.0.1:3181");
+    }
+
     @Test
     public void testRecoverCmdRecoverLedgerDefault() throws Exception {
         // default behavior
@@ -235,21 +247,30 @@ public class BookieShellTest {
                                      boolean skipOpenLedgers,
                                      boolean removeCookies,
                                      String... args) throws Exception {
-        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
-        CommandLine cmdLine = parseCommandLine(cmd, args);
-        assertEquals(0, cmd.runCmd(cmdLine));
-        bookKeeperAdminMockedStatic.verify(() -> BookKeeperAdmin.newBookKeeperAdmin(any(ClientConfiguration.class)),
-                times(1));
-        verify(admin, times(1))
-            .recoverBookieData(eq(ledgerId), any(Set.class), eq(dryrun), eq(skipOpenLedgers));
-        verify(admin, times(1)).close();
-        if (removeCookies) {
-            MetadataDrivers.runFunctionWithRegistrationManager(any(ServerConfiguration.class), any(Function.class));
-            verify(rm, times(1)).readCookie(any(BookieId.class));
-            verify(rm, times(1)).removeCookie(any(BookieId.class), eq(version));
-        } else {
-            verify(rm, times(0)).readCookie(any(BookieId.class));
-            verify(rm, times(0)).removeCookie(any(BookieId.class), eq(version));
+        final PrintStream oldPs = System.err;
+        try(ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
+            System.setErr(new PrintStream(outContent));
+
+            RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+            CommandLine cmdLine = parseCommandLine(cmd, args);
+            assertEquals(0, cmd.runCmd(cmdLine));
+            bookKeeperAdminMockedStatic.verify(() -> BookKeeperAdmin.newBookKeeperAdmin(any(ClientConfiguration.class)),
+                    times(1));
+            verify(admin, times(1))
+                .recoverBookieData(eq(ledgerId), any(Set.class), eq(dryrun), eq(skipOpenLedgers));
+            verify(admin, times(1)).close();
+            if (removeCookies) {
+                MetadataDrivers.runFunctionWithRegistrationManager(any(ServerConfiguration.class), any(Function.class));
+                verify(rm, times(1)).readCookie(any(BookieId.class));
+                verify(rm, times(1)).removeCookie(any(BookieId.class), eq(version));
+            } else {
+                verify(rm, times(0)).readCookie(any(BookieId.class));
+                verify(rm, times(0)).removeCookie(any(BookieId.class), eq(version));
+            }
+            assertFalse("invalid value for option detected:\n" + outContent,
+                    outContent.toString().contains("invalid value for option"));
+        } finally {
+            System.setErr(oldPs);
         }
     }
 
@@ -259,6 +280,14 @@ public class BookieShellTest {
         testRecoverCmdRecover(
             false, false, false, false,
             "-force", "127.0.0.1:3181");
+    }
+
+    @Test
+    public void testRecoverWithRateLimit() throws Exception {
+        // default behavior
+        testRecoverCmdRecover(
+                false, false, false, false,
+                "-force", "127.0.0.1:3181");
     }
 
     @Test
@@ -307,21 +336,30 @@ public class BookieShellTest {
                                boolean removeCookies,
                                boolean skipUnrecoverableLedgers,
                                String... args) throws Exception {
-        RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
-        CommandLine cmdLine = parseCommandLine(cmd, args);
-        assertEquals(0, cmd.runCmd(cmdLine));
-        bookKeeperAdminMockedStatic.verify(() -> BookKeeperAdmin.newBookKeeperAdmin(any(ClientConfiguration.class)),
-                times(1));
-        verify(admin, times(1))
-            .recoverBookieData(any(Set.class), eq(dryrun), eq(skipOpenLedgers), eq(skipUnrecoverableLedgers));
-        verify(admin, times(1)).close();
-        if (removeCookies) {
-            MetadataDrivers.runFunctionWithRegistrationManager(any(ServerConfiguration.class), any(Function.class));
-            verify(rm, times(1)).readCookie(any(BookieId.class));
-            verify(rm, times(1)).removeCookie(any(BookieId.class), eq(version));
-        } else {
-            verify(rm, times(0)).readCookie(any(BookieId.class));
-            verify(rm, times(0)).removeCookie(any(BookieId.class), eq(version));
+        final PrintStream oldPs = System.err;
+        try(ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
+            System.setErr(new PrintStream(outContent));
+
+            RecoverCmd cmd = (RecoverCmd) shell.commands.get("recover");
+            CommandLine cmdLine = parseCommandLine(cmd, args);
+            assertEquals(0, cmd.runCmd(cmdLine));
+            bookKeeperAdminMockedStatic.verify(() -> BookKeeperAdmin.newBookKeeperAdmin(any(ClientConfiguration.class)),
+                    times(1));
+            verify(admin, times(1))
+                .recoverBookieData(any(Set.class), eq(dryrun), eq(skipOpenLedgers), eq(skipUnrecoverableLedgers));
+            verify(admin, times(1)).close();
+            if (removeCookies) {
+                MetadataDrivers.runFunctionWithRegistrationManager(any(ServerConfiguration.class), any(Function.class));
+                verify(rm, times(1)).readCookie(any(BookieId.class));
+                verify(rm, times(1)).removeCookie(any(BookieId.class), eq(version));
+            } else {
+                verify(rm, times(0)).readCookie(any(BookieId.class));
+                verify(rm, times(0)).removeCookie(any(BookieId.class), eq(version));
+            }
+            assertFalse("invalid value for option detected:\n" + outContent,
+                    outContent.toString().contains("invalid value for option"));
+        } finally {
+            System.setErr(oldPs);
         }
     }
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Running `recover` command with rate limit like
```
bin/bookkeeper shell recover -rate 10000 <the rest of the params>
```
produces error
```
The provided bookie dest 10000 will be ignored!
ERROR: invalid value for option replicationRate : null
```

### Changes

Fixed the bug, added tests.
