### PR TITLE
Upgrade Apache Commons libraries to compatible versions

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -211,10 +211,10 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-cli-commons-cli-1.2.jar [5]
-- lib/commons-codec-commons-codec-1.6.jar [6]
+- lib/commons-cli-commons-cli-1.9.0.jar [5]
+- lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-configuration-commons-configuration-1.10.jar [7]
-- lib/commons-io-commons-io-2.17.0.jar [8]
+- lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
 - lib/io.netty-netty-buffer-4.1.115.Final.jar [11]
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
-- lib/org.apache.commons-commons-lang3-3.6.jar [20]
+- lib/org.apache.commons-commons-lang3-3.17.0.jar [58]
 - lib/org.apache.zookeeper-zookeeper-3.9.3.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.3.jar [21]
 - lib/org.apache.zookeeper-zookeeper-3.9.3-tests.jar [21]
@@ -361,10 +361,10 @@ Apache Software License, Version 2.
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
-[5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
-[6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2
+[5] Source available at https://github.com/apache/commons-cli/tree/rel/commons-cli-1.9.0
+[6] Source available at https://github.com/apache/commons-codec/tree/rel/commons-codec-1.18.0
 [7] Source available at https://github.com/apache/commons-configuration/tree/CONFIGURATION_1_10
-[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.17.0
+[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.115.Final
@@ -409,6 +409,7 @@ Apache Software License, Version 2.
 [55] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.8.21
 [57] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
+[58] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.115.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -211,10 +211,10 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-cli-commons-cli-1.2.jar [5]
-- lib/commons-codec-commons-codec-1.6.jar [6]
+- lib/commons-cli-commons-cli-1.9.0.jar [5]
+- lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-configuration-commons-configuration-1.10.jar [7]
-- lib/commons-io-commons-io-2.17.0.jar [8]
+- lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
 - lib/io.netty-netty-buffer-4.1.115.Final.jar [11]
@@ -241,7 +241,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [16]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
-- lib/org.apache.commons-commons-lang3-3.6.jar [19]
+- lib/org.apache.commons-commons-lang3-3.17.0.jar [55]
 - lib/org.apache.zookeeper-zookeeper-3.9.3.jar [20]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.3.jar [20]
 - lib/org.apache.zookeeper-zookeeper-3.9.3-tests.jar [20]
@@ -316,10 +316,10 @@ Apache Software License, Version 2.
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
-[5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
-[6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2
+[5] Source available at https://github.com/apache/commons-cli/tree/rel/commons-cli-1.9.0
+[6] Source available at https://github.com/apache/commons-codec/tree/rel/commons-codec-1.18.0
 [7] Source available at https://github.com/apache/commons-configuration/tree/CONFIGURATION_1_10
-[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.17.0
+[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.115.Final
@@ -353,7 +353,7 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
-
+[55] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.115.Final.jar bundles some 3rd party dependencies
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -211,10 +211,10 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-cli-commons-cli-1.2.jar [5]
-- lib/commons-codec-commons-codec-1.6.jar [6]
+- lib/commons-cli-commons-cli-1.9.0.jar [5]
+- lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-configuration-commons-configuration-1.10.jar [7]
-- lib/commons-io-commons-io-2.17.0.jar [8]
+- lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.1.1.jar [10]
 - lib/io.netty-netty-buffer-4.1.115.Final.jar [11]
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [17]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
-- lib/org.apache.commons-commons-lang3-3.6.jar [20]
+- lib/org.apache.commons-commons-lang3-3.17.0.jar [57]
 - lib/org.apache.zookeeper-zookeeper-3.9.3.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.3.jar [21]
 - lib/org.apache.zookeeper-zookeeper-3.9.3-tests.jar [21]
@@ -357,10 +357,10 @@ Apache Software License, Version 2.
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1
 [3] Source available at https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.17.1
 [4] Source available at https://github.com/google/guava/tree/v32.0.1
-[5] Source available at https://github.com/apache/commons-cli/tree/cli-1.2
-[6] Source available at https://github.com/apache/commons-codec/tree/commons-codec-1.6-RC2
+[5] Source available at https://github.com/apache/commons-cli/tree/rel/commons-cli-1.9.0
+[6] Source available at https://github.com/apache/commons-codec/tree/rel/commons-codec-1.18.0
 [7] Source available at https://github.com/apache/commons-configuration/tree/CONFIGURATION_1_10
-[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.17.0
+[8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.1.1
 [11] Source available at https://github.com/netty/netty/tree/netty-4.1.115.Final
@@ -404,6 +404,7 @@ Apache Software License, Version 2.
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v1.8.21
 [56] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
+[57] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
 
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.115.Final.jar bundles some 3rd party dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -120,14 +120,14 @@
     <arquillian-junit.version>1.8.0.Final</arquillian-junit.version>
     <bc-non-fips.version>1.78</bc-non-fips.version>
     <codahale.metrics.version>3.0.1</codahale.metrics.version>
-    <commons-cli.version>1.2</commons-cli.version>
+    <commons-cli.version>1.9.0</commons-cli.version>
     <commons-collections4.version>4.1</commons-collections4.version>
-    <commons-codec.version>1.6</commons-codec.version>
+    <commons-codec.version>1.18.0</commons-codec.version>
     <commons-configuration.version>1.10</commons-configuration.version>
-    <commons-compress.version>1.26.0</commons-compress.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-lang3.version>3.6</commons-lang3.version>
-    <commons-io.version>2.17.0</commons-io.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-io.version>2.19.0</commons-io.version>
     <bouncycastle.version>1.0.2.5</bouncycastle.version>
     <curator.version>5.7.1</curator.version>
     <disruptor.version>4.0.0</disruptor.version>


### PR DESCRIPTION
### Motivation

While working on #4580, I noticed that the Commons Compress version and the Commons Codec library version aren't compatible. It causes a ClassDefNotFoundError in running tests which were using some specific methods of docker-java.
While exploring this, I noticed that Apache Commons library versions haven't been kept up-to-date for a long time and it's better to handle that for 4.18.0 release.

### Changes

- upgrade commons-cli from 1.2 to 1.9.0
- upgrade commons-codec from 1.6 to 1.18.0
- upgrade commons-io from 2.17.0 to 2.19.0
- upgrade commons-lang3 from 3.6 to 3.17.0
- upgrade commons-compress from 1.26.0 to 1.27.0