### PR TITLE
Upgrade to grpc 1.72.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -276,29 +276,29 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.48.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [28]
 - lib/com.google.code.gson-gson-2.11.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
-- lib/io.grpc-grpc-all-1.70.0.jar [33]
-- lib/io.grpc-grpc-alts-1.70.0.jar [33]
-- lib/io.grpc-grpc-api-1.70.0.jar [33]
-- lib/io.grpc-grpc-auth-1.70.0.jar [33]
-- lib/io.grpc-grpc-context-1.70.0.jar [33]
-- lib/io.grpc-grpc-core-1.70.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.70.0.jar [33]
-- lib/io.grpc-grpc-inprocess-1.70.0.jar [33]
-- lib/io.grpc-grpc-opentelemetry-1.70.0.jar [33]
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.70.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar [33]
-- lib/io.grpc-grpc-services-1.70.0.jar [33]
-- lib/io.grpc-grpc-stub-1.70.0.jar [33]
-- lib/io.grpc-grpc-testing-1.70.0.jar [33]
-- lib/io.grpc-grpc-util-1.70.0.jar [33]
-- lib/io.grpc-grpc-xds-1.70.0.jar [33]
-- lib/io.grpc-grpc-rls-1.70.0.jar[33]
-- lib/io.grpc-grpc-gcp-csm-observability-1.70.0.jar [33]
+- lib/io.grpc-grpc-all-1.72.0.jar [33]
+- lib/io.grpc-grpc-alts-1.72.0.jar [33]
+- lib/io.grpc-grpc-api-1.72.0.jar [33]
+- lib/io.grpc-grpc-auth-1.72.0.jar [33]
+- lib/io.grpc-grpc-context-1.72.0.jar [33]
+- lib/io.grpc-grpc-core-1.72.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.72.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.72.0.jar [33]
+- lib/io.grpc-grpc-opentelemetry-1.72.0.jar [33]
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.72.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar [33]
+- lib/io.grpc-grpc-services-1.72.0.jar [33]
+- lib/io.grpc-grpc-stub-1.72.0.jar [33]
+- lib/io.grpc-grpc-testing-1.72.0.jar [33]
+- lib/io.grpc-grpc-util-1.72.0.jar [33]
+- lib/io.grpc-grpc-xds-1.72.0.jar [33]
+- lib/io.grpc-grpc-rls-1.72.0.jar[33]
+- lib/io.grpc-grpc-gcp-csm-observability-1.72.0.jar [33]
 - lib/org.apache.curator-curator-client-5.7.1.jar [34]
 - lib/org.apache.curator-curator-framework-5.7.1.jar [34]
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [34]
@@ -313,7 +313,7 @@ Apache Software License, Version 2.
 - lib/com.google.http-client-google-http-client-gson-1.44.2.jar [43]
 - lib/com.google.auto.value-auto-value-annotations-1.11.0.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
-- lib/com.google.re2j-re2j-1.7.jar [46]
+- lib/com.google.re2j-re2j-1.8.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar [47]
 - lib/io.dropwizard.metrics-metrics-jmx-4.1.12.1.jar [47]
@@ -386,10 +386,10 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.48.0
+[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.70.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.72.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.7.1
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -401,7 +401,7 @@ Apache Software License, Version 2.
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
 [44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
+[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.8
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.27.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -247,29 +247,29 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-3.9.3-tests.jar [20]
 - lib/com.beust-jcommander-1.82.jar [23]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
-- lib/com.google.api.grpc-proto-google-common-protos-2.48.0.jar [27]
+- lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [27]
 - lib/com.google.code.gson-gson-2.11.0.jar [28]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [29]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [29]
-- lib/io.grpc-grpc-all-1.70.0.jar [32]
-- lib/io.grpc-grpc-alts-1.70.0.jar [32]
-- lib/io.grpc-grpc-api-1.70.0.jar [32]
-- lib/io.grpc-grpc-auth-1.70.0.jar [32]
-- lib/io.grpc-grpc-context-1.70.0.jar [32]
-- lib/io.grpc-grpc-core-1.70.0.jar [32]
-- lib/io.grpc-grpc-grpclb-1.70.0.jar [32]
-- lib/io.grpc-grpc-inprocess-1.70.0.jar [32]
-- lib/io.grpc-grpc-opentelemetry-1.70.0.jar [32]
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar [32]
-- lib/io.grpc-grpc-protobuf-1.70.0.jar [32]
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar [32]
-- lib/io.grpc-grpc-services-1.70.0.jar [32]
-- lib/io.grpc-grpc-stub-1.70.0.jar [32]
-- lib/io.grpc-grpc-testing-1.70.0.jar [32]
-- lib/io.grpc-grpc-util-1.70.0.jar [32]
-- lib/io.grpc-grpc-xds-1.70.0.jar [32]
-- lib/io.grpc-grpc-rls-1.70.0.jar[32]
-- lib/io.grpc-grpc-gcp-csm-observability-1.70.0.jar [32]
+- lib/io.grpc-grpc-all-1.72.0.jar [32]
+- lib/io.grpc-grpc-alts-1.72.0.jar [32]
+- lib/io.grpc-grpc-api-1.72.0.jar [32]
+- lib/io.grpc-grpc-auth-1.72.0.jar [32]
+- lib/io.grpc-grpc-context-1.72.0.jar [32]
+- lib/io.grpc-grpc-core-1.72.0.jar [32]
+- lib/io.grpc-grpc-grpclb-1.72.0.jar [32]
+- lib/io.grpc-grpc-inprocess-1.72.0.jar [32]
+- lib/io.grpc-grpc-opentelemetry-1.72.0.jar [32]
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar [32]
+- lib/io.grpc-grpc-protobuf-1.72.0.jar [32]
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar [32]
+- lib/io.grpc-grpc-services-1.72.0.jar [32]
+- lib/io.grpc-grpc-stub-1.72.0.jar [32]
+- lib/io.grpc-grpc-testing-1.72.0.jar [32]
+- lib/io.grpc-grpc-util-1.72.0.jar [32]
+- lib/io.grpc-grpc-xds-1.72.0.jar [32]
+- lib/io.grpc-grpc-rls-1.72.0.jar[32]
+- lib/io.grpc-grpc-gcp-csm-observability-1.72.0.jar [32]
 - lib/org.apache.curator-curator-client-5.7.1.jar [33]
 - lib/org.apache.curator-curator-framework-5.7.1.jar [33]
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [33]
@@ -284,7 +284,7 @@ Apache Software License, Version 2.
 - lib/com.google.http-client-google-http-client-1.44.2.jar [43]
 - lib/com.google.http-client-google-http-client-gson-1.44.2.jar [43]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [44]
-- lib/com.google.re2j-re2j-1.7.jar [45]
+- lib/com.google.re2j-re2j-1.8.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
 - lib/io.perfmark-perfmark-api-0.27.0.jar [47]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar [49]
@@ -325,10 +325,10 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [23] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.48.0
+[27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[32] Source available at https://github.com/grpc/grpc-java/tree/v1.70.0
+[32] Source available at https://github.com/grpc/grpc-java/tree/v1.72.0
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.7.1
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -340,7 +340,7 @@ Apache Software License, Version 2.
 [42] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
 [44] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
+[45] Source available at https://github.com/google/re2j/releases/tag/re2j-1.8
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [47] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.27.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -276,29 +276,29 @@ Apache Software License, Version 2.
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
 - lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
-- lib/com.google.api.grpc-proto-google-common-protos-2.48.0.jar [28]
+- lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [28]
 - lib/com.google.code.gson-gson-2.11.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
 - lib/io.opencensus-opencensus-contrib-http-util-0.31.1.jar [30]
-- lib/io.grpc-grpc-all-1.70.0.jar [33]
-- lib/io.grpc-grpc-alts-1.70.0.jar [33]
-- lib/io.grpc-grpc-api-1.70.0.jar [33]
-- lib/io.grpc-grpc-auth-1.70.0.jar [33]
-- lib/io.grpc-grpc-context-1.70.0.jar [33]
-- lib/io.grpc-grpc-core-1.70.0.jar [33]
-- lib/io.grpc-grpc-grpclb-1.70.0.jar [33]
-- lib/io.grpc-grpc-inprocess-1.70.0.jar [33]
-- lib/io.grpc-grpc-opentelemetry-1.70.0.jar [33]
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar [33]
-- lib/io.grpc-grpc-protobuf-1.70.0.jar [33]
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar [33]
-- lib/io.grpc-grpc-services-1.70.0.jar [33]
-- lib/io.grpc-grpc-stub-1.70.0.jar [33]
-- lib/io.grpc-grpc-testing-1.70.0.jar [33]
-- lib/io.grpc-grpc-util-1.70.0.jar [33]
-- lib/io.grpc-grpc-xds-1.70.0.jar [33]
-- lib/io.grpc-grpc-rls-1.70.0.jar[33]
-- lib/io.grpc-grpc-gcp-csm-observability-1.70.0.jar [33]
+- lib/io.grpc-grpc-all-1.72.0.jar [33]
+- lib/io.grpc-grpc-alts-1.72.0.jar [33]
+- lib/io.grpc-grpc-api-1.72.0.jar [33]
+- lib/io.grpc-grpc-auth-1.72.0.jar [33]
+- lib/io.grpc-grpc-context-1.72.0.jar [33]
+- lib/io.grpc-grpc-core-1.72.0.jar [33]
+- lib/io.grpc-grpc-grpclb-1.72.0.jar [33]
+- lib/io.grpc-grpc-inprocess-1.72.0.jar [33]
+- lib/io.grpc-grpc-opentelemetry-1.72.0.jar [33]
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar [33]
+- lib/io.grpc-grpc-protobuf-1.72.0.jar [33]
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar [33]
+- lib/io.grpc-grpc-services-1.72.0.jar [33]
+- lib/io.grpc-grpc-stub-1.72.0.jar [33]
+- lib/io.grpc-grpc-testing-1.72.0.jar [33]
+- lib/io.grpc-grpc-util-1.72.0.jar [33]
+- lib/io.grpc-grpc-xds-1.72.0.jar [33]
+- lib/io.grpc-grpc-rls-1.72.0.jar[33]
+- lib/io.grpc-grpc-gcp-csm-observability-1.72.0.jar [33]
 - lib/org.apache.curator-curator-client-5.7.1.jar [34]
 - lib/org.apache.curator-curator-framework-5.7.1.jar [34]
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [34]
@@ -313,7 +313,7 @@ Apache Software License, Version 2.
 - lib/com.google.http-client-google-http-client-gson-1.44.2.jar [43]
 - lib/com.google.auto.value-auto-value-annotations-1.11.0.jar [44]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
-- lib/com.google.re2j-re2j-1.7.jar [46]
+- lib/com.google.re2j-re2j-1.8.jar [46]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
 - lib/io.perfmark-perfmark-api-0.27.0.jar [48]
 - lib/org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar [49]
@@ -382,10 +382,10 @@ Apache Software License, Version 2.
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
 [26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
-[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.48.0
+[28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
-[33] Source available at https://github.com/grpc/grpc-java/tree/v1.70.0
+[33] Source available at https://github.com/grpc/grpc-java/tree/v1.72.0
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.7.1
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
@@ -397,7 +397,7 @@ Apache Software License, Version 2.
 [43] Source available at https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3
 [44] Source available at https://github.com/google/auto/releases/tag/auto-value-1.10.4
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
-[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.7
+[46] Source available at https://github.com/google/re2j/releases/tag/re2j-1.8
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1
 [48] Source available at https://github.com/perfmark/perfmark/releases/tag/v0.27.0
 [49] Source available at https://github.com/google/conscrypt/releases/tag/2.5.2

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -135,15 +135,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.70.0.jar
-- lib/io.grpc-grpc-auth-1.70.0.jar
-- lib/io.grpc-grpc-context-1.70.0.jar
-- lib/io.grpc-grpc-core-1.70.0.jar
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar
-- lib/io.grpc-grpc-stub-1.70.0.jar
-- lib/io.grpc-grpc-testing-1.70.0.jar
+- lib/io.grpc-grpc-all-1.72.0.jar
+- lib/io.grpc-grpc-auth-1.72.0.jar
+- lib/io.grpc-grpc-context-1.72.0.jar
+- lib/io.grpc-grpc-core-1.72.0.jar
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar
+- lib/io.grpc-grpc-stub-1.72.0.jar
+- lib/io.grpc-grpc-testing-1.72.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -53,15 +53,15 @@ under the License.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.70.0.jar
-- lib/io.grpc-grpc-auth-1.70.0.jar
-- lib/io.grpc-grpc-context-1.70.0.jar
-- lib/io.grpc-grpc-core-1.70.0.jar
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar
-- lib/io.grpc-grpc-stub-1.70.0.jar
-- lib/io.grpc-grpc-testing-1.70.0.jar
+- lib/io.grpc-grpc-all-1.72.0.jar
+- lib/io.grpc-grpc-auth-1.72.0.jar
+- lib/io.grpc-grpc-context-1.72.0.jar
+- lib/io.grpc-grpc-core-1.72.0.jar
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar
+- lib/io.grpc-grpc-stub-1.72.0.jar
+- lib/io.grpc-grpc-testing-1.72.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -117,15 +117,15 @@ granted provided that the copyright notice appears in all copies.
 Copyright 2010 Cedric Beust cedric@beust.com
 
 ------------------------------------------------------------------------------------
-- lib/io.grpc-grpc-all-1.70.0.jar
-- lib/io.grpc-grpc-auth-1.70.0.jar
-- lib/io.grpc-grpc-context-1.70.0.jar
-- lib/io.grpc-grpc-core-1.70.0.jar
-- lib/io.grpc-grpc-netty-shaded-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-1.70.0.jar
-- lib/io.grpc-grpc-protobuf-lite-1.70.0.jar
-- lib/io.grpc-grpc-stub-1.70.0.jar
-- lib/io.grpc-grpc-testing-1.70.0.jar
+- lib/io.grpc-grpc-all-1.72.0.jar
+- lib/io.grpc-grpc-auth-1.72.0.jar
+- lib/io.grpc-grpc-context-1.72.0.jar
+- lib/io.grpc-grpc-core-1.72.0.jar
+- lib/io.grpc-grpc-netty-shaded-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-1.72.0.jar
+- lib/io.grpc-grpc-protobuf-lite-1.72.0.jar
+- lib/io.grpc-grpc-stub-1.72.0.jar
+- lib/io.grpc-grpc-testing-1.72.0.jar
 
 Copyright 2014, gRPC Authors All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <freebuilder.version>2.8.0</freebuilder.version>
     <google.code.version>3.0.2</google.code.version>
     <google.errorprone.version>2.9.0</google.errorprone.version>
-    <grpc.version>1.70.0</grpc.version>
+    <grpc.version>1.72.0</grpc.version>
     <guava.version>32.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
     <hadoop.version>3.3.5</hadoop.version>


### PR DESCRIPTION
### Motivation

Before next 4.18.x and 4.17.x releases, it would be useful to have grpc upgraded to latest version.
- [1.72.0 release notes](https://github.com/grpc/grpc-java/releases/tag/v1.72.0)
- [1.71.0 release notes](https://github.com/grpc/grpc-java/releases/tag/v1.71.0)

### Changes

- Upgrade grpc from 1.70.0 to 1.72.0