### PR TITLE
Fix the data loss issue that caused by the wrong entry log header

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -1151,6 +1151,10 @@ public class DefaultEntryLogger implements EntryLogger {
                     + " -- found: " + meta.getLedgersMap().size() + " -- entryLogId: " + entryLogId);
         }
 
+        if (header.ledgersCount == 0) {
+            throw new IOException("No ledgers map found in entryLogId " + entryLogId + ", do scan to double confirm");
+        }
+
         return meta;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/EntryLoggerAllocator.java
@@ -85,6 +85,7 @@ class EntryLoggerAllocator {
         // within the same JVM. All of these Bookie instances access this header
         // so there can be race conditions when entry logs are rolled over and
         // this header buffer is cleared before writing it into the new logChannel.
+        logfileHeader.setZero(0, DefaultEntryLogger.LOGFILE_HEADER_SIZE);
         logfileHeader.writeBytes("BKLO".getBytes(UTF_8));
         logfileHeader.writeInt(DefaultEntryLogger.HEADER_CURRENT_VERSION);
         logfileHeader.writerIndex(DefaultEntryLogger.LOGFILE_HEADER_SIZE);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -842,11 +842,12 @@ public class GarbageCollectorThread implements Runnable {
                 continue;
             }
 
-            LOG.info("Extracting entry log meta from entryLogId: {}", entryLogId);
 
             try {
                 // Read through the entry log file and extract the entry log meta
                 EntryLogMetadata entryLogMeta = entryLogger.getEntryLogMetadata(entryLogId, throttler);
+                LOG.info("Extracted entry log meta from entryLogId: {}, ledgers {}",
+                    entryLogId, entryLogMeta.getLedgersMap().keys());
                 removeIfLedgerNotExists(entryLogMeta);
                 if (entryLogMeta.isEmpty()) {
                     // This means the entry log is not associated with any active


### PR DESCRIPTION
---

# Motivation

We observed numerous errors in the broker that failed to read the ledger from the bookkeeper; although the ledger metadata still exists, it was unable to read from the bookkeeper. After checking the data, we found the ledger located entry log was deleted by the bookkeeper. We have a data loss issue with the bookkeeper.

The entry log file was deleted by the Garbage collector because the entry log file wrote a wrong file header.

And there is an example that the shows the header is wrong:
```
Failed to get ledgers map index from: 82.log : Not all ledgers were found in ledgers map index. expected: -1932430239 -- found: 0 -- entryLogId: 82
```
