### PR TITLE
[website]: Update .asf.yaml to add "publish" configuration block

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -80,6 +80,9 @@ github:
     branch-4.15: {}
     branch-4.16: {}
 
+publish:
+  whoami: asf-site
+
 notifications:
   commits:      commits@bookkeeper.apache.org
   issues:       commits@bookkeeper.apache.org


### PR DESCRIPTION
Branch asf-site contains all the website content, but sometimes the website source checker is not reference to the latest version. 

At present(Apr 8, 2025), the latest commit of asf-site is [76edded](https://github.com/apache/bookkeeper/commit/76edded8a783d4dd76367c8ac3ed2f1973c39c17), 
<img width="911" alt="image" src="https://github.com/user-attachments/assets/bf68c5e3-23c5-4e85-866b-177e08111efc" />

but the website [asf site source checker](https://infra-reports.apache.org/#sitesource) referenced to previous (Feb 11, 2025) commit [8a3a8c2ee](https://github.com/apache/bookkeeper/commit/8a3a8c2eeba29b3003980be5f21b40c9150d6ae6)

<img width="959" alt="image" src="https://github.com/user-attachments/assets/d29224ad-81dc-48a3-a783-c678a0ed006f" />

According the instruction of [asf infra doc](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features), we need to add the publish configuration block to make sure the asf-site branch published well. 
`
Note: although publishing the asf-site branch used to work without .asf.yaml being present, since May 2021 that file MUST be present at the root of the branch you wish to publish. for everything (including soft purging the CDN cache on updates) to work correctly.
`
