### PR TITLE
[fix] Write stuck due to pending add callback by multiple threads

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -411,7 +411,9 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
                                       PerChannelBookieClient pcbc) {
             try {
                 if (rc != BKException.Code.OK) {
-                    bookieClient.completeAdd(rc, ledgerId, entryId, addr, cb, ctx);
+                    bookieClient.executor.executeOrdered(ledgerId, () -> {
+                        bookieClient.completeAdd(rc, ledgerId, entryId, addr, cb, ctx);
+                    });
                 } else {
                     pcbc.addEntry(ledgerId, masterKey, entryId,
                             toSend, cb, ctx, options, allowFastFail, writeFlags);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieClientImpl.java
@@ -22,6 +22,7 @@ package org.apache.bookkeeper.proto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ExtensionRegistry;
 import io.netty.buffer.ByteBuf;
@@ -370,7 +371,9 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         }
     }
 
-    private static class ChannelReadyForAddEntryCallback
+    // Without test, this class should be modifier with "private".
+    @VisibleForTesting
+    static class ChannelReadyForAddEntryCallback
         implements GenericCallback<PerChannelBookieClient> {
         private final Handle<ChannelReadyForAddEntryCallback> recyclerHandle;
 
@@ -380,7 +383,9 @@ public class BookieClientImpl implements BookieClient, PerChannelBookieClientFac
         private long entryId;
         private BookieId addr;
         private Object ctx;
-        private WriteCallback cb;
+        // Without test, this class should be modifier with "private".
+        @VisibleForTesting
+        WriteCallback cb;
         private int options;
         private byte[] masterKey;
         private boolean allowFastFail;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -616,9 +616,13 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
         }
 
         ChannelFuture future = bootstrap.connect(bookieAddr);
-        future.addListener(contextPreservingListener(new ConnectionFutureListener(startTime)));
-        future.addListener(x -> makeWritable());
+        addChannelListeners(future, startTime);
         return future;
+    }
+
+    protected void addChannelListeners(ChannelFuture future, long connectStartTime) {
+        future.addListener(contextPreservingListener(new ConnectionFutureListener(connectStartTime)));
+        future.addListener(x -> makeWritable());
     }
 
     void cleanDisconnectAndClose() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ClientSocketDisconnectTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ClientSocketDisconnectTest.java
@@ -1,0 +1,144 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.proto;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.BookKeeper;
+import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.tls.SecurityException;
+import org.apache.bookkeeper.util.EventLoopUtil;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ClientSocketDisconnectTest extends BookKeeperClusterTestCase {
+
+    public ClientSocketDisconnectTest() {
+        super(1);
+        this.useUUIDasBookieId = true;
+    }
+
+    public static class PerChannelBookieClientDecorator extends PerChannelBookieClient {
+
+        private final ThreadCounter threadCounter;
+        private final AtomicInteger failurePredicate = new AtomicInteger();
+
+        public PerChannelBookieClientDecorator(PerChannelBookieClient client, BookieId addr, ThreadCounter tCounter)
+                throws SecurityException {
+            super(client.executor, client.eventLoopGroup, addr, client.bookieAddressResolver);
+            this.threadCounter = tCounter;
+        }
+
+        // Inject a disconnection per two connections.
+        protected void addChannelListeners(ChannelFuture future, long connectStartTime) {
+            future.addListener((ChannelFutureListener) future1 -> {
+                if (failurePredicate.incrementAndGet() % 2 == 1) {
+                    future1.channel().close();
+                }
+            });
+            super.addChannelListeners(future, connectStartTime);
+        }
+
+        // Records the thread who running "PendingAddOp.writeComplete".
+        @Override
+        protected void connectIfNeededAndDoOp(BookkeeperInternalCallbacks.GenericCallback<PerChannelBookieClient> op) {
+            BookieClientImpl.ChannelReadyForAddEntryCallback callback =
+                    (BookieClientImpl.ChannelReadyForAddEntryCallback) op;
+            BookkeeperInternalCallbacks.WriteCallback originalCallback = callback.cb;
+            callback.cb = (rc, ledgerId, entryId, addr, ctx) -> {
+                threadCounter.record();
+                originalCallback.writeComplete(rc, ledgerId, entryId, addr, ctx);
+            };
+            super.connectIfNeededAndDoOp(op);
+        }
+    }
+
+    private static class ThreadCounter {
+
+        private final Map<Thread, AtomicInteger> records = new ConcurrentHashMap<>();
+
+        public void record() {
+            Thread currentThread = Thread.currentThread();
+            records.computeIfAbsent(currentThread, k -> new AtomicInteger());
+            records.get(currentThread).incrementAndGet();
+        }
+    }
+
+    @Test
+    public void testAddEntriesCallbackWithBKClientThread() throws Exception {
+        // Create BKC and a ledger handle.
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+        org.apache.bookkeeper.client.BookKeeper bkc =
+                (org.apache.bookkeeper.client.BookKeeper) BookKeeper.newBuilder(conf)
+                .eventLoopGroup(
+                        EventLoopUtil.getClientEventLoopGroup(conf, new DefaultThreadFactory("test-io")))
+                .build();
+        final BookieClientImpl bookieClient = (BookieClientImpl) bkc.getClientCtx().getBookieClient();
+        LedgerHandle lh = (LedgerHandle) bkc.newCreateLedgerOp()
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withDigestType(DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .execute().join();
+
+        // Inject two operations.
+        // 1. Inject a disconnection when connecting successfully.
+        // 2. Records the thread who running "PendingAddOp.writeComplete".
+        final ThreadCounter callbackThreadRecorder = new ThreadCounter();
+        List<BookieId> ensemble = lh.getLedgerMetadata()
+                .getAllEnsembles().entrySet().iterator().next().getValue();
+        DefaultPerChannelBookieClientPool clientPool =
+                (DefaultPerChannelBookieClientPool) bookieClient.lookupClient(ensemble.get(0));
+        PerChannelBookieClient[] clients = clientPool.clients;
+
+        // Write 100 entries and wait for finishing.
+        for (int i = 0; i < clients.length; i++) {
+            clients[i] = new PerChannelBookieClientDecorator(clients[i], ensemble.get(0), callbackThreadRecorder);
+        }
+        int addCount = 1000;
+        CountDownLatch countDownLatch = new CountDownLatch(addCount);
+        for (int i = 0; i < addCount; i++) {
+            lh.asyncAddEntry(new byte[]{1}, (rc, lh1, entryId, ctx) -> {
+                countDownLatch.countDown();
+            }, i);
+        }
+        countDownLatch.await();
+
+        // Verify: all callback will run in the "BookKeeperClientWorker" thread.
+        for (Thread callbackThread : callbackThreadRecorder.records.keySet()) {
+            Assert.assertTrue(callbackThread.getName(), callbackThread.getName().startsWith("BookKeeperClientWorker"));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

**Background: the normal steps of adding an entry**
- Gains BKC's IO thread
- Triggers the callback after gaining the IO thread
  - Write data to servers
- Triggers `PendingAddOp.writeComplete` after receiving the response from BK servers.
- Triggers all succeed callbacks in the pending queue

**Background: the steps of disconnection**
- Gains BKC's IO thread
- Triggers a failed callback after gaining the IO thread
  - Triggers a failed `PendingAddOp.writeComplete`. You can reproduce this flow by the new test `testAddEntriesCallbackWithBKClientThread`
  - **(Highlight)** If the writing is already complete, this process will also trigger all successful callbacks in the pending queue even if the current writing is failed<sup>[code-1]</sup>

---

**Issue-1: write stuck due to pending add callback by multiple threads**
- Settings
  - Ensembles: `3`
  - WriteQuoram: `3`
  - AckQuoram: `2`


| steps | write entries | `client->BK1` | `client->BK2` | `client-> BK3`|
| --- | --- | --- | --- | --- |
| 1 | write BKs | 
| 2 | | start writing | start writing | start writing |
| 3 | | write success<br> `ack`: `1/3` | write success<br> `ack`: `2/3` | |
| 4 | mark the writing as `complete` since ack quorum is `2/3` |
| 5 | | | | connected and disconnected |
| 6 | | | | Triggers a failed `PendingAddOp.writeComplete` |
| 8 | | | `thread`: `bookkeeper workers` |  `thread`: `client-server io` |
| 7 | | | Trigger all succeed callbacks in the pending queue |  Trigger all succeed callbacks in the pending queue<sup>[code-1]</sup> |

Since there are multiple threads that will trigger all successful callbacks in the pending queue, it may cause the following race condition<sup>[code-2]</sup>
  - BTW, the `thread-1` and `thread-2` may be triggered by different `PendingAddOps`

| steps | `thread-1` | `thread-2` |
| --- | --- | --- |
| 1 | peek pending addOp from the queue | peek pending addOp from the queue |
| 2 | check it is the first item: `success`|  check it is the first item: `success`|
| 3 | call `queue.pop` | call `queue.pop`|
| 4 | | Issue: the second OP will never get a callback triggering|


**[1] code link**: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java#L307

```java
// PendingAddOp.writeComplete
public synchronized void writeComplete(int rc, long ledgerId, long entryId, BookieId addr, Object ctx) {
        if (completed) {
            sendAddSuccessCallbacks();
            maybeRecycle();
            return;
}
```

**[2] code-link**: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L2092-L2124

```java
    // LedgerHandle.sendAddSuccessCallbacks
    void sendAddSuccessCallbacks() {
        while ((pendingAddOp = pendingAddOps.peek()) != null && !changingEnsemble) {
            if (!pendingAddOp.completed) {
                return;
            }
            pendingAddOps.remove();
            explicitLacFlushPolicy.updatePiggyBackedLac(lastAddConfirmed);
            pendingAddsSequenceHead = pendingAddOp.entryId;
            pendingAddOp.submitCallback(BKException.Code.OK);
        }
    }

```

---

**Issue-2: ledger will be closed with a incorrect length**

Since the task that triggers all successful callbacks in the pending queue may be run in `IO` thread, the task "triggers all successful callbacks in the pending queue" and closing ledger may concurrectly execute

| steps | `worker-thread` | `io-thread` |
| --- | --- | --- |
| 1 | start closing ledger | peek pending addOp from the queue |
| 2 |  |  check it is the first item: `success`|
| 3 | drain pending adds<sup>[code-3]</sup> |
| 4 | reduce `ledger.length` which was popped out from the queue<sup>[code-3]</sup> | |
| 5 | | call `queue.pop` and pop nothing|
| 6 | | update `ledger.LAC` |

The variables `ledger.LAC` and `ledger.length` do not match

**[3] code-link**: https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L2076-L2084

```java
    synchronized List<PendingAddOp> drainPendingAddsAndAdjustLength() {
        PendingAddOp pendingAddOp;
        List<PendingAddOp> opsDrained = new ArrayList<PendingAddOp>(pendingAddOps.size());
        while ((pendingAddOp = pendingAddOps.poll()) != null) {
            addToLength(-pendingAddOp.entryLength);
            opsDrained.add(pendingAddOp);
        }
        return opsDrained;
    }
```

---

**The issue we encountered**

A pulsar topic is stuck at `ClosingLedger` state

**pulsar topic stats**
```json
{
  "entriesAddedCounter" : 12485917,
  "numberOfEntries" : 126383,
  "totalSize" : 53668291,
  "currentLedgerEntries" : 137418,
  "currentLedgerSize" : 58374388,
  "lastLedgerCreatedTimestamp" : "2025-02-06T09:13:45.371Z",
  "waitingCursorsCount" : 1,
  "pendingAddEntriesCount" : 8342123,
  "lastConfirmedEntry" : "41901:126416",
  "state" : "ClosingLedger",
  "ledgers" : [ {
    "ledgerId" : 41901,
    "entries" : 0,
    "size" : 0,
    "offloaded" : false,
    "underReplicated" : false
  } ],
  "cursors" : {
...
```

**logs**
```
2025-02-06T09:14:06,421+0000 [BookKeeperClientWorker-OrderedExecutor-2-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (41901, 126417) to bookie (2, bookie-0:3181): Bookie handle is not available"
2025-02-06T09:14:06,421+0000 [BookKeeperClientWorker-OrderedExecutor-2-0] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (41901, 126412) to bookie (2, bookie-0:3181): Bookie handle is not available"
2025-02-06T09:14:06,421+0000 [pulsar-io-3-5] INFO  org.apache.bookkeeper.proto.PerChannelBookieClient - Successfully connected to bookie: bookie-0:3181 [id: 0xbc663b9b, L:/10.247.4.112:59578 - R:bookie-0/10.247.4.38:3181]"
2025-02-06T09:14:06,421+0000 [pulsar-io-3-5] INFO  org.apache.bookkeeper.proto.PerChannelBookieClient - connection [id: 0xbc663b9b, L:/10.247.4.112:59578 - R:bookie-0/10.247.4.38:3181] authenticated as BookKeeperPrincipal{ANONYMOUS}"
2025-02-06T09:14:06,423+0000 [BookKeeperClientWorker-OrderedExecutor-2-0] INFO  org.apache.bookkeeper.client.LedgerHandle - New Ensemble: [bookie-3:3181, bookie-2:3181, bookie-1:3181] for ledger: 41901"
2025-02-06T09:14:06,423+0000 [pulsar-io-3-5] WARN  org.apache.bookkeeper.proto.PerChannelBookieClient - Exception caught on:[id: 0xbc663b9b, L:/10.247.4.112:59578 - R:bookie-0/10.247.4.38:3181] cause: recvAddress(..) failed: Connection reset by peer"
2025-02-06T09:14:06,423+0000 [pulsar-io-3-5] INFO  org.apache.bookkeeper.proto.PerChannelBookieClient - Disconnected from bookie channel [id: 0xbc663b9b, L:/10.247.4.112:59578 ! R:bookie-0/10.247.4.38:3181]"
2025-02-06T09:14:06,423+0000 [pulsar-io-3-6] WARN  org.apache.bookkeeper.mledger.impl.OpAddEntry - [{topic}] The add op is terminal legacy callback for entry 41901-126416 adding."
2025-02-06T09:14:06,423+0000 [pulsar-io-3-6] WARN  org.apache.bookkeeper.client.PendingAddOp - Failed to write entry (41901, 126426) to bookie (2, bookie-1:3181): Bookie handle is not available"
2025-02-06T09:14:06,423+0000 [BookKeeperClientWorker-OrderedExecutor-3-0] WARN  org.apache.bookkeeper.client.BookieWatcherImpl - replaceBookie for bookie: bookie-1:3181 in ensemble: [bookie-3:3181, bookie-2:3181, bookie-1:3181] is not adhering to placement policy and chose bookie-0:3181. excludedBookies [bookie-1:3181] and quarantinedBookies [bookie-2:3181]"
```


### Changes

Switch the thread to `Bookkeeper works` if the connection is broken.