### PR TITLE
[BUG] fix incorrect ensembles for ledger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -2273,7 +2273,6 @@ public class LedgerHandle implements WriteHandle {
                         Set<Integer> replaced = null;
 
                         Map<Integer, BookieId> toReplace = null;
-                        boolean changed = false;
                         synchronized (metadataLock) {
                             if (!delayedWriteFailedBookies.isEmpty()) {
                                 toReplace = new HashMap<>(delayedWriteFailedBookies);
@@ -2282,7 +2281,8 @@ public class LedgerHandle implements WriteHandle {
                                 newEnsemble = getCurrentEnsemble();
                                 replaced = EnsembleUtils.diffEnsemble(origEnsemble, newEnsemble);
                                 LOG.info("New Ensemble: {} for ledger: {}", newEnsemble, ledgerId);
-                                changed = true;
+
+                                changingEnsemble = false;
                             }
                         }
 
@@ -2292,13 +2292,6 @@ public class LedgerHandle implements WriteHandle {
 
                         if (newEnsemble != null) { // unsetSuccess outside of lock
                             unsetSuccessAndSendWriteRequest(newEnsemble, replaced);
-                        }
-                        if (changed) {
-                            // We cannot handle the success callback before unsetSuccessAndSendWriteRequest completes,
-                            // as this would remove the PendingAddOp from pendingAddOps.
-                            // After unsetSuccessAndSendWriteRequest executes, the ensemble in PendingAddOp will have been updated,
-                            // allowing the condition !ensemble.get(bookieIndex).equals(addr) to properly filter out incorrect bookies.
-                            changingEnsemble = false;
                         }
                     }
             }, clientCtx.getMainWorkerPool().chooseThread(ledgerId));


### PR DESCRIPTION
fix [4651](https://github.com/apache/bookkeeper/issues/4651)

### Motivation
**BUG REPORT**

```
2025-08-01T17:09:12,274+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:12,372+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:14,914+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:15,114+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:15,940+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,040+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,103+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,201+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,258+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,369+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,427+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,474+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,573+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,632+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,677+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,837+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,913+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:16,966+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
2025-08-01T17:09:17,178+0800 [BookKeeperClientWorker-OrderedExecutor-11-0] INFO  org.apache.bookkeeper.client.LedgerHandle.lambda$ensembleChangeLoop$12(LedgerHandle.java:2274) - New Ensemble: [xxx, xxx] for ledger: 1547399
```
Scenario:
e2/w2/a1
Ledger `L1` has entries `(5-10)` to write (Thread A).
Initial state: `LAC=4`, ledger metadata: `{5: [BK1, BK2]}`.
Steps:

1. Start writes: `5,6` send request to bk server; `7` fails (channel unwritable, queues callback).
2. `Ensemble change triggered` (since `LAC=4` matches `newEnsembleStartEntry=5`):
3. Metadata updated to `{5: [BK3, BK4]}` (callback queued).
4. `5,6` succeed, `LAC` updates to `6`, entries removed from pending queue.
5. Issue: Entries `5-6` were written to `[BK1,BK2]`, but ZK incorrectly records them as `[BK3,BK4]`.


### Changes

make sure `org.apache.bookkeeper.client.LedgerHandle#sendAddSuccessCallbacks` only can be called after `unsetSuccessAndSendWriteRequest(...) completes`, which can avoid the fix incorrect meta of ledger.
