### PR TITLE
Add documentation to bk_server.conf about RocksDB config

### DIFF
--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -758,17 +758,31 @@ gcEntryLogMetadataCacheEnabled=false
 # How many entries to pre-fill in cache after a read cache miss
 # dbStorage_readAheadCacheBatchSize=100
 
+#############################################################################
 ## RocksDB specific configurations
+#############################################################################
 ## DbLedgerStorage uses RocksDB to store the indexes from
-## (ledgerId, entryId) -> (entryLog, offset)
-
+## (ledgerId, entryId) -> (entryLog, offset). This is called the entry location database.
+## There's also a separate RocksDB database to to store the ledger metadata.
+#
+# RocksDB configuration can be applied in two ways: by using a configuration file
+# or by setting individual properties.
+#
+# Most individual properties are applied only to the entry location database.
+# To fine-tune the ledger metadata database, the configuration file method should be used.
+#
+# These properties apply to both entry location and ledger metadata databases
+#############################################################################
+# dbStorage_rocksDB_format_version=5
+# dbStorage_rocksDB_checksum_type=kxxHash
+#############################################################################
+# Entry location RocksDB database specific configurations:
 # Size of RocksDB block-cache. For best performance, this cache
 # should be big enough to hold a significant portion of the index
 # database which can reach ~2GB in some cases
 # Default is to use 10% / numberOfLedgers of the direct memory size
 # dbStorage_rocksDB_blockCacheSize=
-
-# Other RocksDB specific tunables
+# Other RocksDB specific tunables for the entry location database
 # dbStorage_rocksDB_writeBufferSizeMB=64
 # dbStorage_rocksDB_sstSizeInMB=64
 # dbStorage_rocksDB_blockSize=65536
@@ -777,7 +791,12 @@ gcEntryLogMetadataCacheEnabled=false
 # dbStorage_rocksDB_numFilesInLevel0=4
 # dbStorage_rocksDB_maxSizeInLevel1MB=256
 # dbStorage_rocksDB_logPath=
-# dbStorage_rocksDB_format_version=5
+#############################################################################
+# Alternative RocksDB configuration by using configuration files.
+#############################################################################
+# entryLocationRocksdbConf=conf/entry_location_rocksdb.conf
+# ledgerMetadataRocksdbConf=conf/ledger_metadata_rocksdb.conf
+# defaultRocksdbConf=conf/default_rocksdb.conf
 
 #############################################################################
 ## DirectIO entry logger configuration


### PR DESCRIPTION
### Motivation

RocksDB config for the file based configuration alternative has been missing from bk_server.conf

### Changes

- Add comments and missing keys to bk_server.conf

This depends on #4559 so that `dbStorage_rocksDB_format_version` would apply to all RocksDB databases.