### PR TITLE
[Improve] Repeated defer ledger lock release.

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -528,9 +528,11 @@ public class ReplicationWorker implements Runnable {
             return false;
         } catch (BKNotEnoughBookiesException e) {
             logBKExceptionAndReleaseLedger(e, ledgerIdToReplicate);
+            deferLedgerLockRelease = true;
             throw e;
         } catch (BKException e) {
             logBKExceptionAndReleaseLedger(e, ledgerIdToReplicate);
+            deferLedgerLockRelease = true;
             return false;
         } finally {
             // we make sure we always release the underreplicated lock, unless we decided to defer it. If the lock has


### PR DESCRIPTION
### Motivation
Method `logBKExceptionAndReleaseLedger` has call `underreplicationManager.releaseUnderreplicatedLedger(ledgerIdToReplicate)`, so we not need execute `underreplicationManager.releaseUnderreplicatedLedger(ledgerIdToReplicate)` in finally.

### Changes
Set `deferLedgerLockRelease` is true after execute `logBKExceptionAndReleaseLedger(e, ledgerIdToReplicate)`.