### PR TITLE
refactor: Eliminate redundant cleanup logic in entry log extraction

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -559,7 +559,7 @@ public class GarbageCollectorThread implements Runnable {
     /**
      * Garbage collect those entry loggers which are not associated with any active ledgers.
      */
-    private void doGcEntryLogs() throws EntryLogMetadataMapException {
+    protected void doGcEntryLogs() throws EntryLogMetadataMapException {
         // Get a cumulative count, don't update until complete
         AtomicLong activeEntryLogSizeAcc = new AtomicLong(0L);
         AtomicLong totalEntryLogSizeAcc = new AtomicLong(0L);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -200,6 +200,7 @@ public class GarbageCollectorThreadTest {
         // all ledgers exist, nothing should disappear
         final EntryLogMetadataMap entryLogMetaMap = gcThread.getEntryLogMetaMap();
         gcThread.extractMetaFromEntryLogs();
+        gcThread.doGcEntryLogs();
 
         assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1, logId2));
         assertTrue(entryLogMetaMap.containsKey(logId1));
@@ -210,6 +211,7 @@ public class GarbageCollectorThreadTest {
         entryLogMetaMap.clear();
         storage.deleteLedger(2L);
         gcThread.extractMetaFromEntryLogs();
+        gcThread.doGcEntryLogs();
 
         assertThat(entryLogger.getFlushedLogIds(), containsInAnyOrder(logId1));
         assertTrue(entryLogMetaMap.containsKey(logId1));
@@ -220,6 +222,7 @@ public class GarbageCollectorThreadTest {
         storage.deleteLedger(1L);
         storage.deleteLedger(3L);
         gcThread.extractMetaFromEntryLogs();
+        gcThread.doGcEntryLogs();
 
         assertThat(entryLogger.getFlushedLogIds(), empty());
         assertTrue(entryLogMetaMap.isEmpty());
@@ -233,6 +236,7 @@ public class GarbageCollectorThreadTest {
 
         entryLogMetaMap.clear();
         gcThread.extractMetaFromEntryLogs();
+        gcThread.doGcEntryLogs();
 
         assertThat(entryLogger.getFlushedLogIds(), empty());
         assertTrue(entryLogMetaMap.isEmpty());


### PR DESCRIPTION
### Motivation

The purpose of `extractMetaFromEntryLogs` is to extract metadata, not perform garbage collection. The logic for removing entry logs with no active ledgers is handled separately in `doGcEntryLogs()`. 

### Changes

This change removes the redundant cleanup code from `extractMetaFromEntryLogs` to better separate concerns and avoid duplication.