### PR TITLE
Fix a NPE bug after refactor recycler of BookieClient

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/CompletionValue.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/CompletionValue.java
@@ -87,9 +87,9 @@ abstract class CompletionValue {
     }
 
     void timeout() {
-        errorOut(BKException.Code.TimeoutException);
         timeoutOpLogger.registerSuccessfulEvent(latency(),
                 TimeUnit.NANOSECONDS);
+        errorOut(BKException.Code.TimeoutException);
     }
 
     protected void logResponse(BookkeeperProtocol.StatusCode status, Object... extraInfo) {


### PR DESCRIPTION
### Motivation

After  refactor recycler of bookieClient and  test for a few days in cluster, there is a NPE bug.


![企业微信截图_c8eea33b-7b52-49dc-8179-1f9f25fc35d1](https://github.com/user-attachments/assets/76391b1c-09c0-417e-ac98-afeb31441022)


In CompletionValue#timeout(), it would do errorOut() and then register latency in timeoutOpLogger. But errorOut() would trigger writeComplete() and then recycle the completionValue object. So the timeoutOpLogger is also recycle and throw NPE. 

### Changes

change the execute order: register latency first and then do errorOut().


Alternative fix is like: 
```
void timeout() {
        OpStatsLogger logger = timeoutOpLogger;
        errorOut(BKException.Code.TimeoutException);
        logger.registerSuccessfulEvent(latency(),
                TimeUnit.NANOSECONDS);
}
```
But I think it is unnecessary to record the errorOut() time in prometheus, because this time cost has no influence of this timeout metric.


