### PR TITLE
improve: Resolve hostname only when useHostNameAsBookieID is enabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -267,15 +267,15 @@ public class BookieImpl implements Bookie {
             iface = "default";
         }
 
-        String hostName = DNS.getDefaultHost(iface);
-        InetSocketAddress inetAddr = new InetSocketAddress(hostName, conf.getBookiePort());
-        if (inetAddr.isUnresolved()) {
-            throw new UnknownHostException("Unable to resolve default hostname: "
-                    + hostName + " for interface: " + iface);
-        }
-        String hostAddress = null;
-        InetAddress iAddress = inetAddr.getAddress();
+        String hostAddress;
         if (conf.getUseHostNameAsBookieID()) {
+            String hostName = DNS.getDefaultHost(iface);
+            InetSocketAddress inetAddr = new InetSocketAddress(hostName, conf.getBookiePort());
+            if (inetAddr.isUnresolved()) {
+                throw new UnknownHostException("Unable to resolve default hostname: "
+                        + hostName + " for interface: " + iface);
+            }
+            InetAddress iAddress = inetAddr.getAddress();
             hostAddress = iAddress.getCanonicalHostName();
             if (conf.getUseShortHostName()) {
                 /*
@@ -285,7 +285,7 @@ public class BookieImpl implements Bookie {
                 hostAddress = hostAddress.split("\\.", 2)[0];
             }
         } else {
-            hostAddress = iAddress.getHostAddress();
+            hostAddress = DNS.getDefaultIP(iface);
         }
 
         BookieSocketAddress addr =


### PR DESCRIPTION
### Motivation

The existing implementation always resolves the default hostname for the specified network interface, even when `useHostNameAsBookieID` is disabled. This is unnecessary and can introduce resolution failures or delays in environments where DNS is misconfigured or unavailable.

Restricting hostname resolution to only when `useHostNameAsBookieID` is enabled improves efficiency and avoids potential issues related to unnecessary hostname lookups.


### Changes

- Moved hostname resolution logic under the `useHostNameAsBookieID` condition.

- When `useHostNameAsBookieID` is false, the code now directly uses `DNS.getDefaultIP(iface)` to obtain the IP address.