### PR TITLE
Upgrade jctools version to 4.0.5

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -306,7 +306,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [34]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.12.0.jar [37]
-- lib/org.jctools-jctools-core-2.1.2.jar [38]
+- lib/org.jctools-jctools-core-4.0.5.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
@@ -395,7 +395,7 @@ Apache Software License, Version 2.
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.7.1
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
-[38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
+[38] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -277,7 +277,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [33]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [35]
 - lib/org.apache.yetus-audience-annotations-0.12.0.jar [36]
-- lib/org.jctools-jctools-core-2.1.2.jar [37]
+- lib/org.jctools-jctools-core-4.0.5.jar [37]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [39]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [40]
@@ -334,7 +334,7 @@ Apache Software License, Version 2.
 [33] Source available at https://github.com/apache/curator/tree/apache-curator-5.7.1
 [35] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [36] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
-[37] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
+[37] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [40] Source available at https://github.com/apache/thrift/tree/0.14.2

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -306,7 +306,7 @@ Apache Software License, Version 2.
 - lib/org.apache.curator-curator-recipes-5.7.1.jar [34]
 - lib/com.google.errorprone-error_prone_annotations-2.9.0.jar [36]
 - lib/org.apache.yetus-audience-annotations-0.12.0.jar [37]
-- lib/org.jctools-jctools-core-2.1.2.jar [38]
+- lib/org.jctools-jctools-core-4.0.5.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
 - lib/org.apache.thrift-libthrift-0.14.2.jar [41]
@@ -391,7 +391,7 @@ Apache Software License, Version 2.
 [34] Source available at https://github.com/apache/curator/releases/tag/apache.curator-5.7.1
 [36] Source available at https://github.com/google/error-prone/tree/v2.9.0
 [37] Source available at https://github.com/apache/yetus/tree/rel/0.12.0
-[38] Source available at https://github.com/JCTools/JCTools/tree/v2.1.2
+[38] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
 [41] Source available at https://github.com/apache/thrift/tree/0.14.2

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <vertx.version>4.5.11</vertx.version>
     <zookeeper.version>3.9.3</zookeeper.version>
     <snappy.version>1.1.10.5</snappy.version>
-    <jctools.version>2.1.2</jctools.version>
+    <jctools.version>4.0.5</jctools.version>
     <hppc.version>0.9.1</hppc.version>
     <!-- plugin dependencies -->
     <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version>


### PR DESCRIPTION
### Motivation

The current jctools version is extremely old. It's better to keep the dependency updated.
jctools is currently used in BookKeeper to implement https://github.com/apache/bookkeeper/blob/master/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/BlockingMpscQueue.java .

### Changes

Upgrade jctools version from 2.1.2 to 4.0.5.
