### PR TITLE
Reduce metadataLock contention in LedgerHandle

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -1852,19 +1852,24 @@ public class LedgerHandle implements WriteHandle {
     }
 
     void maybeHandleDelayedWriteBookieFailure() {
+        Map<Integer, BookieId> toReplace = null;
         synchronized (metadataLock) {
             if (delayedWriteFailedBookies.isEmpty()) {
                 return;
             }
-            Map<Integer, BookieId> toReplace = new HashMap<>(delayedWriteFailedBookies);
+            toReplace = new HashMap<>(delayedWriteFailedBookies);
             delayedWriteFailedBookies.clear();
-
-            // Original intent of this change is to do a best-effort ensemble change.
-            // But this is not possible until the local metadata is completely immutable.
-            // Until the feature "Make LedgerMetadata Immutable #610" Is complete we will use
-            // handleBookieFailure() to handle delayed writes as regular bookie failures.
-            handleBookieFailure(toReplace);
         }
+
+        if (toReplace.isEmpty()) {
+            return;
+        }
+
+        // Original intent of this change is to do a best-effort ensemble change.
+        // But this is not possible until the local metadata is completely immutable.
+        // Until the feature "Make LedgerMetadata Immutable #610" Is complete we will use
+        // handleBookieFailure() to handle delayed writes as regular bookie failures.
+        handleBookieFailure(toReplace);
     }
 
     void handleBookieFailure(final Map<Integer, BookieId> failedBookies) {
@@ -1982,12 +1987,12 @@ public class LedgerHandle implements WriteHandle {
 
                         List<BookieId> newEnsemble = null;
                         Set<Integer> replaced = null;
+
+                        Map<Integer, BookieId> toReplace = null;
                         synchronized (metadataLock) {
                             if (!delayedWriteFailedBookies.isEmpty()) {
-                                Map<Integer, BookieId> toReplace = new HashMap<>(delayedWriteFailedBookies);
+                                toReplace = new HashMap<>(delayedWriteFailedBookies);
                                 delayedWriteFailedBookies.clear();
-
-                                ensembleChangeLoop(origEnsemble, toReplace);
                             } else {
                                 newEnsemble = getCurrentEnsemble();
                                 replaced = EnsembleUtils.diffEnsemble(origEnsemble, newEnsemble);
@@ -1996,6 +2001,11 @@ public class LedgerHandle implements WriteHandle {
                                 changingEnsemble = false;
                             }
                         }
+
+                        if (toReplace != null && !toReplace.isEmpty()) {
+                            ensembleChangeLoop(origEnsemble, toReplace);
+                        }
+
                         if (newEnsemble != null) { // unsetSuccess outside of lock
                             unsetSuccessAndSendWriteRequest(newEnsemble, replaced);
                         }


### PR DESCRIPTION
Descriptions of the changes in this PR:

<!-- Either this PR fixes an issue, -->

Fix #4517

### Motivation

we can move changeEnsembleLoop out side the metadataLock because the changing ensemble field can be a guard for do the action and the callback will trigger next.

### Changes

(Describe: what changes you have made)

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
