### PR TITLE
fix replicateRate of batchRead in auto-recover is negative

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerFragmentReplicator.java
@@ -471,8 +471,9 @@ public class LedgerFragmentReplicator {
         int entriesToReplicateCnt = (int) (endEntryId - startEntryId + 1);
         int maxBytesToReplicate = conf.getReplicationRateByBytes();
         if (replicationThrottle != null) {
-            if (maxBytesToReplicate != -1 && maxBytesToReplicate > averageEntrySize.get() * entriesToReplicateCnt) {
-                maxBytesToReplicate = averageEntrySize.get() * entriesToReplicateCnt;
+            long bytesToReplicateCnt = (long) averageEntrySize.get() * entriesToReplicateCnt;
+            if (bytesToReplicateCnt <= Integer.MAX_VALUE && bytesToReplicateCnt >= 0) {
+                maxBytesToReplicate = Math.min(maxBytesToReplicate, (int) bytesToReplicateCnt);
             }
             replicationThrottle.acquire(maxBytesToReplicate);
         }


### PR DESCRIPTION
### Motivation

Currently the replicateRate of batchRead in auto-recover may exceed Integer.MAX_VALUE and then become negative, which would result in batchRead  operation stuck. 

### Changes

deal with the negative situation


