### PR TITLE
Ensure that formatVersion is specified for all RocksDB databases

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -182,6 +182,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
         Options options = new Options();
         options.setCreateIfMissing(true);
         ChecksumType checksumType = ChecksumType.valueOf(conf.getString(ROCKSDB_CHECKSUM_TYPE, "kxxHash"));
+        int formatVersion = conf.getInt(ROCKSDB_FORMAT_VERSION, 5);
 
         if (dbConfigType == DbConfigType.EntryLocation) {
             /* Set default RocksDB block-cache size to 10% / numberOfLedgers of direct memory, unless override */
@@ -198,7 +199,6 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
             int blockSize = conf.getInt(ROCKSDB_BLOCK_SIZE, 64 * 1024);
             int bloomFilterBitsPerKey = conf.getInt(ROCKSDB_BLOOM_FILTERS_BITS_PER_KEY, 10);
             boolean lz4CompressionEnabled = conf.getBoolean(ROCKSDB_LZ4_COMPRESSION_ENABLED, true);
-            int formatVersion = conf.getInt(ROCKSDB_FORMAT_VERSION, 5);
 
             if (lz4CompressionEnabled) {
                 options.setCompressionType(CompressionType.LZ4_COMPRESSION);
@@ -235,6 +235,7 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
         } else {
             this.cache = null;
             BlockBasedTableConfig tableOptions = new BlockBasedTableConfig();
+            tableOptions.setFormatVersion(formatVersion);
             tableOptions.setChecksumType(checksumType);
             options.setTableFormatConfig(tableOptions);
         }


### PR DESCRIPTION
### Motivation

Related to upgrading RocksDB to 9.x, #4422. Downgrading isn't possible if databases aren't created with a specified formatVersion that previous versions support.

### Changes

Set formatVersion to 5 for all RocksDB databases configured with Java code in BookKeeper.