### PR TITLE
Fix bot script to allow `rerun failure checks` command as expected

### DIFF
--- a/.github/actions/bot/src/run.js
+++ b/.github/actions/bot/src/run.js
@@ -19,13 +19,13 @@
 async function run(core, context, github) {
 
     try {
-        const owner = process.env.PROVIDER;
-        const repo = process.env.REPOSITORY;
+        const owner = context.repo.owner;
+        const repo = context.repo.repo;
         const reRunCmd = process.env.RERUN_CMD;
         const comment = context.payload.comment.body;
 
         if (comment !== reRunCmd) {
-            console.log("this is not a bot command");
+            core.info("this is not a bot command");
             return;
         }
 
@@ -35,13 +35,13 @@ async function run(core, context, github) {
                     sha: prRef,
                 }
             }
-        } = await github.pulls.get({
+        } = await github.rest.pulls.get({
             owner,
             repo,
             pull_number: context.issue.number,
         });
 
-        const jobs = await github.checks.listForRef({
+        const jobs = await github.rest.checks.listForRef({
             owner,
             repo,
             ref: prRef,
@@ -50,8 +50,8 @@ async function run(core, context, github) {
 
         jobs.data.check_runs.forEach(job => {
             if (job.conclusion === 'failure' || job.conclusion === 'cancelled') {
-                console.log("rerun job " + job.name);
-                github.checks.rerequestSuite({
+                core.info("rerun job " + job.name);
+                github.rest.checks.rerequestSuite({
                     owner,
                     repo,
                     check_suite_id: job.check_suite.id

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -34,8 +34,6 @@ jobs:
       - name: bot actions
         uses: actions/github-script@v7
         env:
-          PROVIDER: 'apache'
-          REPOSITORY: 'bookkeeper'
           RERUN_CMD: 'rerun failure checks'
         with:
           github-token: ${{secrets.BKBOT_TOKEN}}


### PR DESCRIPTION
### Motivation

Currently, the `Bot tests` job is not running as expected.
e.g. https://github.com/apache/bookkeeper/actions/runs/12297251209/job/34317994313

Since github-script V5, the interface has changed, but we have not changed the script of action.
https://github.com/actions/github-script/tree/4020e461acd7a80762cdfff123a1fde368246fa4?tab=readme-ov-file#v5

### Changes

* Fix bot script to address github-script V5 changes
