### PR TITLE
add rate limit for gc.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -114,6 +114,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String GC_OVERREPLICATED_LEDGER_WAIT_TIME = "gcOverreplicatedLedgerWaitTime";
     protected static final String GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_REQUESTS =
             "gcOverreplicatedLedgerMaxConcurrentRequests";
+    protected static final String GC_RATE_LIMIT = "gcRateLimit";
     protected static final String USE_TRANSACTIONAL_COMPACTION = "useTransactionalCompaction";
     protected static final String VERIFY_METADATA_ON_GC = "verifyMetadataOnGC";
     protected static final String GC_ENTRYLOGMETADATA_CACHE_ENABLED = "gcEntryLogMetadataCacheEnabled";
@@ -478,6 +479,24 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
             int gcOverreplicatedLedgerMaxConcurrentRequests) {
         this.setProperty(GC_OVERREPLICATED_LEDGER_MAX_CONCURRENT_REQUESTS,
                 Integer.toString(gcOverreplicatedLedgerMaxConcurrentRequests));
+        return this;
+    }
+
+    /**
+     * Get the rate limit of zookeeper operations in garbage collection.
+     * @return
+     */
+    public int getGcRateLimit() {
+        return this.getInt(GC_RATE_LIMIT, 1000);
+    }
+
+    /**
+     * Set the rate limit of zookeeper operations in garbage collection.
+     * @param gcRateLimit
+     * @return
+     */
+    public ServerConfiguration setGcRateLimit(int gcRateLimit) {
+        this.setProperty(GC_RATE_LIMIT, Integer.toString(gcRateLimit));
         return this;
     }
 


### PR DESCRIPTION

### Motivation

Each time the bookie gc is triggered, the read latency of zookeeper soars high to tens of seconds, threatening the stability of the cluster.
<img width="830" height="556" alt="image" src="https://github.com/user-attachments/assets/ef32fa3a-8fd1-477d-9822-25ffd4c2c868" />
The unlimited zookeeper read operation in gc is responsible for the issue.
<img width="830" height="346" alt="image" src="https://github.com/user-attachments/assets/cc29d93b-1313-4b80-93c1-03722982eaea" />


### Changes

Add config `gcRateLimit` to limit the read operation rate in gc.

> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
