### PR TITLE
Fix the coredump that occurs when calling KeyValueStorageRocksDB.count after rocksdb has been closed

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageFactory.DbConfigType;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.commons.lang3.StringUtils;
@@ -524,12 +523,14 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     @Override
     public long count() throws IOException {
         try {
-            if (closed)
+            if (closed) {
                 throw new IOException("RocksDB is closed");
+            }
             try {
                 closedLock.readLock().lock();
-                if (!closed)
+                if (!closed) {
                     return db.getLongProperty("rocksdb.estimate-num-keys");
+                }
                 throw new IOException("RocksDB is closed");
             } finally {
                 closedLock.readLock().unlock();


### PR DESCRIPTION
Descriptions of the changes in this PR:


### Motivation

Fix https://github.com/apache/bookkeeper/issues/4238

### Changes

Add a boolean status check before KeyValueStorageRocksDB.count()
