### PR TITLE
Upgrade dependency-check-maven to 12.1.3 to fix OWASP CI job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
+    <dependency-check-maven.version>12.1.3</dependency-check-maven.version>
     <nar-maven-plugin.version>3.10.1</nar-maven-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
### Motivation

According to the [changelog for version 12.1.1](https://github.com/dependency-check/DependencyCheck/blob/main/CHANGELOG.md#change-log), this update includes the following important fix:

```
fix: resolve NVD data Parse error com.fasterxml.jackson.core.JsonParseException: Unexpected character (']' (code 93))
```

Upgrading to 12.1.3 ensures this and other recent fixes are included, improving the reliability of the OWASP Dependency-Check Maven plugin in this project.

### Changes

- Bump `dependency-check-maven.version` from 12.1.0 to 12.1.3 in `pom.xml`.