### PR TITLE
Fix tune-runner-vm action to run correctly on `ubuntu-24.04` image

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -76,13 +76,6 @@ runs:
 
             # stop Azure Linux agent to save RAM
             sudo systemctl stop walinuxagent.service || true
-          
-            # enable docker experimental mode which is
-            # required for using "docker build --squash" / "-Ddocker.squash=true"
-            daemon_json="$(sudo cat /etc/docker/daemon.json  | jq '.experimental = true')"
-            echo "$daemon_json" | sudo tee /etc/docker/daemon.json
-            # restart docker daemon
-            sudo systemctl restart docker
             echo '::endgroup::'
 
             # show memory


### PR DESCRIPTION
### Motivation

In the `ubuntu-24.04` image, it seems `/etc/docker/daemon.json` file does not exist.
The CI action will always modify this file.
https://github.com/apache/bookkeeper/blob/b372e9031e3f43adc831947332a6852680e750db/.github/actions/tune-runner-vm/action.yml#L82

Therefore, the CI will fail as follows.
https://github.com/apache/bookkeeper/pull/4533#issuecomment-2538458232

I considered fixing it like https://github.com/apache/pulsar/pull/22448, but I wonder if CI uses experimental features.

### Changes

* Remove docker tuning from tune-runner-vm action
