### PR TITLE
Only stop Gc for the fill disk for DbLedgerStorage

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -449,7 +449,7 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @VisibleForTesting
-    List<SingleDirectoryDbLedgerStorage> getLedgerStorageList() {
+    public List<SingleDirectoryDbLedgerStorage> getLedgerStorageList() {
         return ledgerStorageList;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
@@ -259,7 +259,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
     }
 
     @org.junit.Test
-    public void testOneDirectoryFull() throws Exception {
+    public void testStopGCOnCorrespondingDiskWhenDiskFull() throws Exception {
         // 1. Create test directories
         File ledgerDir1 = tmpDirs.createNew("ledger", "test1");
         File ledgerDir2 = tmpDirs.createNew("ledger", "test2");

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
@@ -328,7 +328,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
 
         // 9. Verify GC status
         ((DbLedgerStorage) bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
-            if (Objects.equals(storage.getCurrentFile(), currentDirectories[0])) {
+            if (Objects.equals(storage.getLedgerBaseDir(), currentDirectories[0].getPath())) {
                 assertTrue("dir1 should suspend minor GC", storage.isMinorGcSuspended());
                 assertTrue("dir1 should suspend major GC", storage.isMajorGcSuspended());
             } else {
@@ -343,7 +343,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
 
         // 11. Verify GC status after recovery
         ((DbLedgerStorage) bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
-            if (Objects.equals(storage.getCurrentFile(), currentDirectories[0])) {
+            if (Objects.equals(storage.getLedgerBaseDir(), currentDirectories[0].getPath())) {
                 assertFalse("dir1 should not suspend minor GC", storage.isMinorGcSuspended());
                 assertFalse("dir1 should not suspend major GC", storage.isMajorGcSuspended());
             } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieStorageThresholdTest.java
@@ -302,12 +302,16 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         ledgerDirsManager.addLedgerDirsListener(new LedgerDirsListener() {
             @Override
             public void diskFull(File disk) {
-                if (disk.equals(currentDirectories[0])) dir1Full.countDown();
+                if (disk.equals(currentDirectories[0])) {
+                    dir1Full.countDown();
+                }
             }
 
             @Override
             public void diskWritable(File disk) {
-                if (disk.equals(currentDirectories[0])) dir1Writable.countDown();
+                if (disk.equals(currentDirectories[0])) {
+                    dir1Writable.countDown();
+                }
             }
         });
 
@@ -323,7 +327,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         assertEquals("Only 1 writable directory should remain", 1, writableDirs.size());
 
         // 9. Verify GC status
-        ((DbLedgerStorage)bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
+        ((DbLedgerStorage) bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
             if (Objects.equals(storage.getCurrentFile(), currentDirectories[0])) {
                 assertTrue("dir1 should suspend minor GC", storage.isMinorGcSuspended());
                 assertTrue("dir1 should suspend major GC", storage.isMajorGcSuspended());
@@ -338,7 +342,7 @@ public class BookieStorageThresholdTest extends BookKeeperClusterTestCase {
         assertTrue("dir1 did not become writable again", dir1Writable.await(3, TimeUnit.SECONDS));
 
         // 11. Verify GC status after recovery
-        ((DbLedgerStorage)bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
+        ((DbLedgerStorage) bookieImpl.ledgerStorage).getLedgerStorageList().forEach(storage -> {
             if (Objects.equals(storage.getCurrentFile(), currentDirectories[0])) {
                 assertFalse("dir1 should not suspend minor GC", storage.isMinorGcSuspended());
                 assertFalse("dir1 should not suspend major GC", storage.isMajorGcSuspended());


### PR DESCRIPTION
Main Issue: https://github.com/apache/bookkeeper/issues/4655
## Problem Description  
When a single ledger disk becomes full, `suspendMajorGC()`/`suspendMinorGC()` pauses garbage collection (GC) for **all disks**. However, a single disk failure should not affect GC operations on other disks.  

**Two scenarios:**  
- **Even Data Distribution**: Data is evenly distributed across ledger disks. When all disks are nearly full and one disk fills first.  
- **Uneven Data Distribution**: Individual disk usage spikes due to write skew or data cleanup anomalies.  

For the even Data Distribution:  
Disabling GC only on the full ledger disk first, then waiting for the next check (default `diskCheckInterval=10000` ms) to disable GC on other disks causes no harm.  

For uneven storage distribution:  
Disabling GC on all ledger disks affects normal operations of other disks.  

## Solution  

- solution 1: Add a new configuration to control whether to stop GC on other disks when any single disk becomes full.  
- solution 2: When `isReadOnlyModeOnAnyDiskFullEnabled == true`, stop GC on other disks. Otherwise, other disks should continue normal operations without GC suspension.  
- **solution 3: When a single disk becomes full, only stop GC for that specific disk.(current fix)**

