### PR TITLE
Upgrade Netty to 4.1.122.Final

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -218,32 +218,32 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.netty-netty-buffer-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.121.Final.jar [11]
-- lib/io.netty-netty-common-4.1.121.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.121.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.121.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.121.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.121.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-buffer-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.122.Final.jar [11]
+- lib/io.netty-netty-common-4.1.122.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.122.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.122.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.122.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.122.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -374,7 +374,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.121.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.122.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -423,9 +423,9 @@ Apache Software License, Version 2.
 [62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [63] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.122.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -434,7 +434,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -442,7 +442,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -450,7 +450,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -458,7 +458,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -468,7 +468,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -476,7 +476,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -485,7 +485,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -493,7 +493,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -501,7 +501,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -509,7 +509,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -517,7 +517,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -525,7 +525,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -533,7 +533,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -541,7 +541,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -550,7 +550,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -558,7 +558,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -566,7 +566,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -574,7 +574,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -582,7 +582,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -590,7 +590,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -598,7 +598,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -606,7 +606,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -614,7 +614,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -622,7 +622,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -631,7 +631,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -639,7 +639,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -218,26 +218,26 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.netty-netty-buffer-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.121.Final.jar [11]
-- lib/io.netty-netty-common-4.1.121.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.121.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.121.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-buffer-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.122.Final.jar [11]
+- lib/io.netty-netty-common-4.1.122.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.122.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.122.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [16]
@@ -321,7 +321,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.121.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.122.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.23.1
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -357,9 +357,9 @@ Apache Software License, Version 2.
 [57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [58] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.122.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -368,7 +368,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -376,7 +376,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -384,7 +384,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -392,7 +392,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -402,7 +402,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -410,7 +410,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -419,7 +419,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -427,7 +427,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -435,7 +435,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -443,7 +443,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -451,7 +451,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -459,7 +459,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -467,7 +467,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -475,7 +475,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -484,7 +484,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -492,7 +492,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -500,7 +500,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -508,7 +508,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -516,7 +516,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -524,7 +524,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -532,7 +532,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -540,7 +540,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -548,7 +548,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -556,7 +556,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -565,7 +565,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -573,7 +573,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -218,32 +218,32 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-lang-commons-lang-2.6.jar [9]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.netty-netty-buffer-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.1.121.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.1.121.Final.jar [11]
-- lib/io.netty-netty-common-4.1.121.Final.jar [11]
-- lib/io.netty-netty-handler-4.1.121.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.1.121.Final.jar [11]
-- lib/io.netty-netty-resolver-4.1.121.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.1.121.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar [11]
-- lib/io.netty-netty-transport-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-buffer-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.1.122.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.1.122.Final.jar [11]
+- lib/io.netty-netty-common-4.1.122.Final.jar [11]
+- lib/io.netty-netty-handler-4.1.122.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.1.122.Final.jar [11]
+- lib/io.netty-netty-resolver-4.1.122.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.1.122.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar [11]
+- lib/io.netty-netty-transport-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar [11]
 - lib/io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -370,7 +370,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.1.121.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.1.122.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -418,9 +418,9 @@ Apache Software License, Version 2.
 [61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [62] Source available at https://github.com/apache/commons-collections/tree/collections-3.3.2
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-4.1.121.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-4.1.122.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -429,7 +429,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -437,7 +437,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -445,7 +445,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -453,7 +453,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -463,7 +463,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -471,7 +471,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -480,7 +480,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -488,7 +488,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -496,7 +496,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -504,7 +504,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -512,7 +512,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -520,7 +520,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -528,7 +528,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -536,7 +536,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -545,7 +545,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -553,7 +553,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -561,7 +561,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -569,7 +569,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -577,7 +577,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -585,7 +585,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-4.1.122.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -593,7 +593,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -601,7 +601,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -609,7 +609,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -617,7 +617,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-4.1.122.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -626,7 +626,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -634,7 +634,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-4.1.121.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-4.1.122.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,31 +23,31 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.121.Final.jar
-- lib/io.netty-netty-codec-4.1.121.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.121.Final.jar
-- lib/io.netty-netty-codec-http-4.1.121.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.121.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.121.Final.jar
-- lib/io.netty-netty-common-4.1.121.Final.jar
-- lib/io.netty-netty-handler-4.1.121.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.121.Final.jar
-- lib/io.netty-netty-resolver-4.1.121.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.121.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar
-- lib/io.netty-netty-transport-4.1.121.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar
+- lib/io.netty-netty-buffer-4.1.122.Final.jar
+- lib/io.netty-netty-codec-4.1.122.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.122.Final.jar
+- lib/io.netty-netty-codec-http-4.1.122.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.122.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.122.Final.jar
+- lib/io.netty-netty-common-4.1.122.Final.jar
+- lib/io.netty-netty-handler-4.1.122.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.122.Final.jar
+- lib/io.netty-netty-resolver-4.1.122.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.122.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar
+- lib/io.netty-netty-transport-4.1.122.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,25 +5,25 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.121.Final.jar
-- lib/io.netty-netty-codec-4.1.121.Final.jar
-- lib/io.netty-netty-common-4.1.121.Final.jar
-- lib/io.netty-netty-handler-4.1.121.Final.jar
-- lib/io.netty-netty-resolver-4.1.121.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar
-- lib/io.netty-netty-transport-4.1.121.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar
+- lib/io.netty-netty-buffer-4.1.122.Final.jar
+- lib/io.netty-netty-codec-4.1.122.Final.jar
+- lib/io.netty-netty-common-4.1.122.Final.jar
+- lib/io.netty-netty-handler-4.1.122.Final.jar
+- lib/io.netty-netty-resolver-4.1.122.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar
+- lib/io.netty-netty-transport-4.1.122.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,31 +5,31 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.1.121.Final.jar
-- lib/io.netty-netty-codec-4.1.121.Final.jar
-- lib/io.netty-netty-codec-dns-4.1.121.Final.jar
-- lib/io.netty-netty-codec-http-4.1.121.Final.jar
-- lib/io.netty-netty-codec-http2-4.1.121.Final.jar
-- lib/io.netty-netty-codec-socks-4.1.121.Final.jar
-- lib/io.netty-netty-common-4.1.121.Final.jar
-- lib/io.netty-netty-handler-4.1.121.Final.jar
-- lib/io.netty-netty-handler-proxy-4.1.121.Final.jar
-- lib/io.netty-netty-resolver-4.1.121.Final.jar
-- lib/io.netty-netty-resolver-dns-4.1.121.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.70.Final.jar
-- lib/io.netty-netty-transport-4.1.121.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.1.121.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.1.121.Final-linux-x86_64.jar
+- lib/io.netty-netty-buffer-4.1.122.Final.jar
+- lib/io.netty-netty-codec-4.1.122.Final.jar
+- lib/io.netty-netty-codec-dns-4.1.122.Final.jar
+- lib/io.netty-netty-codec-http-4.1.122.Final.jar
+- lib/io.netty-netty-codec-http2-4.1.122.Final.jar
+- lib/io.netty-netty-codec-socks-4.1.122.Final.jar
+- lib/io.netty-netty-common-4.1.122.Final.jar
+- lib/io.netty-netty-handler-4.1.122.Final.jar
+- lib/io.netty-netty-handler-proxy-4.1.122.Final.jar
+- lib/io.netty-netty-resolver-4.1.122.Final.jar
+- lib/io.netty-netty-resolver-dns-4.1.122.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.72.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.72.Final.jar
+- lib/io.netty-netty-transport-4.1.122.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.1.122.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
 - lib/io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.1.121.Final.jar
+- lib/io.netty-netty-transport-native-unix-common-4.1.122.Final.jar
 
 
                             The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <log4j.version>2.23.1</log4j.version>
     <lz4.version>1.3.0</lz4.version>
     <mockito.version>4.11.0</mockito.version>
-    <netty.version>4.1.121.Final</netty.version>
+    <netty.version>4.1.122.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>


### PR DESCRIPTION
### Motivation

Keeping Netty up-to-date with bug fixes.
* https://netty.io/news/2025/06/03/4-1-122-Final.html
* https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.70.Final...netty-tcnative-parent-2.0.72.Final

### Changes

- Upgrade Netty to 4.1.122.Final and tcnative to 2.0.72.Final
