### PR TITLE
Upgrade commons-beanutils to 1.11.0 to address CVE-2025-48734

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -211,7 +211,7 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-beanutils-commons-beanutils-1.10.1.jar [62]
+- lib/commons-beanutils-commons-beanutils-1.11.0.jar [62]
 - lib/commons-cli-commons-cli-1.9.0.jar [5]
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-collections-commons-collections-3.2.2.jar [62]
@@ -420,7 +420,7 @@ Apache Software License, Version 2.
 [59] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v1.33.6
 [60] Source available at https://github.com/prometheus/client_java/tree/v1.3.4
 [61] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
-[62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.10.1
+[62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [63] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -211,7 +211,7 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-beanutils-commons-beanutils-1.10.1.jar [57]
+- lib/commons-beanutils-commons-beanutils-1.11.0.jar [57]
 - lib/commons-cli-commons-cli-1.9.0.jar [5]
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-collections-commons-collections-3.2.2.jar [58]
@@ -354,7 +354,7 @@ Apache Software License, Version 2.
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.45.0
 [55] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
 [56] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
-[57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.10.1
+[57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [58] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -211,7 +211,7 @@ Apache Software License, Version 2.
 - lib/com.google.guava-guava-32.0.1-jre.jar [4]
 - lib/com.google.guava-failureaccess-1.0.1.jar [4]
 - lib/com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar [4]
-- lib/commons-beanutils-commons-beanutils-1.10.1.jar [61]
+- lib/commons-beanutils-commons-beanutils-1.11.0.jar [61]
 - lib/commons-cli-commons-cli-1.9.0.jar [5]
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-collections-commons-collections-3.2.2.jar [62]
@@ -415,7 +415,7 @@ Apache Software License, Version 2.
 [58] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v1.33.6
 [59] Source available at https://github.com/prometheus/client_java/tree/v1.3.4
 [60] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
-[61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.10.1
+[61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [62] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <commons-collections4.version>4.1</commons-collections4.version>
     <commons-codec.version>1.18.0</commons-codec.version>
     <commons-configuration2.version>2.12.0</commons-configuration2.version>
-    <commons-beanutils.version>1.10.1</commons-beanutils.version>
+    <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>


### PR DESCRIPTION
### Motivation & Changes

Upgrade commons-beanutils to 1.11.0 to address CVE-2025-48734.