### PR TITLE
Adds the bookie cookie service for http api

### DIFF
--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpRouter.java
@@ -56,6 +56,7 @@ public abstract class HttpRouter<Handler> {
     public static final String BOOKIE_INFO                  = "/api/v1/bookie/info";
     public static final String CLUSTER_INFO                  = "/api/v1/bookie/cluster_info";
     public static final String ENTRY_LOCATION_COMPACT       = "/api/v1/bookie/entry_location_compact";
+    public static final String BOOKIE_COOKIE                = "/api/v1/bookie/cookie";
     // autorecovery
     public static final String AUTORECOVERY_STATUS          = "/api/v1/autorecovery/status";
     public static final String RECOVERY_BOOKIE              = "/api/v1/autorecovery/bookie";
@@ -100,6 +101,7 @@ public abstract class HttpRouter<Handler> {
             handlerFactory.newHandler(HttpServer.ApiType.RESUME_GC_COMPACTION));
         this.endpointHandlers.put(ENTRY_LOCATION_COMPACT,
                 handlerFactory.newHandler(HttpServer.ApiType.TRIGGER_ENTRY_LOCATION_COMPACT));
+        this.endpointHandlers.put(BOOKIE_COOKIE, handlerFactory.newHandler(HttpServer.ApiType.BOOKIE_COOKIE));
 
         // autorecovery
         this.endpointHandlers.put(AUTORECOVERY_STATUS, handlerFactory

--- a/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
+++ b/bookkeeper-http/http-server/src/main/java/org/apache/bookkeeper/http/HttpServer.java
@@ -91,6 +91,7 @@ public interface HttpServer {
         RESUME_GC_COMPACTION,
         SUSPEND_GC_COMPACTION,
         TRIGGER_ENTRY_LOCATION_COMPACT,
+        BOOKIE_COOKIE,
         // autorecovery
         AUTORECOVERY_STATUS,
         RECOVERY_BOOKIE,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/BKHttpServiceProvider.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.Auditor;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.server.http.service.AutoRecoveryStatusService;
+import org.apache.bookkeeper.server.http.service.BookieCookieService;
 import org.apache.bookkeeper.server.http.service.BookieInfoService;
 import org.apache.bookkeeper.server.http.service.BookieIsReadyService;
 import org.apache.bookkeeper.server.http.service.BookieSanityService;
@@ -238,6 +239,8 @@ public class BKHttpServiceProvider implements HttpServiceProvider {
                 return new ResumeCompactionService(bookieServer);
             case TRIGGER_ENTRY_LOCATION_COMPACT:
                 return new TriggerLocationCompactService(bookieServer);
+            case BOOKIE_COOKIE:
+                return new BookieCookieService(configuration);
 
             // autorecovery
             case AUTORECOVERY_STATUS:

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieCookieService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieCookieService.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.server.http.service;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.UnknownHostException;
+import java.util.Map;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.bookie.Cookie;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.http.HttpServer;
+import org.apache.bookkeeper.http.service.HttpEndpointService;
+import org.apache.bookkeeper.http.service.HttpServiceRequest;
+import org.apache.bookkeeper.http.service.HttpServiceResponse;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.versioning.LongVersion;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BookieCookieService implements HttpEndpointService {
+    static final Logger LOG = LoggerFactory.getLogger(BookieCookieService.class);
+    private final ServerConfiguration conf;
+
+    public BookieCookieService(ServerConfiguration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public HttpServiceResponse handle(HttpServiceRequest request) throws Exception {
+        Map<String, String> params = request.getParams();
+        if (params == null || !params.containsKey("bookie_id")) {
+            return new HttpServiceResponse("Not found bookie id. Should provide bookie_id=<ip:port>",
+                    HttpServer.StatusCode.BAD_REQUEST);
+        }
+        if (request.getMethod() == HttpServer.Method.PUT && !params.containsKey("cookie")) {
+            return new HttpServiceResponse("Not found cookie. "
+                    + "Should provide cookie=<cookie string>", HttpServer.StatusCode.BAD_REQUEST);
+        }
+
+        String bookieIdStr = params.get("bookie_id");
+        try {
+            new BookieSocketAddress(bookieIdStr);
+        } catch (UnknownHostException nhe) {
+            return new HttpServiceResponse("Illegal bookie id. Should provide bookie_id=<ip:port>",
+                    HttpServer.StatusCode.BAD_REQUEST);
+        }
+
+        BookieId bookieId = BookieId.parse(bookieIdStr);
+        return MetadataDrivers.runFunctionWithRegistrationManager(conf, registrationManager -> {
+            try {
+                switch (request.getMethod()) {
+                    case PUT:
+                        Versioned<byte[]> newCookieWithVersion = new Versioned<>(params.get("cookie").getBytes(UTF_8),
+                                Version.NEW);
+                        registrationManager.writeCookie(bookieId, newCookieWithVersion);
+                        return new HttpServiceResponse("Added cookie: " + bookieId, HttpServer.StatusCode.OK);
+                    case GET:
+                        Versioned<Cookie> cookie = Cookie.readFromRegistrationManager(registrationManager, bookieId);
+                        return new HttpServiceResponse(cookie.getValue().toString(), HttpServer.StatusCode.OK);
+                    case DELETE:
+                        registrationManager.removeCookie(bookieId, new LongVersion(-1));
+                        return new HttpServiceResponse("Deleted cookie: " + bookieId, HttpServer.StatusCode.OK);
+                    default:
+                        return new HttpServiceResponse("Method not allowed. Should be GET or DELETE method",
+                                HttpServer.StatusCode.METHOD_NOT_ALLOWED);
+                }
+            } catch (BookieException.CookieNotFoundException e) {
+                return new HttpServiceResponse("Not found cookie: " + bookieId, HttpServer.StatusCode.NOT_FOUND);
+            } catch (BookieException.CookieExistException e) {
+                return new HttpServiceResponse("Cookie exist for bookieId: " + bookieId, HttpServer.StatusCode.OK);
+            } catch (BookieException e) {
+                LOG.error("Failed to op bookie cookie: ", e);
+                return new HttpServiceResponse("Request failed, e:" + e.getMessage(),
+                        HttpServer.StatusCode.INTERNAL_ERROR);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

Motivation
It would be convenient to support get, or delete the cookie of bookie with REST API, just like what does in the shell command.

Changes
Adds an API to get, delete the cookie of bookie at /api/v1/bookie/cookie.