### PR TITLE
Add vertx-grpc to dependencyManagement to get rid of CVE-2024-8391

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,11 @@
         <artifactId>failsafe</artifactId>
         <version>${failsafe.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-grpc</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
 
       <!-- override otel's okhttp 4.11.0 for now, wait for otel update -->
       <dependency>


### PR DESCRIPTION
### Motivation

Related to https://github.com/apache/bookkeeper/pull/4545

The `OWASP Dependency Check` job failed with the following errors.
```
Run mvn -q -B -ntp clean install verify -Powasp-dependency-check -DskipTests -pl '!stream/distributedlog/io/dlfs,!tests'
Error:  Failed to execute goal org.owasp:dependency-check-maven:10.0.2:aggregate (default) on project bookkeeper: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  vertx-grpc-4.5.1.jar: CVE-2024-8391(7.5)
...
```
https://github.com/apache/bookkeeper/actions/runs/12851240827/job/35831830711?pr=4533

```
% mvn dependency:tree
...
[INFO] ------< org.apache.bookkeeper.metadata.drivers:jetcd-core-shaded >------
[INFO] Building Apache BookKeeper :: Metadata Drivers:: jetcd-core shaded 4.18.0-SNAPSHOT [56/93]
[INFO]   from metadata-drivers/jetcd-core-shaded/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.6.1:tree (default-cli) @ jetcd-core-shaded ---
[INFO] org.apache.bookkeeper.metadata.drivers:jetcd-core-shaded:jar:4.18.0-SNAPSHOT
[INFO] +- io.etcd:jetcd-core:jar:0.7.7:compile
[INFO] |  +- io.etcd:jetcd-grpc:jar:0.7.7:compile
[INFO] |  |  \- io.vertx:vertx-grpc:jar:4.5.1:compile
[INFO] |  |     \- io.vertx:vertx-core:jar:4.5.11:compile
...
```

### Changes

* Add `io.vertx:vertx-grpc` to dependencyManagement