### PR TITLE
#4574: fix sanity check asyncBatchReadEntries 

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -754,10 +754,10 @@ public class LedgerHandle implements WriteHandle {
      */
     public void asyncBatchReadEntries(long startEntry, int maxCount, long maxSize, ReadCallback cb, Object ctx) {
         // Little sanity check
-        if (startEntry > lastAddConfirmed) {
-            LOG.error("ReadEntries exception on ledgerId:{} firstEntry:{} lastAddConfirmed:{}",
+        if (startEntry < 0 || startEntry > lastAddConfirmed) {
+            LOG.error("IncorrectParameterException on ledgerId:{} startEntry:{} lastAddConfirmed:{}",
                     ledgerId, startEntry, lastAddConfirmed);
-            cb.readComplete(BKException.Code.ReadException, this, null, ctx);
+            cb.readComplete(BKException.Code.IncorrectParameterException, this, null, ctx);
             return;
         }
         if (notSupportBatchRead()) {


### PR DESCRIPTION
Fix:  #4574

### Motivation

The little sanity check in the method asyncBatchReadEntries in LedgerHandle does not check if the entrId is equal to or grater 
 to zero.

### Changes

The method validates the input only for `startEntry > lastAddConfirmed`. This fix makes it compliant to the other reader methods and validates the input like this `startEntry < 0 || startEntry > lastAddConfirmed`.