### PR TITLE
Change the new ensemble log to info level

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookieWatcherImpl.java
@@ -273,7 +273,7 @@ class BookieWatcherImpl implements BookieWatcher {
             if (isEnsembleAdheringToPlacementPolicy == PlacementPolicyAdherence.FAIL) {
                 ensembleNotAdheringToPlacementPolicy.inc();
                 if (ensembleSize > 1) {
-                    log.warn("New ensemble: {} is not adhering to Placement Policy. quarantinedBookies: {}",
+                    log.info("New ensemble: {} is not adhering to Placement Policy. quarantinedBookies: {}",
                             socketAddresses, quarantinedBookiesSet);
                 }
             }
@@ -289,7 +289,7 @@ class BookieWatcherImpl implements BookieWatcher {
             isEnsembleAdheringToPlacementPolicy = newEnsembleResponse.getAdheringToPolicy();
             if (isEnsembleAdheringToPlacementPolicy == PlacementPolicyAdherence.FAIL) {
                 ensembleNotAdheringToPlacementPolicy.inc();
-                log.warn("New ensemble: {} is not adhering to Placement Policy", socketAddresses);
+                log.info("New ensemble: {} is not adhering to Placement Policy", socketAddresses);
             }
             newEnsembleTimer.registerFailedEvent(MathUtils.nowInNano() - startTime, TimeUnit.NANOSECONDS);
         }


### PR DESCRIPTION
---

### Motivation

Change the new ensemble log to the info level. Sometimes, the ensemble may not satisfied with the placement policy. The log should be info level but not a warn level. Because it will fix by the auto recovery later, so this just a information from the ensemble choose.

