### PR TITLE
Disable bookie check task by auditorPeriodicBookieCheckInterval=-1

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java
@@ -420,10 +420,12 @@ public class Auditor implements AutoCloseable {
         if (bookieCheckInterval == 0) {
             LOG.info("Auditor periodic bookie checking disabled, running once check now anyhow");
             submitBookieCheckTask();
-        } else {
+        } else if (bookieCheckInterval > 0) {
             LOG.info("Auditor periodic bookie checking enabled" + " 'auditorPeriodicBookieCheckInterval' {} seconds",
                     bookieCheckInterval);
             executor.scheduleAtFixedRate(auditorBookieCheckTask, 0, bookieCheckInterval, TimeUnit.SECONDS);
+        } else {
+            LOG.info("Auditor periodic bookie checking disabled");
         }
     }
 


### PR DESCRIPTION
### Motivation

ScheduleBookieCheckTask is used to periodically check whether the ensemble bookie of all ledgers is available. If it is not available, these ledgers are audited and replicated. However, BookieCheckTask cannot be disabled by configuring the parameter auditorPeriodicBookieCheckInterval, so this pr implements disabling BookieCheckTask when auditorPeriodicBookieCheckInterval is configured to -1.

### Changes

disabling BookieCheckTask when auditorPeriodicBookieCheckInterval is configured to -1.
