### PR TITLE
[Improve] Replace outdated temp directory creation with java.nio.Files

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/IOUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/IOUtils.java
@@ -21,6 +21,8 @@
 package org.apache.bookkeeper.util;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
@@ -146,14 +148,12 @@ public class IOUtils {
      */
     public static File createTempDir(String prefix, String suffix, File dir)
             throws IOException {
-        File tmpDir = File.createTempFile(prefix, suffix, dir);
-        if (!tmpDir.delete()) {
-            throw new IOException("Couldn't delete directory " + tmpDir);
-        }
-        if (!tmpDir.mkdir()) {
-            throw new IOException("Couldn't create directory " + tmpDir);
-        }
-        return tmpDir;
+        try {
+            final File tmpDir = Files.createTempDirectory(prefix + suffix).toFile();
+                return tmpDir;
+            } catch (IOException e) {
+                throw new IOException("Could not create temp directory: " + prefix + suffix, e);
+            }
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

This PR modernizes the createTempDir method in IOUtils.java and eliminates a potential race condition/directory hijacking vulnerability by using a safer, atomic method Files.createTempDirectory() introduced in Java 7 (NIO).
This was also done here:
https://github.com/openkm/document-management-system/commit/c069e4d73ab8864345c25119d8459495f45453e1
https://github.com/samtools/htsjdk/commit/269ba3fa507b9bab2dce54bf786d46b575db5527

### Motivation

The existing implementation of createTempDir in IOUtils.java uses an outdated pattern involving File.createTempFile() followed by delete() and mkdir(). This sequence is potentially vulnerable to a race condition (CWE-379) which can lead to temporary directory hijacking or information disclosure.

