### PR TITLE
[fix]BK stays at read_only state even if the disk is empty

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -202,7 +202,7 @@ public class BookieStateManager implements StateManager {
     @Override
     public void initState(){
         if (forceReadOnly.get()) {
-            this.bookieStatus.setToReadOnlyMode();
+            this.bookieStatus.setToReadOnlyMode(false);
         } else if (conf.isPersistBookieStatusEnabled()) {
             this.bookieStatus.readFromDirectories(statusDirs);
         }
@@ -293,22 +293,22 @@ public class BookieStateManager implements StateManager {
     }
 
     @Override
-    public Future<Void> transitionToWritableMode() {
+    public Future<Void> transitionToWritableMode(boolean isManuallyModify) {
         return stateService.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception{
-                doTransitionToWritableMode();
+                doTransitionToWritableMode(isManuallyModify);
                 return null;
             }
         });
     }
 
     @Override
-    public Future<Void> transitionToReadOnlyMode() {
+    public Future<Void> transitionToReadOnlyMode(boolean isManuallyModify) {
         return stateService.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception{
-                doTransitionToReadOnlyMode();
+                doTransitionToReadOnlyMode(isManuallyModify);
                 return null;
             }
         });
@@ -335,8 +335,13 @@ public class BookieStateManager implements StateManager {
     }
 
     @VisibleForTesting
-    public void doTransitionToWritableMode() {
+    public void doTransitionToWritableMode(boolean isManuallyModify) {
         if (shuttingdown || forceReadOnly.get()) {
+            return;
+        }
+        if (!isManuallyModify && bookieStatus.isInReadOnlyMode() && bookieStatus.isManuallyModifiedToReadOnly()) {
+            LOG.info("Skip to transition Bookie to Writable mode automatically because it is manually set to read-only"
+                    + " mode, which can only be changed manually.");
             return;
         }
 
@@ -371,11 +376,11 @@ public class BookieStateManager implements StateManager {
     }
 
     @VisibleForTesting
-    public void doTransitionToReadOnlyMode() {
+    public void doTransitionToReadOnlyMode(boolean isManuallyModify) {
         if (shuttingdown) {
             return;
         }
-        if (!bookieStatus.setToReadOnlyMode()) {
+        if (!bookieStatus.setToReadOnlyMode(isManuallyModify)) {
             return;
         }
         if (!conf.isReadOnlyModeEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java
@@ -182,7 +182,7 @@ class LedgerDirsMonitor {
         }
 
         if (isFirstLoopOfCheckTaskLocalValue && ldm.getFullFilledLedgerDirs().isEmpty()) {
-            // notify any disk full.
+            // notify no disk full.
             for (LedgerDirsListener listener : ldm.getListeners()) {
                 listener.allDisksWritable();
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -100,12 +100,20 @@ public interface StateManager extends AutoCloseable {
     /**
      * Change the state of bookie to Writable mode.
      */
-    Future<Void> transitionToWritableMode();
+    Future<Void> transitionToWritableMode(boolean isManuallyModify);
+
+    default Future<Void> transitionToWritableMode() {
+        return transitionToWritableMode(false);
+    }
 
     /**
      * Change the state of bookie to ReadOnly mode.
      */
-    Future<Void> transitionToReadOnlyMode();
+    Future<Void> transitionToReadOnlyMode(boolean isManuallyModify);
+
+    default Future<Void> transitionToReadOnlyMode() {
+        return transitionToReadOnlyMode(false);
+    }
 
     /**
      * ShutdownHandler used to shutdown bookie.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/BookieStateReadOnlyService.java
@@ -58,14 +58,14 @@ public class BookieStateReadOnlyService implements HttpEndpointService {
                     response.setBody("Bookie is in forceReadOnly mode, cannot transit to writable mode");
                     return response;
                 }
-                stateManager.transitionToWritableMode().get();
+                stateManager.transitionToWritableMode(true).get();
             } else if (!stateManager.isReadOnly() && inState.isReadOnly()) {
                 if (!stateManager.isReadOnlyModeEnabled()) {
                     response.setCode(HttpServer.StatusCode.BAD_REQUEST);
                     response.setBody("Bookie is disabled ReadOnly mode, cannot transit to readOnly mode");
                     return response;
                 }
-                stateManager.transitionToReadOnlyMode().get();
+                stateManager.transitionToReadOnlyMode(true).get();
             }
         } else if (!HttpServer.Method.GET.equals(request.getMethod())) {
             response.setCode(HttpServer.StatusCode.NOT_FOUND);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -711,7 +711,7 @@ public class LedgerCacheTest {
                 LOG.info("Started flushing mem table.");
                 memTable.flush(FlushTestSortedLedgerStorage.this);
             } catch (IOException e) {
-                getStateManager().doTransitionToReadOnlyMode();
+                getStateManager().doTransitionToReadOnlyMode(false);
                 LOG.error("Exception thrown while flushing skip list cache.", e);
          }
          }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -326,7 +326,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         BookieServer bk = serverByIndex(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
 
-        ((BookieImpl) bk.getBookie()).getStateManager().doTransitionToReadOnlyMode();
+        ((BookieImpl) bk.getBookie()).getStateManager().doTransitionToReadOnlyMode(false);
         bkc.waitForReadOnlyBookie(BookieImpl.getBookieId(confByIndex(bkIndex)))
             .get(30, TimeUnit.SECONDS);
 
@@ -361,7 +361,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
         BookieServer bk = serverByIndex(bkIndex);
         bookieConf.setReadOnlyModeEnabled(true);
 
-        ((BookieImpl) bk.getBookie()).getStateManager().doTransitionToReadOnlyMode();
+        ((BookieImpl) bk.getBookie()).getStateManager().doTransitionToReadOnlyMode(false);
         bkc.waitForReadOnlyBookie(BookieImpl.getBookieId(confByIndex(bkIndex)))
             .get(30, TimeUnit.SECONDS);
 


### PR DESCRIPTION
### Motivation

Issue: BK stays at `readOnly` state even if the disk is empty

Reproduce steps
- Configurations
  - `diskUsageLwmThreshold`: `0.85`
  - `diskUsageWarnThreshold`: `0.85`
  - `diskUsageThreshold`: `0.90`
  - `persistBookieStatusEnabled`: `true`
- The state of BK switches to `read-only` because the disk usage increased to `0.92`.
- The disk usage came down to `0.851`.
- Restart the BK.
  - The state is set to `read-only`, because the payload of the state file is `1, {timestamp}, Read_only`
- **(Highlight)**  The attributes of `LedgerDirsManager` is as follows
  -  `filledDirs`: `[]`
  - `writableLedgerDirectories`: `["ledger-0"]`
- **Issue:** the state stays at `read_only` and never recovers, because there is no ledger dir that will switch state from `filled` to `writable` since the `filledDirs` is empty. See also https://github.com/apache/bookkeeper/blob/master/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDirsMonitor.java#L186-L191

```java
// When a dir switches state from "filled" to "writable" and the variable "filledDirs" is empty, BK will switch state to "read_write" 
if (someDiskRecovered && ldm.getFullFilledLedgerDirs().isEmpty()) {
    // notify all disk recovered.
    for (LedgerDirsListener listener: ldm.getListeners()) {
        listener.allDisksWritable();
    }
}
```


### Changes

- If `filledDirs` is empty, the first check task after BK starts will switch the `read_only` state to `read_write`
- If the `read_only` state was set by Admin API, the check task will not trigger a switching that changes the state from `read_only` to `read_write` until users call an Admin API to set the state manually. which keeps the previous behavior

### Downgrade compatibility

Since the PR changed the layout of the persistence file of the BK status, you need to delete the latest part of the status file manually before downgrading the BK node(if you want to keep the BK in `read_only` status). Otherwise, you will lose the `BK_mode` status after the downgrade
