### PR TITLE
[fix]compile error of the file native_io_jni.c for the env jdk11 & windows

### DIFF
--- a/native-io/src/main/native-io-jni/cpp/native_io_jni.c
+++ b/native-io/src/main/native-io-jni/cpp/native_io_jni.c
@@ -20,11 +20,16 @@
  */
 #define _GNU_SOURCE
 
+#include <jni.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <org_apache_bookkeeper_common_util_nativeio_NativeIOJni.h>
 
@@ -165,7 +170,14 @@ JNIEXPORT jint JNICALL
 Java_org_apache_bookkeeper_common_util_nativeio_NativeIOJni_fsync(JNIEnv * env,
                                                                jclass clazz,
                                                                jint fd) {
-    int res = fsync(fd);
+    int res;
+
+    // Guarantee compatibility for winsows.
+    #ifdef _WIN32
+        res = _commit((int)fd);
+    #else
+        res = fsync((int)fd);
+    #endif
 
     if (res == -1) {
       throwExceptionWithErrno(env, "Failed to fsync");


### PR DESCRIPTION
### Motivation

https://github.com/apache/bookkeeper/actions/runs/17647901080/job/50151556235?pr=4613
```
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c: In function 'Java_org_apache_bookkeeper_common_util_nativeio_NativeIOJni_fsync':
Error:  OUTPUT>native-io-jni/cpp/native_io_jni.c:168:21: error: passing argument 1 of 'fflush' makes pointer from integer without a cast [-Wint-conversion]
[INFO] OUTPUT>  168 |     int res = fsync(fd);
[INFO] OUTPUT>      |                     ^~
[INFO] OUTPUT>      |                     |
[INFO] OUTPUT>      |                     jint {aka long int}
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c:33:26: note: in definition of macro 'fsync'
[INFO] OUTPUT>   33 | #define fsync(fd) fflush(fd)
[INFO] OUTPUT>      |                          ^~
[INFO] OUTPUT>In file included from C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.28-6\x64\include/jni.h:39,
[INFO] OUTPUT>                 from D:\a\bookkeeper\bookkeeper\native-io\target\nar\javah-include/org_apache_bookkeeper_common_util_nativeio_NativeIOJni.h:2,
[INFO] OUTPUT>                 from native-io-jni/cpp/native_io_jni.c:29:
[INFO] OUTPUT>C:/mingw64/x86_64-w64-mingw32/include/stdio.h:635:28: note: expected 'FILE *' {aka 'struct _iobuf *'} but argument is of type 'jint' {aka 'long int'}
[INFO] OUTPUT>  635 |   int __cdecl fflush(FILE *_File);
[INFO] OUTPUT>      |                      ~~~~~~^~~~~
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c: In function 'Java_org_apache_bookkeeper_common_util_nativeio_NativeIOJni_pwrite':
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c:261:26: warning: passing argument 2 of 'pwrite' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
[INFO] OUTPUT>  261 |     int res = pwrite(fd, (const void*) pointer, count, offset);
[INFO] OUTPUT>      |                          ^~~~~~~~~~~~~~~~~~~~~
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c:49:38: note: expected 'void *' but argument is of type 'const void *'
[INFO] OUTPUT>   49 | static ssize_t pwrite (int fd, void *buf, size_t count, off_t offset)
[INFO] OUTPUT>      |                                ~~~~~~^~~
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c: In function 'Java_org_apache_bookkeeper_common_util_nativeio_NativeIOJni_free':
[INFO] OUTPUT>native-io-jni/cpp/native_io_jni.c:311:11: warning: passing argument 1 of 'free' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
[INFO] OUTPUT>  311 |      free((const void*) pointer);
[INFO] OUTPUT>      |           ^~~~~~~~~~~~~~~~~~~~~
[INFO] OUTPUT>In file included from native-io-jni/cpp/native_io_jni.c:25:
[INFO] OUTPUT>C:/mingw64/x86_64-w64-mingw32/include/stdlib.h:537:27: note: expected 'void *' but argument is of type 'const void *'
[INFO] OUTPUT>  537 |   void __cdecl free(void *_Memory);
[INFO] OUTPUT>      |                     ~~~~~~^~~~~~~
```

the file `native-io-jni/cpp/native_io_jni.c` failed compile in the CI when using `JdK11` & `windows`

### Changes

Add compitibility support for windows