### PR TITLE
Bump dependency-check to 12.1.0 to fix OWASP Check job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
+    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
### Motivation

The CI Job `OWASP Dependency Check` has failed consistently since [last month][failed-ci-job], below are the error details:
```
Error:  Unable to continue dependency-check analysis.
Error:  Failed to execute goal org.owasp:dependency-check-maven:10.0.2:aggregate (default) on project bookkeeper: Fatal exception(s) analyzing Apache BookKeeper :: Parent: One or more exceptions occurred during analysis:
Error:  	UpdateException: Error updating the NVD Data
Error:  		caused by NvdApiException: Failed to parse NVD data
Error:  		caused by ValueInstantiationException: Cannot construct instance of `io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data$ModifiedCiaType`, problem: SAFETY
Error:   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 3052240] (through reference chain: io.github.jeremylong.openvulnerability.client.nvd.CveApiJson20["vulnerabilities"]->java.util.ArrayList[1471]->io.github.jeremylong.openvulnerability.client.nvd.DefCveItem["cve"]->io.github.jeremylong.openvulnerability.client.nvd.CveItem["metrics"]->io.github.jeremylong.openvulnerability.client.nvd.Metrics["cvssMetricV40"]->java.util.ArrayList[0]->io.github.jeremylong.openvulnerability.client.nvd.CvssV4["cvssData"]->io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data["modifiedSubsequentSystemIntegrity"])
Error:  		caused by IllegalArgumentException: SAFETY
Error:  	NoDataException: No documents exist
Error:  -> [Help 1]
```

According to `dependency-check` Mandatory Upgrade [Notice](https://github.com/dependency-check/DependencyCheck/issues/7463):
```
Due to compatibility issues with the NVD API - all users must upgrade to 12.1.0 or later.
```

This patch is to do so.

[failed-ci-job]: https://github.com/apache/bookkeeper/actions/runs/13349834218/job/37284861261