### PR TITLE
[fix]Wrong error code(-102) when opening a deleted ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieException.java
@@ -69,6 +69,8 @@ public abstract class BookieException extends Exception {
             return new MetadataStoreException();
         case Code.UnknownBookieIdException:
             return new UnknownBookieIdException();
+        case Code.LedgerFencedAndDeletedException:
+            return new LedgerFencedAndDeletedException();
         case Code.DataUnknownException:
             return new DataUnknownException();
         default:
@@ -95,6 +97,7 @@ public abstract class BookieException extends Exception {
         int CookieExistsException = -109;
         int EntryLogMetadataMapException = -110;
         int DataUnknownException = -111;
+        int LedgerFencedAndDeletedException = -112;
     }
 
     public int getCode() {
@@ -195,6 +198,15 @@ public abstract class BookieException extends Exception {
      */
     public static class LedgerFencedException extends BookieException {
         public LedgerFencedException() {
+            super(Code.LedgerFencedException);
+        }
+    }
+
+    /**
+     * Signals that a ledger has been fenced in a bookie. No more entries can be appended to that ledger.
+     */
+    public static class LedgerFencedAndDeletedException extends BookieException {
+        public LedgerFencedAndDeletedException() {
             super(Code.LedgerFencedException);
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/HandleFactoryImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/HandleFactoryImpl.java
@@ -57,7 +57,7 @@ class HandleFactoryImpl implements HandleFactory, LedgerDeletionListener {
 
         if (handle == null) {
             if (!journalReplay && recentlyFencedAndDeletedLedgers.getIfPresent(ledgerId) != null) {
-                throw BookieException.create(BookieException.Code.LedgerFencedException);
+                throw BookieException.create(BookieException.Code.LedgerFencedAndDeletedException);
             }
             handle = LedgerDescriptor.create(masterKey, ledgerId, ledgerStorage);
             ledgers.putIfAbsent(ledgerId, handle);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -1194,6 +1194,11 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                             completion.setOutstanding();
                         }
                     } else {
+                        try {
+                            future.get();
+                        } catch (Exception ex) {
+                            LOG.warn("Failed to request to the bookie: {}", bookieId, ex);
+                        }
                         nettyOpLogger.registerFailedEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
                         errorOut(key);
                     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -94,7 +94,7 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
                 handleReadResultForFenceRead(fenceResult, data, startTimeNanos);
                 return;
             }
-        } catch (Bookie.NoLedgerException e) {
+        } catch (Bookie.NoLedgerException | BookieException.LedgerFencedAndDeletedException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Error reading {}", request, e);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -215,9 +215,10 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                 }
             }
             return readEntry(readResponse, entryId, startTimeSw);
-        } catch (Bookie.NoLedgerException e) {
+        } catch (Bookie.NoLedgerException | BookieException.LedgerFencedAndDeletedException e) {
             if (RequestUtils.isFenceRequest(readRequest)) {
-                LOG.info("No ledger found reading entry {} when fencing ledger {}", entryId, ledgerId);
+                LOG.info("No ledger found(or it has been deleted) reading entry {} when fencing ledger {}",
+                    entryId, ledgerId);
             } else if (entryId != BookieProtocol.LAST_ADD_CONFIRMED) {
                 LOG.info("No ledger found while reading entry: {} from ledger: {}", entryId, ledgerId);
             } else if (LOG.isDebugEnabled()) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessor.java
@@ -90,8 +90,8 @@ class WriteEntryProcessor extends PacketProcessorBase<ParsedAddRequest> implemen
         } catch (IOException e) {
             LOG.error("Error writing {}", request, e);
             rc = BookieProtocol.EIO;
-        } catch (BookieException.LedgerFencedException lfe) {
-            LOG.warn("Write attempt on fenced ledger {} by client {}", request.getLedgerId(),
+        } catch (BookieException.LedgerFencedException | BookieException.LedgerFencedAndDeletedException lfe) {
+            LOG.warn("Write attempt on fenced/deleted ledger {} by client {}", request.getLedgerId(),
                     requestHandler.ctx().channel().remoteAddress());
             rc = BookieProtocol.EFENCED;
         } catch (BookieException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteEntryProcessorV3.java
@@ -136,8 +136,8 @@ class WriteEntryProcessorV3 extends PacketProcessorBaseV3 {
             logger.error("Error writing entry:{} to ledger:{}",
                     entryId, ledgerId, e);
             status = StatusCode.EIO;
-        } catch (BookieException.LedgerFencedException e) {
-            logger.error("Ledger fenced while writing entry:{} to ledger:{}",
+        } catch (BookieException.LedgerFencedException | BookieException.LedgerFencedAndDeletedException e) {
+            logger.error("Ledger fenced/deleted while writing entry:{} to ledger:{}",
                     entryId, ledgerId, e);
             status = StatusCode.EFENCED;
         } catch (BookieException e) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/WriteLacProcessorV3.java
@@ -105,6 +105,10 @@ class WriteLacProcessorV3 extends PacketProcessorBaseV3 implements Runnable {
             requestProcessor.bookie.setExplicitLac(Unpooled.wrappedBuffer(lacToAdd),
                     writeCallback, requestHandler, masterKey);
             status = StatusCode.EOK;
+        } catch (BookieException.LedgerFencedAndDeletedException e) {
+            logger.error("Error saving lac {} for ledger:{}, which has been deleted",
+                    lac, ledgerId, e);
+            status = StatusCode.ENOLEDGER;
         } catch (IOException e) {
             logger.error("Error saving lac {} for ledger:{}",
                     lac, ledgerId, e);


### PR DESCRIPTION
### Motivation

**Background**

https://github.com/apache/bookkeeper/pull/4462 fixed the issue that the ledger can still be written even though it was deleted, and throws `LedgerFencedException` exception for the case, but the callers did not handle the error, leading to the Bookie server responding with a  `-102` error(wrong password) to the client side

**Issue**
```
Message: org.apache.bookkeeper.mledger.ManagedLedgerException: Attempted to access ledger using the wrong password error code: -102
Stacktrace:
org.apache.pulsar.broker.service.BrokerServiceException$PersistenceException: org.apache.bookkeeper.mledger.ManagedLedgerException: Attempted to access ledger using the wrong password error code: -102
        at org.apache.pulsar.broker.service.BrokerService$2.openLedgerFailed(BrokerService.java:1872)
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$asyncOpen$10(ManagedLedgerFactoryImpl.java:430)
        at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
```

Actually, the error Attempted to access ledger using the wrong password error code: -102 is not caused by the password; it didn’t go to check the password
From the error stack, it throws [here](https://github.com/streamnative/bookkeeper/blob/cfea64f2c79d1395b8c103336c55ad77a23ba4b7/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/HandleFactoryImpl.java#L60). And outside wrap the exception to the EUA exception [here](https://github.com/streamnative/bookkeeper/blob/cfea64f2c79d1395b8c103336c55ad77a23ba4b7/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java#L115). So we got the 102 at the client side. So actually, the ledger is fenced at the bk server.
```
org.apache.bookkeeper.bookie.BookieException$LedgerFencedException: null
    at org.apache.bookkeeper.bookie.BookieException.create(BookieException.java:57) ~[io.streamnative-bookkeeper-server-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.bookie.HandleFactoryImpl.getHandle(HandleFactoryImpl.java:60) ~[io.streamnative-bookkeeper-server-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.bookie.BookieImpl.fenceLedger(BookieImpl.java:1103) ~[io.streamnative-bookkeeper-server-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.proto.ReadEntryProcessor.processPacket(ReadEntryProcessor.java:81) ~[io.streamnative-bookkeeper-server-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.proto.PacketProcessorBase.run(PacketProcessorBase.java:202) ~[io.streamnative-bookkeeper-server-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128) ~[io.streamnative-bookkeeper-common-4.16.6.4.jar:4.16.6.4]
    at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:105) ~[io.streamnative-bookkeeper-common-4.16.6.4.jar:4.16.6.4]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.121.Final.jar:4.1.121.Final]
    at java.lang.Thread.run(Thread.java:840) ~[?:?]
```


### Changes

- Instead of using `LedgerFencedException`, use a new exception `LedgerFencedAndDeletedException`
- Let all callers handle the new error