### PR TITLE
Update bc tests to include versions up to 4.17.2 and 4.16.7

### DIFF
--- a/tests/docker-images/all-released-versions-image/Dockerfile
+++ b/tests/docker-images/all-released-versions-image/Dockerfile
@@ -51,8 +51,8 @@ RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.12.1/bookke
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.13.0/bookkeeper-server-4.13.0-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.14.8/bookkeeper-server-4.14.8-bin.tar.gz{,.sha512,.asc}
 RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.15.5/bookkeeper-server-4.15.5-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.6/bookkeeper-server-4.16.6-bin.tar.gz{,.sha512,.asc}
-RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.17.1/bookkeeper-server-4.17.1-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.7/bookkeeper-server-4.16.7-bin.tar.gz{,.sha512,.asc}
+RUN wget -nv https://archive.apache.org/dist/bookkeeper/bookkeeper-4.17.2/bookkeeper-server-4.17.2-bin.tar.gz{,.sha512,.asc}
 
 RUN wget -nv https://dist.apache.org/repos/dist/release/bookkeeper/KEYS
 RUN wget -nv http://svn.apache.org/repos/asf/zookeeper/bookkeeper/dist/KEYS?p=1620552 -O KEYS.old

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
@@ -51,8 +51,8 @@ public class BookKeeperClusterUtils {
     public static final String VERSION_4_13_x = "4.13.0";
     public static final String VERSION_4_14_x = "4.14.8";
     public static final String VERSION_4_15_x = "4.15.5";
-    public static final String VERSION_4_16_x = "4.16.6";
-    public static final String VERSION_4_17_x = "4.17.1";
+    public static final String VERSION_4_16_x = "4.16.7";
+    public static final String VERSION_4_17_x = "4.17.2";
 
     public static final List<String> OLD_CLIENT_VERSIONS =
             Arrays.asList(VERSION_4_8_x, VERSION_4_9_x, VERSION_4_10_x, VERSION_4_11_x, VERSION_4_12_x,


### PR DESCRIPTION
https://bookkeeper.apache.org/community/release-guide/#verify-docker-image
Once the new docker image is built, update BC tests to include new docker image. 