### PR TITLE
Delete outdated TODO for Issue #458

### DIFF
--- a/deploy/kubernetes/gke/bookkeeper.statefulset.yml
+++ b/deploy/kubernetes/gke/bookkeeper.statefulset.yml
@@ -39,7 +39,6 @@ data:
     BK_ledgerDirectories: "/bookkeeper/data/ledgers"
     BK_indexDirectories: "/bookkeeper/data/ledgers"
     BK_zkServers: zookeeper
-    # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
     #BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
     # use hostname as bookie id for StatefulSets deployment
     BK_useHostNameAsBookieID: "true"

--- a/deploy/kubernetes/gke/bookkeeper.yaml
+++ b/deploy/kubernetes/gke/bookkeeper.yaml
@@ -30,7 +30,6 @@ data:
     BK_ledgerDirectories: "/bookkeeper/data/ledgers"
     BK_indexDirectories: "/bookkeeper/data/ledgers"
     BK_zkServers: zookeeper
-    # TODO: Issue 458: https://github.com/apache/bookkeeper/issues/458
     #BK_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 ---
 


### PR DESCRIPTION
Main Issue: https://github.com/apache/bookkeeper/issues/458

### Motivation
The  https://github.com/apache/bookkeeper/issues/458 is completed. The TODO comment is no longer necessary now.

- Avoids confusion for users maintaining Helm charts or deployment templates.
- Removes redundant comments that imply unresolved technical debt.

### Changes

PR removes a stale TODO comment  related to [Issue #458](https://github.com/apache/bookkeeper/issues/458)