### PR TITLE
Optimize ListActiveLedgersCommand

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -160,11 +160,12 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
       if (entryLogMetadata.getRemainingSize() == 0){
         LOG.info("No active ledgers on log file {}", logId);
       } else {
-        LOG.info("entryLogId: {}, remaining size: {}, total size: {}, usage: {}",
-                entryLogMetadata.getEntryLogId(), entryLogMetadata.getRemainingSize(), entryLogMetadata.getTotalSize(), entryLogMetadata.getUsage());
+        LOG.info("entryLogId: {}, remaining size: {}, total size: {}, usage: {}", entryLogMetadata.getEntryLogId(),
+                entryLogMetadata.getRemainingSize(), entryLogMetadata.getTotalSize(), entryLogMetadata.getUsage());
       }
       entryLogMetadata.getLedgersMap().forEach((ledgerId, size) -> {
-        LOG.info("--------- Lid={}, TotalSizeOfEntriesOfLedger={}  ---------", ledgerIdFormatter.formatLedgerId(ledgerId), size);
+        LOG.info("--------- Lid={}, TotalSizeOfEntriesOfLedger={}  ---------",
+                ledgerIdFormatter.formatLedgerId(ledgerId), size);
       });
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommand.java
@@ -155,7 +155,7 @@ public class ListActiveLedgersCommand extends BookieCommand<ActiveLedgerFlags>{
       });
     }
 
-    public void printActiveLedgerOnEntryLog(long logId, EntryLogMetadata entryLogMetadata) {
+    private void printActiveLedgerOnEntryLog(long logId, EntryLogMetadata entryLogMetadata) {
       LOG.info("Print active ledgers of entrylog {} ({}.log)", logId, Long.toHexString(logId));
       if (entryLogMetadata.getRemainingSize() == 0){
         LOG.info("No active ledgers on log file {}", logId);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLogMetadataCommand.java
@@ -131,8 +131,7 @@ public class ReadLogMetadataCommand extends BookieCommand<ReadLogMetadataFlags> 
         LOG.info("Print entryLogMetadata of entrylog {} ({}.log)", logId, Long.toHexString(logId));
         initEntryLogger(conf);
         EntryLogMetadata entryLogMetadata = entryLogger.getEntryLogMetadata(logId);
-        LOG.info("entryLogId: {}, remaining size: {}, total size: {}, usage: {}", entryLogMetadata.getEntryLogId(),
-                entryLogMetadata.getRemainingSize(), entryLogMetadata.getTotalSize(), entryLogMetadata.getUsage());
+        LOG.info("entryLogId: {}, total size: {}", entryLogMetadata.getEntryLogId(), entryLogMetadata.getTotalSize());
 
         entryLogMetadata.getLedgersMap().forEach((ledgerId, size) -> {
             LOG.info("--------- Lid={}, TotalSizeOfEntriesOfLedger={}  ---------",

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommandTest.java
@@ -71,8 +71,8 @@ public class ListActiveLedgersCommandTest extends BookieCommandTestBase {
             AsyncCallback.VoidCallback callback = invocation.getArgument(1);
             callback.processResult(BKException.Code.OK, "", null);
             return true;
-        }).when(ledgerManager).asyncProcessLedgers(any(BookkeeperInternalCallbacks.Processor.class), any(AsyncCallback.VoidCallback.class),
-                any(), anyInt(), anyInt());
+        }).when(ledgerManager).asyncProcessLedgers(any(BookkeeperInternalCallbacks.Processor.class),
+                any(AsyncCallback.VoidCallback.class), any(), anyInt(), anyInt());
 
         entryLogMetadata = createEntryLogMeta();
         mockConstruction(ReadOnlyDefaultEntryLogger.class, (entryLogger, context) ->  {
@@ -82,7 +82,7 @@ public class ListActiveLedgersCommandTest extends BookieCommandTestBase {
 
     @Test
     public void testCommand() {
-        ListActiveLedgersCommand command = new ListActiveLedgersCommand();;
+        ListActiveLedgersCommand command = new ListActiveLedgersCommand();
         Assert.assertTrue(command.apply(bkFlags, new String[] {"-l", "0", "-t", "1000000"}));
 
         EntryLogMetadata entryLogMetadataToPrint = createEntryLogMeta();

--- a/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommandTest.java
+++ b/tools/ledger/src/test/java/org/apache/bookkeeper/tools/cli/commands/bookie/ListActiveLedgersCommandTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.tools.cli.commands.bookie;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.bookkeeper.bookie.EntryLogMetadata;
+import org.apache.bookkeeper.bookie.ReadOnlyDefaultEntryLogger;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.tools.cli.helpers.BookieCommandTestBase;
+import org.apache.bookkeeper.util.LedgerIdFormatter;
+import org.apache.zookeeper.AsyncCallback;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ListActiveLedgersCommand}.
+ */
+public class ListActiveLedgersCommandTest extends BookieCommandTestBase {
+    private EntryLogMetadata entryLogMetadata;
+
+    public ListActiveLedgersCommandTest() {
+        super(3, 3);
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        mockServerConfigurationConstruction();
+
+        LedgerManagerFactory mFactory = mock(LedgerManagerFactory.class);
+        mockMetadataDriversWithLedgerManagerFactory(mFactory);
+
+        mockStatic(LedgerIdFormatter.class)
+                .when(() -> LedgerIdFormatter.newLedgerIdFormatter(any()))
+                .thenReturn(new LedgerIdFormatter.LongLedgerIdFormatter());
+
+        LedgerManager ledgerManager = mock(LedgerManager.class);
+        when(mFactory.newLedgerManager()).thenReturn(ledgerManager);
+
+        doAnswer(invocation -> {
+            BookkeeperInternalCallbacks.Processor<Long> processor = invocation.getArgument(0);
+            AsyncCallback.VoidCallback cb = mock(AsyncCallback.VoidCallback.class);
+            processor.process(101L, cb); // only legerId-101 on metadata
+
+            AsyncCallback.VoidCallback callback = invocation.getArgument(1);
+            callback.processResult(BKException.Code.OK, "", null);
+            return true;
+        }).when(ledgerManager).asyncProcessLedgers(any(BookkeeperInternalCallbacks.Processor.class), any(AsyncCallback.VoidCallback.class),
+                any(), anyInt(), anyInt());
+
+        entryLogMetadata = createEntryLogMeta();
+        mockConstruction(ReadOnlyDefaultEntryLogger.class, (entryLogger, context) ->  {
+            when(entryLogger.getEntryLogMetadata(anyLong())).thenReturn(entryLogMetadata);
+        });
+    }
+
+    @Test
+    public void testCommand() {
+        ListActiveLedgersCommand command = new ListActiveLedgersCommand();;
+        Assert.assertTrue(command.apply(bkFlags, new String[] {"-l", "0", "-t", "1000000"}));
+
+        EntryLogMetadata entryLogMetadataToPrint = createEntryLogMeta();
+        entryLogMetadataToPrint.removeLedgerIf(lId -> lId == 100L);
+
+        Assert.assertEquals(entryLogMetadataToPrint.getTotalSize(), entryLogMetadata.getTotalSize());
+        Assert.assertEquals(entryLogMetadataToPrint.getRemainingSize(), entryLogMetadata.getRemainingSize());
+        Assert.assertEquals(entryLogMetadataToPrint.getUsage(), entryLogMetadata.getUsage(), 0.0);
+    }
+
+    private EntryLogMetadata createEntryLogMeta() {
+        EntryLogMetadata entryLogMetadata = new EntryLogMetadata(0);
+        entryLogMetadata.addLedgerSize(100, 10);
+        entryLogMetadata.addLedgerSize(101, 20);
+        return entryLogMetadata;
+    }
+}


### PR DESCRIPTION
### Motivation

1. Optimze `bookkeepr shell activeledgers` . 
Currently  `activeledgers` only print the ledger id of the active ledgers.  if we want to know the size of the active ledgers in then entry log, we need caculate manually.   

In this PR,  we will  also print the active ledgers and the usage of the entrylog.

2.  No more print usage of the entrylog in `bookkeepr shell readlogmetadata`, because the usage will always be `1.0` which is a false result.

3. Examples after optimization
* ` bin/bookkeeper shell activeledgers `

before:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/6ea1bdc7-1d25-4654-8fd6-c8f00cc610a5" />
after:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/d91dcd56-a6cd-47c2-9996-d940d9dff014" />

* ` bin/bookkeeper shell readlogmetadata `

before:
<img width="786" alt="image" src="https://github.com/user-attachments/assets/db61094e-44cb-4c94-b389-01c4b20227ca" />
after:
<img width="684" alt="image" src="https://github.com/user-attachments/assets/1c725317-f448-4fa7-9b97-461435846131" />

### Changes

1.  Print more info in `activeledgers`  cmd
2. No more print usage in `readlogmetadata` cmd
