### PR TITLE
improve: Improve host address resolution logic for bookie id

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -24,7 +24,6 @@ package org.apache.bookkeeper.bookie;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.JOURNAL_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_INDEX_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_LEDGER_SCOPE;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -37,7 +36,6 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.file.FileStore;
@@ -269,13 +267,7 @@ public class BookieImpl implements Bookie {
 
         String hostAddress = DNS.getDefaultIP(iface);
         if (conf.getUseHostNameAsBookieID()) {
-            InetSocketAddress inetAddr = new InetSocketAddress(hostAddress, conf.getBookiePort());
-            if (inetAddr.isUnresolved()) {
-                throw new UnknownHostException("Unable to resolve default hostaddress: "
-                        + hostAddress + " for interface: " + iface);
-            }
-            InetAddress iAddress = inetAddr.getAddress();
-            hostAddress = iAddress.getCanonicalHostName();
+            hostAddress = InetAddress.getByName(hostAddress).getCanonicalHostName();
             if (conf.getUseShortHostName()) {
                 /*
                  * if short hostname is used, then FQDN is not used. Short

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -268,7 +268,14 @@ public class BookieImpl implements Bookie {
 
         String hostAddress = DNS.getDefaultIP(iface);
         if (conf.getUseHostNameAsBookieID()) {
-            hostAddress = InetAddress.getByName(hostAddress).getCanonicalHostName();
+            try {
+                hostAddress = InetAddress.getByName(hostAddress).getCanonicalHostName();
+            } catch (Exception e) {
+                UnknownHostException unknownHostException =
+                        new UnknownHostException("Unable to resolve hostname for interface: " + iface);
+                unknownHostException.initCause(e);
+                throw unknownHostException;
+            }
             if (conf.getUseShortHostName()) {
                 /*
                  * if short hostname is used, then FQDN is not used. Short

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -24,6 +24,7 @@ package org.apache.bookkeeper.bookie;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.JOURNAL_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_INDEX_SCOPE;
 import static org.apache.bookkeeper.bookie.BookKeeperServerStats.LD_LEDGER_SCOPE;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -267,15 +267,14 @@ public class BookieImpl implements Bookie {
             iface = "default";
         }
 
-        String hostName = DNS.getDefaultHost(iface);
-        InetSocketAddress inetAddr = new InetSocketAddress(hostName, conf.getBookiePort());
-        if (inetAddr.isUnresolved()) {
-            throw new UnknownHostException("Unable to resolve default hostname: "
-                    + hostName + " for interface: " + iface);
-        }
-        String hostAddress = null;
-        InetAddress iAddress = inetAddr.getAddress();
+        String hostAddress = DNS.getDefaultIP(iface);
         if (conf.getUseHostNameAsBookieID()) {
+            InetSocketAddress inetAddr = new InetSocketAddress(hostAddress, conf.getBookiePort());
+            if (inetAddr.isUnresolved()) {
+                throw new UnknownHostException("Unable to resolve default hostaddress: "
+                        + hostAddress + " for interface: " + iface);
+            }
+            InetAddress iAddress = inetAddr.getAddress();
             hostAddress = iAddress.getCanonicalHostName();
             if (conf.getUseShortHostName()) {
                 /*
@@ -284,8 +283,6 @@ public class BookieImpl implements Bookie {
                  */
                 hostAddress = hostAddress.split("\\.", 2)[0];
             }
-        } else {
-            hostAddress = iAddress.getHostAddress();
         }
 
         BookieSocketAddress addr =


### PR DESCRIPTION

### Motivation

The existing implementation resolves the default hostname for the network interface early, even when it's not required. This can lead to unnecessary DNS resolution or even failures in environments where hostname mappings are missing or incomplete.

The goal is to simplify and make host address resolution more robust by:

- Using the default IP address as the starting point.
- Performing reverse DNS lookup (IP → hostname) only when `useHostNameAsBookieID` is enabled.
- Avoiding unnecessary dependency on hostname resolution when IP-based Bookie IDs are sufficient.


### Changes

- Replaced `DNS.getDefaultHost(iface)` with `DNS.getDefaultIP(iface)` as the default starting point.
- Introduced conditional logic to resolve the hostname from the IP only when `useHostNameAsBookieID` is true.
- Simplified code structure and reduced redundant resolution steps.