### PR TITLE
PoolingPolicy support UnpooledDirect

### DIFF
--- a/bookkeeper-common-allocator/src/main/java/org/apache/bookkeeper/common/allocator/PoolingPolicy.java
+++ b/bookkeeper-common-allocator/src/main/java/org/apache/bookkeeper/common/allocator/PoolingPolicy.java
@@ -31,6 +31,8 @@ public enum PoolingPolicy {
      */
     UnpooledHeap,
 
+    UnpooledDirect,
+
     /**
      * Use Direct memory for all buffers and pool the memory.
      *

--- a/bookkeeper-common-allocator/src/main/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorImpl.java
+++ b/bookkeeper-common-allocator/src/main/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorImpl.java
@@ -140,7 +140,7 @@ public class ByteBufAllocatorImpl extends AbstractByteBufAllocator implements By
 
     @Override
     public ByteBuf buffer(int initialCapacity, int maxCapacity) {
-        if (poolingPolicy == PoolingPolicy.PooledDirect) {
+        if (poolingPolicy == PoolingPolicy.PooledDirect || poolingPolicy == PoolingPolicy.UnpooledDirect) {
             return newDirectBuffer(initialCapacity, maxCapacity, true /* can fallback to heap if needed */);
         } else {
             return newHeapBuffer(initialCapacity, maxCapacity);


### PR DESCRIPTION
Previously, the memory allocation strategy was limited to pooled memory on the Java heap.
This update adds support for unpooled memory allocation off-heap, allowing greater flexibility in memory management and reducing GC pressure in certain workloads.