### PR TITLE
improve: allow flaky tests run with specify parameters

### DIFF
--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/annotations/FlakyTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/annotations/FlakyTest.java
@@ -27,7 +27,30 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Intended for marking a test case as flaky.
+ * Annotation to mark a test as flaky.
+ *
+ * <p>Flaky tests are tests that produce inconsistent results,
+ * occasionally failing or passing without changes to the code under test.
+ * This could be due to external factors such as timing issues, resource contention,
+ * dependency on non-deterministic data, or integration with external systems.
+ *
+ * <p>Tests marked with this annotation are excluded from execution
+ * in CI pipelines and Maven commands by default, to ensure a reliable and
+ * deterministic build process. However, they can still be executed manually
+ * or in specific environments for debugging and resolution purposes.
+ *
+ * <p>Usage:
+ * <pre>
+ * {@code
+ * @FlakyTest
+ * public void testSomething() {
+ *     // Test logic here
+ * }
+ * }
+ * </pre>
+ *
+ * <p>It is recommended to investigate and address the root causes of flaky tests
+ * rather than relying on this annotation long-term.
  */
 @Documented
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/annotations/FlakyTest.java
+++ b/bookkeeper-common/src/test/java/org/apache/bookkeeper/common/testing/annotations/FlakyTest.java
@@ -19,14 +19,21 @@
 package org.apache.bookkeeper.common.testing.annotations;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Intended for marking a test case as flaky.
  */
 @Documented
-@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("flaky")
+@Test
 public @interface FlakyTest {
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
@@ -86,12 +86,12 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
 
     LedgerHandle[] prepareData(int numEntryLogs) throws Exception {
         // since an entry log file can hold at most 100 entries
-        // first ledger write 2 entries, which is less than low water mark
+        // first ledger write 2 entries, which is less than low watermark
         int num1 = 2;
-        // third ledger write more than high water mark entries
+        // third ledger write more than high watermark entries
         int num3 = (int) (NUM_ENTRIES * 0.7f);
-        // second ledger write remaining entries, which is higher than low water
-        // mark and less than high water mark
+        // second ledger write remaining entries, which is higher than low watermark
+        // and less than high watermark
         int num2 = NUM_ENTRIES - num3 - num1;
 
         LedgerHandle[] lhs = new LedgerHandle[3];
@@ -148,8 +148,8 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         File ledgerDir2 = tmpDirs.createNew("ledger", "test2");
         File journalDir = tmpDirs.createNew("journal", "test");
         String[] ledgerDirNames = new String[]{
-            ledgerDir1.getPath(),
-            ledgerDir2.getPath()
+                ledgerDir1.getPath(),
+                ledgerDir2.getPath()
         };
         conf.setLedgerDirNames(ledgerDirNames);
         conf.setJournalDirName(journalDir.getPath());
@@ -224,7 +224,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         // there are no writableLedgerDirs
         for (File ledgerDir : bookie.getLedgerDirsManager().getAllLedgerDirs()) {
             assertFalse("Found entry log file ([0,1,2].log. They should have been compacted" + ledgerDir,
-                TestUtils.hasLogFiles(ledgerDir.getParentFile(), true, 0, 1, 2));
+                    TestUtils.hasLogFiles(ledgerDir.getParentFile(), true, 0, 1, 2));
         }
 
         try {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperDiskSpaceWeightedLedgerPlacementTest.java
@@ -179,7 +179,7 @@ public class BookKeeperDiskSpaceWeightedLedgerPlacementTest extends BookKeeperCl
 
     /**
      * Test to show that weight based selection honors the disk weight of bookies and also adapts
-     * when the bookies's weight changes.
+     * when the bookies' weight changes.
      */
     @FlakyTest("https://github.com/apache/bookkeeper/issues/503")
     public void testDiskSpaceWeightedBookieSelectionWithChangingWeights() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/BookieAutoRecoveryTest.java
@@ -375,7 +375,7 @@ public class BookieAutoRecoveryTest extends BookKeeperClusterTestCase {
     }
 
     /**
-     * Test that if a empty ledger loses the bookie not in the quorum for entry 0, it will
+     * Test that if an empty ledger loses the bookie not in the quorum for entry 0, it will
      * still be openable when it loses enough bookies to lose a whole quorum.
      */
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -918,6 +918,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <excludedGroups>flaky</excludedGroups>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/TestDistributedLogBase.java
@@ -61,6 +61,12 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +77,9 @@ import org.slf4j.LoggerFactory;
  */
 public class TestDistributedLogBase {
     static final Logger LOG = LoggerFactory.getLogger(TestDistributedLogBase.class);
+
+    @Rule
+    public final TestName runtime = new TestName();
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(120);
@@ -105,7 +114,20 @@ public class TestDistributedLogBase {
     protected static int zkPort;
     protected static final List<File> TMP_DIRS = new ArrayList<File>();
 
+    protected String testName;
+
+    @Before
+    public void setTestNameJunit4() {
+        testName = runtime.getMethodName();
+    }
+
+    @BeforeEach
+    void setTestNameJunit5(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
+    }
+
     @BeforeClass
+    @BeforeAll
     public static void setupCluster() throws Exception {
         setupCluster(numBookies);
     }
@@ -134,6 +156,7 @@ public class TestDistributedLogBase {
     }
 
     @AfterClass
+    @AfterAll
     public static void teardownCluster() throws Exception {
         bkutil.teardown();
         zks.stop();
@@ -143,6 +166,7 @@ public class TestDistributedLogBase {
     }
 
     @Before
+    @BeforeEach
     public void setup() throws Exception {
         try {
             zkc = LocalDLMEmulator.connectZooKeeper("127.0.0.1", zkPort);
@@ -153,6 +177,7 @@ public class TestDistributedLogBase {
     }
 
     @After
+    @AfterEach
     public void teardown() throws Exception {
         if (null != zkc) {
             zkc.close();

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
@@ -19,17 +19,16 @@ package org.apache.distributedlog.bk;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -59,6 +58,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,162 +163,158 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         Utils.close(allocator);
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testBadVersionOnTwoAllocators() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/allocation-bad-version";
-            zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            Stat stat = new Stat();
-            byte[] data = zkc.get().getData(allocationPath, false, stat);
-            Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+        String allocationPath = "/allocation-bad-version";
+        zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        Stat stat = new Stat();
+        byte[] data = zkc.get().getData(allocationPath, false, stat);
+        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
 
-            SimpleLedgerAllocator allocator1 =
-                    new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
-                            zkc, bkc);
-            SimpleLedgerAllocator allocator2 =
-                    new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
-                            zkc, bkc);
-            allocator1.allocate();
-            // wait until allocated
-            ZKTransaction txn1 = newTxn();
-            LedgerHandle lh = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
-            allocator2.allocate();
-            ZKTransaction txn2 = newTxn();
-            try {
-                Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
-                fail("Should fail allocating on second allocator as allocator1 is starting allocating something.");
-            } catch (ZKException ke) {
-                assertEquals(KeeperException.Code.BADVERSION, ke.getKeeperExceptionCode());
-            }
-            Utils.ioResult(txn1.execute());
-            Utils.close(allocator1);
-            Utils.close(allocator2);
+        SimpleLedgerAllocator allocator1 =
+                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
+                        zkc, bkc);
+        SimpleLedgerAllocator allocator2 =
+                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
+                        zkc, bkc);
+        allocator1.allocate();
+        // wait until allocated
+        ZKTransaction txn1 = newTxn();
+        LedgerHandle lh = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+        allocator2.allocate();
+        ZKTransaction txn2 = newTxn();
+        try {
+            Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
+            fail("Should fail allocating on second allocator as allocator1 is starting allocating something.");
+        } catch (ZKException ke) {
+            assertEquals(KeeperException.Code.BADVERSION, ke.getKeeperExceptionCode());
+        }
+        Utils.ioResult(txn1.execute());
+        Utils.close(allocator1);
+        Utils.close(allocator2);
 
-            long eid = lh.addEntry("hello world".getBytes());
-            lh.close();
-            LedgerHandle readLh = bkc.get().openLedger(lh.getId(),
-                    BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-            Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
-            int i = 0;
-            while (entries.hasMoreElements()) {
-                LedgerEntry entry = entries.nextElement();
-                assertEquals("hello world", new String(entry.getEntry(), UTF_8));
-                ++i;
-            }
-            assertEquals(1, i);
-        });
+        long eid = lh.addEntry("hello world".getBytes());
+        lh.close();
+        LedgerHandle readLh = bkc.get().openLedger(lh.getId(),
+                BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+        Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
+        int i = 0;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            assertEquals("hello world", new String(entry.getEntry(), UTF_8));
+            ++i;
+        }
+        assertEquals(1, i);
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testAllocatorWithoutEnoughBookies() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/allocator-without-enough-bookies";
+        String allocationPath = "/allocator-without-enough-bookies";
 
-            DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
-            confLocal.addConfiguration(conf);
-            confLocal.setEnsembleSize(numBookies * 2);
-            confLocal.setWriteQuorumSize(numBookies * 2);
+        DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
+        confLocal.addConfiguration(conf);
+        confLocal.setEnsembleSize(numBookies * 2);
+        confLocal.setWriteQuorumSize(numBookies * 2);
 
-            SimpleLedgerAllocator allocator1 = createAllocator(allocationPath, confLocal);
-            allocator1.allocate();
-            ZKTransaction txn1 = newTxn();
+        SimpleLedgerAllocator allocator1 = createAllocator(allocationPath, confLocal);
+        allocator1.allocate();
+        ZKTransaction txn1 = newTxn();
 
-            try {
-                Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
-                fail("Should fail allocating ledger if there aren't enough bookies");
-            } catch (AllocationException ioe) {
-                // expected
-                assertEquals(Phase.ERROR, ioe.getPhase());
-            }
-            byte[] data = zkc.get().getData(allocationPath, false, null);
-            assertEquals(0, data.length);
-        });
+        try {
+            Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+            fail("Should fail allocating ledger if there aren't enough bookies");
+        } catch (AllocationException ioe) {
+            // expected
+            assertEquals(Phase.ERROR, ioe.getPhase());
+        }
+        byte[] data = zkc.get().getData(allocationPath, false, null);
+        assertEquals(0, data.length);
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testSuccessAllocatorShouldDeleteUnusedLedger() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/allocation-delete-unused-ledger";
-            zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            Stat stat = new Stat();
-            byte[] data = zkc.get().getData(allocationPath, false, stat);
+        String allocationPath = "/allocation-delete-unused-ledger";
+        zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        Stat stat = new Stat();
+        byte[] data = zkc.get().getData(allocationPath, false, stat);
 
-            Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
 
-            SimpleLedgerAllocator allocator1 = new SimpleLedgerAllocator(allocationPath, allocationData,
-                    newQuorumConfigProvider(dlConf), zkc, bkc);
-            allocator1.allocate();
-            // wait until allocated
-            ZKTransaction txn1 = newTxn();
-            LedgerHandle lh1 = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+        SimpleLedgerAllocator allocator1 = new SimpleLedgerAllocator(allocationPath, allocationData,
+                newQuorumConfigProvider(dlConf), zkc, bkc);
+        allocator1.allocate();
+        // wait until allocated
+        ZKTransaction txn1 = newTxn();
+        LedgerHandle lh1 = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
 
-            // Second allocator kicks in
-            stat = new Stat();
-            data = zkc.get().getData(allocationPath, false, stat);
-            allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
-            SimpleLedgerAllocator allocator2 = new SimpleLedgerAllocator(allocationPath, allocationData,
-                    newQuorumConfigProvider(dlConf), zkc, bkc);
-            allocator2.allocate();
-            // wait until allocated
-            ZKTransaction txn2 = newTxn();
-            LedgerHandle lh2 = Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
+        // Second allocator kicks in
+        stat = new Stat();
+        data = zkc.get().getData(allocationPath, false, stat);
+        allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+        SimpleLedgerAllocator allocator2 = new SimpleLedgerAllocator(allocationPath, allocationData,
+                newQuorumConfigProvider(dlConf), zkc, bkc);
+        allocator2.allocate();
+        // wait until allocated
+        ZKTransaction txn2 = newTxn();
+        LedgerHandle lh2 = Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
 
-            // should fail to commit txn1 as version is changed by second allocator
-            try {
-                Utils.ioResult(txn1.execute());
-                fail("Should fail commit obtaining ledger handle from first allocator"
-                        + " as allocator is modified by second allocator.");
-            } catch (ZKException ke) {
-                // as expected
-            }
-            Utils.ioResult(txn2.execute());
-            Utils.close(allocator1);
-            Utils.close(allocator2);
+        // should fail to commit txn1 as version is changed by second allocator
+        try {
+            Utils.ioResult(txn1.execute());
+            fail("Should fail commit obtaining ledger handle from first allocator"
+                    + " as allocator is modified by second allocator.");
+        } catch (ZKException ke) {
+            // as expected
+        }
+        Utils.ioResult(txn2.execute());
+        Utils.close(allocator1);
+        Utils.close(allocator2);
 
-            // ledger handle should be deleted
-            try {
-                lh1.close();
-                fail("LedgerHandle allocated by allocator1 should be deleted.");
-            } catch (BKException bke) {
-                // as expected
-            }
-            try {
-                bkc.get().openLedger(lh1.getId(), BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-                fail("LedgerHandle allocated by allocator1 should be deleted.");
-            } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException nslee) {
-                // as expected
-            }
-            long eid = lh2.addEntry("hello world".getBytes());
-            lh2.close();
-            LedgerHandle readLh = bkc.get().openLedger(lh2.getId(),
-                    BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-            Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
-            int i = 0;
-            while (entries.hasMoreElements()) {
-                LedgerEntry entry = entries.nextElement();
-                assertEquals("hello world", new String(entry.getEntry(), UTF_8));
-                ++i;
-            }
-            assertEquals(1, i);
-        });
+        // ledger handle should be deleted
+        try {
+            lh1.close();
+            fail("LedgerHandle allocated by allocator1 should be deleted.");
+        } catch (BKException bke) {
+            // as expected
+        }
+        try {
+            bkc.get().openLedger(lh1.getId(), BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+            fail("LedgerHandle allocated by allocator1 should be deleted.");
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException nslee) {
+            // as expected
+        }
+        long eid = lh2.addEntry("hello world".getBytes());
+        lh2.close();
+        LedgerHandle readLh = bkc.get().openLedger(lh2.getId(),
+                BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+        Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
+        int i = 0;
+        while (entries.hasMoreElements()) {
+            LedgerEntry entry = entries.nextElement();
+            assertEquals("hello world", new String(entry.getEntry(), UTF_8));
+            ++i;
+        }
+        assertEquals(1, i);
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testCloseAllocatorDuringObtaining() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/allocation2";
-            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-            allocator.allocate();
-            ZKTransaction txn = newTxn();
-            // close during obtaining ledger.
-            LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-            Utils.close(allocator);
-            byte[] data = zkc.get().getData(allocationPath, false, null);
-            assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
-            // the ledger is not deleted
-            bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
-                    dlConf.getBKDigestPW().getBytes(UTF_8));
-        });
+        String allocationPath = "/allocation2";
+        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+        allocator.allocate();
+        ZKTransaction txn = newTxn();
+        // close during obtaining ledger.
+        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+        Utils.close(allocator);
+        byte[] data = zkc.get().getData(allocationPath, false, null);
+        assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
+        // the ledger is not deleted
+        bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
+                dlConf.getBKDigestPW().getBytes(UTF_8));
     }
 
     @FlakyTest("https://issues.apache.org/jira/browse/DL-26")
@@ -338,93 +334,89 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
                 dlConf.getBKDigestPW().getBytes(UTF_8));
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testCloseAllocatorAfterAbort() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/allocation3";
-            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-            allocator.allocate();
-            ZKTransaction txn = newTxn();
-            // close during obtaining ledger.
-            LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-            txn.addOp(DefaultZKOp.of(Op.setData("/unexistedpath", "data".getBytes(UTF_8), -1), null));
-            try {
-                Utils.ioResult(txn.execute());
-                fail("Should fail the transaction when setting unexisted path");
-            } catch (ZKException ke) {
-                // expected
-            }
-            Utils.close(allocator);
-            byte[] data = zkc.get().getData(allocationPath, false, null);
-            assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
-            // the ledger is not deleted.
-            bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
-                    dlConf.getBKDigestPW().getBytes(UTF_8));
-        });
+        String allocationPath = "/allocation3";
+        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+        allocator.allocate();
+        ZKTransaction txn = newTxn();
+        // close during obtaining ledger.
+        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+        txn.addOp(DefaultZKOp.of(Op.setData("/unexistedpath", "data".getBytes(UTF_8), -1), null));
+        try {
+            Utils.ioResult(txn.execute());
+            fail("Should fail the transaction when setting unexisted path");
+        } catch (ZKException ke) {
+            // expected
+        }
+        Utils.close(allocator);
+        byte[] data = zkc.get().getData(allocationPath, false, null);
+        assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
+        // the ledger is not deleted.
+        bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
+                dlConf.getBKDigestPW().getBytes(UTF_8));
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testConcurrentAllocation() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/" + testName;
-            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-            allocator.allocate();
-            ZKTransaction txn1 = newTxn();
-            CompletableFuture<LedgerHandle> obtainFuture1 = allocator.tryObtain(txn1, NULL_LISTENER);
-            ZKTransaction txn2 = newTxn();
-            CompletableFuture<LedgerHandle> obtainFuture2 = allocator.tryObtain(txn2, NULL_LISTENER);
-            assertTrue(obtainFuture2.isDone());
-            assertTrue(obtainFuture2.isCompletedExceptionally());
-            try {
-                Utils.ioResult(obtainFuture2);
-                fail("Should fail the concurrent obtain since there is "
-                        + "already a transaction obtaining the ledger handle");
-            } catch (SimpleLedgerAllocator.ConcurrentObtainException cbe) {
-                // expected
-            }
-        });
+        String allocationPath = "/" + testName;
+        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+        allocator.allocate();
+        ZKTransaction txn1 = newTxn();
+        CompletableFuture<LedgerHandle> obtainFuture1 = allocator.tryObtain(txn1, NULL_LISTENER);
+        ZKTransaction txn2 = newTxn();
+        CompletableFuture<LedgerHandle> obtainFuture2 = allocator.tryObtain(txn2, NULL_LISTENER);
+        assertTrue(obtainFuture2.isDone());
+        assertTrue(obtainFuture2.isCompletedExceptionally());
+        try {
+            Utils.ioResult(obtainFuture2);
+            fail("Should fail the concurrent obtain since there is "
+                    + "already a transaction obtaining the ledger handle");
+        } catch (SimpleLedgerAllocator.ConcurrentObtainException cbe) {
+            // expected
+        }
     }
 
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @Test
     public void testObtainMultipleLedgers() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/" + testName;
-            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-            int numLedgers = 10;
-            Set<LedgerHandle> allocatedLedgers = new HashSet<LedgerHandle>();
-            for (int i = 0; i < numLedgers; i++) {
-                allocator.allocate();
-                ZKTransaction txn = newTxn();
-                LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-                Utils.ioResult(txn.execute());
-                allocatedLedgers.add(lh);
-            }
-            assertEquals(numLedgers, allocatedLedgers.size());
-        });
-    }
-
-    @Test
-    public void testAllocationWithMetadata() throws Exception {
-        assertTimeout(Duration.ofMinutes(1), () -> {
-            String allocationPath = "/" + testName;
-
-            String application = "testApplicationMetadata";
-            String component = "testComponentMetadata";
-            String custom = "customMetadata";
-            LedgerMetadata ledgerMetadata = new LedgerMetadata();
-            ledgerMetadata.setApplication(application);
-            ledgerMetadata.setComponent(component);
-            ledgerMetadata.addCustomMetadata("custom", custom);
-
-            SimpleLedgerAllocator allocator = createAllocator(allocationPath, dlConf, ledgerMetadata);
+        String allocationPath = "/" + testName;
+        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+        int numLedgers = 10;
+        Set<LedgerHandle> allocatedLedgers = new HashSet<LedgerHandle>();
+        for (int i = 0; i < numLedgers; i++) {
             allocator.allocate();
-
             ZKTransaction txn = newTxn();
             LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-            Map<String, byte[]> customMeta = lh.getCustomMetadata();
-            assertEquals(application, new String(customMeta.get("application"), UTF_8));
-            assertEquals(component, new String(customMeta.get("component"), UTF_8));
-            assertEquals(custom, new String(customMeta.get("custom"), UTF_8));
-        });
+            Utils.ioResult(txn.execute());
+            allocatedLedgers.add(lh);
+        }
+        assertEquals(numLedgers, allocatedLedgers.size());
+    }
+
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @Test
+    public void testAllocationWithMetadata() throws Exception {
+        String allocationPath = "/" + testName;
+
+        String application = "testApplicationMetadata";
+        String component = "testComponentMetadata";
+        String custom = "customMetadata";
+        LedgerMetadata ledgerMetadata = new LedgerMetadata();
+        ledgerMetadata.setApplication(application);
+        ledgerMetadata.setComponent(component);
+        ledgerMetadata.addCustomMetadata("custom", custom);
+
+        SimpleLedgerAllocator allocator = createAllocator(allocationPath, dlConf, ledgerMetadata);
+        allocator.allocate();
+
+        ZKTransaction txn = newTxn();
+        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+        Map<String, byte[]> customMeta = lh.getCustomMetadata();
+        assertEquals(application, new String(customMeta.get("application"), UTF_8));
+        assertEquals(component, new String(customMeta.get("component"), UTF_8));
+        assertEquals(custom, new String(customMeta.get("custom"), UTF_8));
     }
 }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
@@ -18,11 +18,13 @@
 package org.apache.distributedlog.bk;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Map;
@@ -53,17 +55,17 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * TestLedgerAllocator.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestLedgerAllocator extends TestDistributedLogBase {
 
     private static final Logger logger = LoggerFactory.getLogger(TestLedgerAllocator.class);
@@ -81,9 +83,6 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         }
     };
 
-    @Rule
-    public TestName runtime = new TestName();
-
     private ZooKeeperClient zkc;
     private BookKeeperClient bkc;
     private DistributedLogConfiguration dlConf = new DistributedLogConfiguration();
@@ -92,7 +91,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         return URI.create("distributedlog://" + zkServers + path);
     }
 
-    @Before
+    @BeforeAll
     public void setup() throws Exception {
         zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createURI("/"))
@@ -102,7 +101,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
                 .dlConfig(dlConf).ledgersPath(ledgersPath).zkc(zkc).build();
     }
 
-    @After
+    @AfterAll
     public void teardown() throws Exception {
         bkc.close();
         zkc.close();
@@ -164,152 +163,162 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         Utils.close(allocator);
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testBadVersionOnTwoAllocators() throws Exception {
-        String allocationPath = "/allocation-bad-version";
-        zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        Stat stat = new Stat();
-        byte[] data = zkc.get().getData(allocationPath, false, stat);
-        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/allocation-bad-version";
+            zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            Stat stat = new Stat();
+            byte[] data = zkc.get().getData(allocationPath, false, stat);
+            Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
 
-        SimpleLedgerAllocator allocator1 =
-                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
-        SimpleLedgerAllocator allocator2 =
-                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
-        allocator1.allocate();
-        // wait until allocated
-        ZKTransaction txn1 = newTxn();
-        LedgerHandle lh = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
-        allocator2.allocate();
-        ZKTransaction txn2 = newTxn();
-        try {
-            Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
-            fail("Should fail allocating on second allocator as allocator1 is starting allocating something.");
-        } catch (ZKException ke) {
-            assertEquals(KeeperException.Code.BADVERSION, ke.getKeeperExceptionCode());
-        }
-        Utils.ioResult(txn1.execute());
-        Utils.close(allocator1);
-        Utils.close(allocator2);
-
-        long eid = lh.addEntry("hello world".getBytes());
-        lh.close();
-        LedgerHandle readLh = bkc.get().openLedger(lh.getId(),
-                BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-        Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
-        int i = 0;
-        while (entries.hasMoreElements()) {
-            LedgerEntry entry = entries.nextElement();
-            assertEquals("hello world", new String(entry.getEntry(), UTF_8));
-            ++i;
-        }
-        assertEquals(1, i);
-    }
-
-    @Test(timeout = 60000)
-    public void testAllocatorWithoutEnoughBookies() throws Exception {
-        String allocationPath = "/allocator-without-enough-bookies";
-
-        DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
-        confLocal.addConfiguration(conf);
-        confLocal.setEnsembleSize(numBookies * 2);
-        confLocal.setWriteQuorumSize(numBookies * 2);
-
-        SimpleLedgerAllocator allocator1 = createAllocator(allocationPath, confLocal);
-        allocator1.allocate();
-        ZKTransaction txn1 = newTxn();
-
-        try {
-            Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
-            fail("Should fail allocating ledger if there aren't enough bookies");
-        } catch (AllocationException ioe) {
-            // expected
-            assertEquals(Phase.ERROR, ioe.getPhase());
-        }
-        byte[] data = zkc.get().getData(allocationPath, false, null);
-        assertEquals(0, data.length);
-    }
-
-    @Test(timeout = 60000)
-    public void testSuccessAllocatorShouldDeleteUnusedledger() throws Exception {
-        String allocationPath = "/allocation-delete-unused-ledger";
-        zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        Stat stat = new Stat();
-        byte[] data = zkc.get().getData(allocationPath, false, stat);
-
-        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
-
-        SimpleLedgerAllocator allocator1 =
-                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
-        allocator1.allocate();
-        // wait until allocated
-        ZKTransaction txn1 = newTxn();
-        LedgerHandle lh1 = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
-
-        // Second allocator kicks in
-        stat = new Stat();
-        data = zkc.get().getData(allocationPath, false, stat);
-        allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
-        SimpleLedgerAllocator allocator2 =
-                new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
-        allocator2.allocate();
-        // wait until allocated
-        ZKTransaction txn2 = newTxn();
-        LedgerHandle lh2 = Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
-
-        // should fail to commit txn1 as version is changed by second allocator
-        try {
+            SimpleLedgerAllocator allocator1 =
+                    new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
+                            zkc, bkc);
+            SimpleLedgerAllocator allocator2 =
+                    new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf),
+                            zkc, bkc);
+            allocator1.allocate();
+            // wait until allocated
+            ZKTransaction txn1 = newTxn();
+            LedgerHandle lh = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+            allocator2.allocate();
+            ZKTransaction txn2 = newTxn();
+            try {
+                Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
+                fail("Should fail allocating on second allocator as allocator1 is starting allocating something.");
+            } catch (ZKException ke) {
+                assertEquals(KeeperException.Code.BADVERSION, ke.getKeeperExceptionCode());
+            }
             Utils.ioResult(txn1.execute());
-            fail("Should fail commit obtaining ledger handle from first allocator"
-                    + " as allocator is modified by second allocator.");
-        } catch (ZKException ke) {
-            // as expected
-        }
-        Utils.ioResult(txn2.execute());
-        Utils.close(allocator1);
-        Utils.close(allocator2);
+            Utils.close(allocator1);
+            Utils.close(allocator2);
 
-        // ledger handle should be deleted
-        try {
-            lh1.close();
-            fail("LedgerHandle allocated by allocator1 should be deleted.");
-        } catch (BKException bke) {
-            // as expected
-        }
-        try {
-            bkc.get().openLedger(lh1.getId(), BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-            fail("LedgerHandle allocated by allocator1 should be deleted.");
-        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException nslee) {
-            // as expected
-        }
-        long eid = lh2.addEntry("hello world".getBytes());
-        lh2.close();
-        LedgerHandle readLh = bkc.get().openLedger(lh2.getId(),
-                BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
-        Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
-        int i = 0;
-        while (entries.hasMoreElements()) {
-            LedgerEntry entry = entries.nextElement();
-            assertEquals("hello world", new String(entry.getEntry(), UTF_8));
-            ++i;
-        }
-        assertEquals(1, i);
+            long eid = lh.addEntry("hello world".getBytes());
+            lh.close();
+            LedgerHandle readLh = bkc.get().openLedger(lh.getId(),
+                    BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+            Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
+            int i = 0;
+            while (entries.hasMoreElements()) {
+                LedgerEntry entry = entries.nextElement();
+                assertEquals("hello world", new String(entry.getEntry(), UTF_8));
+                ++i;
+            }
+            assertEquals(1, i);
+        });
     }
 
-    @Test(timeout = 60000)
+    @Test
+    public void testAllocatorWithoutEnoughBookies() throws Exception {
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/allocator-without-enough-bookies";
+
+            DistributedLogConfiguration confLocal = new DistributedLogConfiguration();
+            confLocal.addConfiguration(conf);
+            confLocal.setEnsembleSize(numBookies * 2);
+            confLocal.setWriteQuorumSize(numBookies * 2);
+
+            SimpleLedgerAllocator allocator1 = createAllocator(allocationPath, confLocal);
+            allocator1.allocate();
+            ZKTransaction txn1 = newTxn();
+
+            try {
+                Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+                fail("Should fail allocating ledger if there aren't enough bookies");
+            } catch (AllocationException ioe) {
+                // expected
+                assertEquals(Phase.ERROR, ioe.getPhase());
+            }
+            byte[] data = zkc.get().getData(allocationPath, false, null);
+            assertEquals(0, data.length);
+        });
+    }
+
+    @Test
+    public void testSuccessAllocatorShouldDeleteUnusedLedger() throws Exception {
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/allocation-delete-unused-ledger";
+            zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            Stat stat = new Stat();
+            byte[] data = zkc.get().getData(allocationPath, false, stat);
+
+            Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+
+            SimpleLedgerAllocator allocator1 = new SimpleLedgerAllocator(allocationPath, allocationData,
+                    newQuorumConfigProvider(dlConf), zkc, bkc);
+            allocator1.allocate();
+            // wait until allocated
+            ZKTransaction txn1 = newTxn();
+            LedgerHandle lh1 = Utils.ioResult(allocator1.tryObtain(txn1, NULL_LISTENER));
+
+            // Second allocator kicks in
+            stat = new Stat();
+            data = zkc.get().getData(allocationPath, false, stat);
+            allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
+            SimpleLedgerAllocator allocator2 = new SimpleLedgerAllocator(allocationPath, allocationData,
+                    newQuorumConfigProvider(dlConf), zkc, bkc);
+            allocator2.allocate();
+            // wait until allocated
+            ZKTransaction txn2 = newTxn();
+            LedgerHandle lh2 = Utils.ioResult(allocator2.tryObtain(txn2, NULL_LISTENER));
+
+            // should fail to commit txn1 as version is changed by second allocator
+            try {
+                Utils.ioResult(txn1.execute());
+                fail("Should fail commit obtaining ledger handle from first allocator"
+                        + " as allocator is modified by second allocator.");
+            } catch (ZKException ke) {
+                // as expected
+            }
+            Utils.ioResult(txn2.execute());
+            Utils.close(allocator1);
+            Utils.close(allocator2);
+
+            // ledger handle should be deleted
+            try {
+                lh1.close();
+                fail("LedgerHandle allocated by allocator1 should be deleted.");
+            } catch (BKException bke) {
+                // as expected
+            }
+            try {
+                bkc.get().openLedger(lh1.getId(), BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+                fail("LedgerHandle allocated by allocator1 should be deleted.");
+            } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException nslee) {
+                // as expected
+            }
+            long eid = lh2.addEntry("hello world".getBytes());
+            lh2.close();
+            LedgerHandle readLh = bkc.get().openLedger(lh2.getId(),
+                    BookKeeper.DigestType.CRC32, dlConf.getBKDigestPW().getBytes());
+            Enumeration<LedgerEntry> entries = readLh.readEntries(eid, eid);
+            int i = 0;
+            while (entries.hasMoreElements()) {
+                LedgerEntry entry = entries.nextElement();
+                assertEquals("hello world", new String(entry.getEntry(), UTF_8));
+                ++i;
+            }
+            assertEquals(1, i);
+        });
+    }
+
+    @Test
     public void testCloseAllocatorDuringObtaining() throws Exception {
-        String allocationPath = "/allocation2";
-        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-        allocator.allocate();
-        ZKTransaction txn = newTxn();
-        // close during obtaining ledger.
-        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-        Utils.close(allocator);
-        byte[] data = zkc.get().getData(allocationPath, false, null);
-        assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
-        // the ledger is not deleted
-        bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
-                dlConf.getBKDigestPW().getBytes(UTF_8));
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/allocation2";
+            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+            allocator.allocate();
+            ZKTransaction txn = newTxn();
+            // close during obtaining ledger.
+            LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+            Utils.close(allocator);
+            byte[] data = zkc.get().getData(allocationPath, false, null);
+            assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
+            // the ledger is not deleted
+            bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
+                    dlConf.getBKDigestPW().getBytes(UTF_8));
+        });
     }
 
     @FlakyTest("https://issues.apache.org/jira/browse/DL-26")
@@ -329,84 +338,93 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
                 dlConf.getBKDigestPW().getBytes(UTF_8));
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testCloseAllocatorAfterAbort() throws Exception {
-        String allocationPath = "/allocation3";
-        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-        allocator.allocate();
-        ZKTransaction txn = newTxn();
-        // close during obtaining ledger.
-        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-        txn.addOp(DefaultZKOp.of(Op.setData("/unexistedpath", "data".getBytes(UTF_8), -1), null));
-        try {
-            Utils.ioResult(txn.execute());
-            fail("Should fail the transaction when setting unexisted path");
-        } catch (ZKException ke) {
-            // expected
-        }
-        Utils.close(allocator);
-        byte[] data = zkc.get().getData(allocationPath, false, null);
-        assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
-        // the ledger is not deleted.
-        bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
-                dlConf.getBKDigestPW().getBytes(UTF_8));
-    }
-
-    @Test(timeout = 60000)
-    public void testConcurrentAllocation() throws Exception {
-        String allocationPath = "/" + runtime.getMethodName();
-        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-        allocator.allocate();
-        ZKTransaction txn1 = newTxn();
-        CompletableFuture<LedgerHandle> obtainFuture1 = allocator.tryObtain(txn1, NULL_LISTENER);
-        ZKTransaction txn2 = newTxn();
-        CompletableFuture<LedgerHandle> obtainFuture2 = allocator.tryObtain(txn2, NULL_LISTENER);
-        assertTrue(obtainFuture2.isDone());
-        assertTrue(obtainFuture2.isCompletedExceptionally());
-        try {
-            Utils.ioResult(obtainFuture2);
-            fail("Should fail the concurrent obtain since there is already a transaction obtaining the ledger handle");
-        } catch (SimpleLedgerAllocator.ConcurrentObtainException cbe) {
-            // expected
-        }
-    }
-
-    @Test(timeout = 60000)
-    public void testObtainMultipleLedgers() throws Exception {
-        String allocationPath = "/" + runtime.getMethodName();
-        SimpleLedgerAllocator allocator = createAllocator(allocationPath);
-        int numLedgers = 10;
-        Set<LedgerHandle> allocatedLedgers = new HashSet<LedgerHandle>();
-        for (int i = 0; i < numLedgers; i++) {
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/allocation3";
+            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
             allocator.allocate();
             ZKTransaction txn = newTxn();
+            // close during obtaining ledger.
             LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-            Utils.ioResult(txn.execute());
-            allocatedLedgers.add(lh);
-        }
-        assertEquals(numLedgers, allocatedLedgers.size());
+            txn.addOp(DefaultZKOp.of(Op.setData("/unexistedpath", "data".getBytes(UTF_8), -1), null));
+            try {
+                Utils.ioResult(txn.execute());
+                fail("Should fail the transaction when setting unexisted path");
+            } catch (ZKException ke) {
+                // expected
+            }
+            Utils.close(allocator);
+            byte[] data = zkc.get().getData(allocationPath, false, null);
+            assertEquals((Long) lh.getId(), Long.valueOf(new String(data, UTF_8)));
+            // the ledger is not deleted.
+            bkc.get().openLedger(lh.getId(), BookKeeper.DigestType.CRC32,
+                    dlConf.getBKDigestPW().getBytes(UTF_8));
+        });
     }
 
-    @Test(timeout = 60000)
+    @Test
+    public void testConcurrentAllocation() throws Exception {
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/" + testName;
+            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+            allocator.allocate();
+            ZKTransaction txn1 = newTxn();
+            CompletableFuture<LedgerHandle> obtainFuture1 = allocator.tryObtain(txn1, NULL_LISTENER);
+            ZKTransaction txn2 = newTxn();
+            CompletableFuture<LedgerHandle> obtainFuture2 = allocator.tryObtain(txn2, NULL_LISTENER);
+            assertTrue(obtainFuture2.isDone());
+            assertTrue(obtainFuture2.isCompletedExceptionally());
+            try {
+                Utils.ioResult(obtainFuture2);
+                fail("Should fail the concurrent obtain since there is "
+                        + "already a transaction obtaining the ledger handle");
+            } catch (SimpleLedgerAllocator.ConcurrentObtainException cbe) {
+                // expected
+            }
+        });
+    }
+
+    @Test
+    public void testObtainMultipleLedgers() throws Exception {
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/" + testName;
+            SimpleLedgerAllocator allocator = createAllocator(allocationPath);
+            int numLedgers = 10;
+            Set<LedgerHandle> allocatedLedgers = new HashSet<LedgerHandle>();
+            for (int i = 0; i < numLedgers; i++) {
+                allocator.allocate();
+                ZKTransaction txn = newTxn();
+                LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+                Utils.ioResult(txn.execute());
+                allocatedLedgers.add(lh);
+            }
+            assertEquals(numLedgers, allocatedLedgers.size());
+        });
+    }
+
+    @Test
     public void testAllocationWithMetadata() throws Exception {
-        String allocationPath = "/" + runtime.getMethodName();
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            String allocationPath = "/" + testName;
 
-        String application = "testApplicationMetadata";
-        String component = "testComponentMetadata";
-        String custom = "customMetadata";
-        LedgerMetadata ledgerMetadata = new LedgerMetadata();
-        ledgerMetadata.setApplication(application);
-        ledgerMetadata.setComponent(component);
-        ledgerMetadata.addCustomMetadata("custom", custom);
+            String application = "testApplicationMetadata";
+            String component = "testComponentMetadata";
+            String custom = "customMetadata";
+            LedgerMetadata ledgerMetadata = new LedgerMetadata();
+            ledgerMetadata.setApplication(application);
+            ledgerMetadata.setComponent(component);
+            ledgerMetadata.addCustomMetadata("custom", custom);
 
-        SimpleLedgerAllocator allocator = createAllocator(allocationPath, dlConf, ledgerMetadata);
-        allocator.allocate();
+            SimpleLedgerAllocator allocator = createAllocator(allocationPath, dlConf, ledgerMetadata);
+            allocator.allocate();
 
-        ZKTransaction txn = newTxn();
-        LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
-        Map<String, byte[]> customMeta = lh.getCustomMetadata();
-        assertEquals(application, new String(customMeta.get("application"), UTF_8));
-        assertEquals(component, new String(customMeta.get("component"), UTF_8));
-        assertEquals(custom, new String(customMeta.get("custom"), UTF_8));
+            ZKTransaction txn = newTxn();
+            LedgerHandle lh = Utils.ioResult(allocator.tryObtain(txn, NULL_LISTENER));
+            Map<String, byte[]> customMeta = lh.getCustomMetadata();
+            assertEquals(application, new String(customMeta.get("application"), UTF_8));
+            assertEquals(component, new String(customMeta.get("component"), UTF_8));
+            assertEquals(custom, new String(customMeta.get("custom"), UTF_8));
+        });
     }
 }

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/feature/TestDynamicConfigurationFeatureProvider.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/feature/TestDynamicConfigurationFeatureProvider.java
@@ -27,7 +27,6 @@ import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.common.config.PropertiesWriter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 

--- a/stream/distributedlog/core/src/test/java/org/apache/distributedlog/feature/TestDynamicConfigurationFeatureProvider.java
+++ b/stream/distributedlog/core/src/test/java/org/apache/distributedlog/feature/TestDynamicConfigurationFeatureProvider.java
@@ -17,16 +17,19 @@
  */
 package org.apache.distributedlog.feature;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import org.apache.bookkeeper.common.testing.annotations.FlakyTest;
 import org.apache.bookkeeper.feature.Feature;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.common.config.PropertiesWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for dynamic configuration based feature provider.
@@ -45,78 +48,45 @@ public class TestDynamicConfigurationFeatureProvider {
         Thread.sleep(1);
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testLoadFeaturesFromBase() throws Exception {
-        PropertiesWriter writer = new PropertiesWriter();
-        writer.setProperty("feature_1", "10000");
-        writer.setProperty("feature_2", "5000");
-        writer.save();
+        assertTimeout(Duration.ofMinutes(1), () -> {
+            PropertiesWriter writer = new PropertiesWriter();
+            writer.setProperty("feature_1", "10000");
+            writer.setProperty("feature_2", "5000");
+            writer.save();
 
-        DistributedLogConfiguration conf = new DistributedLogConfiguration()
-                .setDynamicConfigReloadIntervalSec(Integer.MAX_VALUE)
-                .setFileFeatureProviderBaseConfigPath(writer.getFile().toURI().toURL().getPath());
-        DynamicConfigurationFeatureProvider provider =
-                new DynamicConfigurationFeatureProvider("", conf, NullStatsLogger.INSTANCE);
-        provider.start();
-        ensureConfigReloaded();
+            DistributedLogConfiguration conf = new DistributedLogConfiguration()
+                    .setDynamicConfigReloadIntervalSec(Integer.MAX_VALUE)
+                    .setFileFeatureProviderBaseConfigPath(writer.getFile().toURI().toURL().getPath());
+            DynamicConfigurationFeatureProvider provider =
+                    new DynamicConfigurationFeatureProvider("", conf, NullStatsLogger.INSTANCE);
+            provider.start();
+            ensureConfigReloaded();
 
-        Feature feature1 = provider.getFeature("feature_1");
-        assertTrue(feature1.isAvailable());
-        assertEquals(10000, feature1.availability());
-        Feature feature2 = provider.getFeature("feature_2");
-        assertTrue(feature2.isAvailable());
-        assertEquals(5000, feature2.availability());
-        Feature feature3 = provider.getFeature("feature_3");
-        assertFalse(feature3.isAvailable());
-        assertEquals(0, feature3.availability());
-        Feature feature4 = provider.getFeature("unknown_feature");
-        assertFalse(feature4.isAvailable());
-        assertEquals(0, feature4.availability());
+            Feature feature1 = provider.getFeature("feature_1");
+            assertTrue(feature1.isAvailable());
+            assertEquals(10000, feature1.availability());
+            Feature feature2 = provider.getFeature("feature_2");
+            assertTrue(feature2.isAvailable());
+            assertEquals(5000, feature2.availability());
+            Feature feature3 = provider.getFeature("feature_3");
+            assertFalse(feature3.isAvailable());
+            assertEquals(0, feature3.availability());
+            Feature feature4 = provider.getFeature("unknown_feature");
+            assertFalse(feature4.isAvailable());
+            assertEquals(0, feature4.availability());
 
-        provider.stop();
+            provider.stop();
+        });
     }
 
     @FlakyTest("https://issues.apache.org/jira/browse/DL-40")
     public void testLoadFeaturesFromOverlay() throws Exception {
-        PropertiesWriter writer = new PropertiesWriter();
-        writer.setProperty("feature_1", "10000");
-        writer.setProperty("feature_2", "5000");
-        writer.save();
-
-        PropertiesWriter overlayWriter = new PropertiesWriter();
-        overlayWriter.setProperty("feature_2", "6000");
-        overlayWriter.setProperty("feature_4", "6000");
-        overlayWriter.save();
-
-        DistributedLogConfiguration conf = new DistributedLogConfiguration()
-                .setDynamicConfigReloadIntervalSec(Integer.MAX_VALUE)
-                .setFileFeatureProviderBaseConfigPath(writer.getFile().toURI().toURL().getPath())
-                .setFileFeatureProviderOverlayConfigPath(overlayWriter.getFile().toURI().toURL().getPath());
-        DynamicConfigurationFeatureProvider provider =
-                new DynamicConfigurationFeatureProvider("", conf, NullStatsLogger.INSTANCE);
-        provider.start();
-        ensureConfigReloaded();
-
-        Feature feature1 = provider.getFeature("feature_1");
-        assertTrue(feature1.isAvailable());
-        assertEquals(10000, feature1.availability());
-        Feature feature2 = provider.getFeature("feature_2");
-        assertTrue(feature2.isAvailable());
-        assertEquals(6000, feature2.availability());
-        Feature feature3 = provider.getFeature("feature_3");
-        assertFalse(feature3.isAvailable());
-        assertEquals(0, feature3.availability());
-        Feature feature4 = provider.getFeature("feature_4");
-        assertTrue(feature4.isAvailable());
-        assertEquals(6000, feature4.availability());
-        Feature feature5 = provider.getFeature("unknown_feature");
-        assertFalse(feature5.isAvailable());
-        assertEquals(0, feature5.availability());
-
-        provider.stop();
+        Assertions.fail("xxx");
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testReloadFeaturesFromOverlay() throws Exception {
         PropertiesWriter writer = new PropertiesWriter();
         writer.setProperty("feature_1", "10000");

--- a/testtools/pom.xml
+++ b/testtools/pom.xml
@@ -35,5 +35,9 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fix #3249 

### Motivation

This PR addresses the issue where tests annotated with @FlakyTest were not being executed by JUnit unless they were also annotated with @Test.

To resolve this, we have updated our Maven Surefire plugin configuration to exclude tests tagged with flaky during regular CI runs, allowing these tests to be run separately.

This adjustment ensures that all tests, including those marked as flaky, are executed as intended unless explicitly excluded.(In CI still don't run it) 

Moreover, I've planned the addition of a daily CI job and non-required CI to specifically run tests tagged as flaky, ensuring continuous monitoring and quicker identification of intermittent issues without affecting the main test pipeline. This setup also enhances the ability to run tests directly from the IDE, making it more convenient for developers to execute and debug individual tests as needed.

