### PR TITLE
Handling outdated and misleading comments in maybeHandleDelayedWriteBookieFailure

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2148,10 +2148,8 @@ public class LedgerHandle implements WriteHandle {
             return;
         }
 
-        // Original intent of this change is to do a best-effort ensemble change.
-        // But this is not possible until the local metadata is completely immutable.
-        // Until the feature "Make LedgerMetadata Immutable #610" Is complete we will use
-        // handleBookieFailure() to handle delayed writes as regular bookie failures.
+        // Treat delayed-write failures as regular bookie failures and trigger an ensemble change.
+        // LedgerMetadata is immutable now (#281), so this is handled via MetadataUpdateLoop.
         handleBookieFailure(toReplace);
     }
 


### PR DESCRIPTION
Main Issue: https://github.com/apache/bookkeeper/issues/281

### Motivation

The issue https://github.com/apache/bookkeeper/issues/281 and https://github.com/apache/bookkeeper/issues/610 is completed. The notes should be updated after https://github.com/apache/bookkeeper/pull/1646.

### Changes

update outdated notes.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
