### PR TITLE
Flaky Test: Build with windows on JDK 11

### DIFF
--- a/native-io/src/main/native-io-jni/cpp/native_io_jni.c
+++ b/native-io/src/main/native-io-jni/cpp/native_io_jni.c
@@ -30,7 +30,12 @@
 
 #ifdef _WIN32
 
-#define fsync(fd) fflush(fd)
+/*  fflush requires a FILE*, but we're passing an int file descriptor.
+   On Windows, the correct equivalent is _commit(fd), which takes an int fd.
+   So, change the mapping of fsync from fflush to _commit. */
+#include <io.h>
+#define fsync(fd) _commit(fd)
+
 #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 
 static ssize_t pread (int fd, void *buf, size_t count, off_t offset)


### PR DESCRIPTION
### Motivation
Many PRs cannot be merged because of this test failure. Even after rerunning multiple times, they still fail due to the same error.

**This doesn't seem to be a flaky test, but rather a blocking test that always fails！**

`
Error:  OUTPUT>native-io-jni/cpp/native_io_jni.c:168:21: error: passing argument 1 of 'fflush' makes pointer from integer without a cast [-Wint-conversion]
`

https://github.com/apache/bookkeeper/actions/runs/18648851159/job/53162582666?pr=4674
https://github.com/apache/bookkeeper/actions/runs/18552216345/job/53161739919?pr=4673
https://github.com/apache/bookkeeper/actions/runs/18526985175/job/52800716265?pr=4672
https://github.com/apache/bookkeeper/actions/runs/18526392532/job/52798756494?pr=4653
### Changes

fflush requires a FILE*, but we're passing an int file descriptor.
   On Windows, the correct equivalent is _commit(fd), which takes an int fd.
   So, change the mapping of fsync from fflush to _commit.
