### PR TITLE
feat: support `equalsAndHashcode` for BookieServerInfo

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/BookieServiceInfo.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/BookieServiceInfo.java
@@ -154,10 +154,16 @@ public final class BookieServiceInfo {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Endpoint)) return false;
-            Endpoint endpoint = (Endpoint) o;
-            return port == endpoint.port && Objects.equals(id, endpoint.id) && Objects.equals(host, endpoint.host) && Objects.equals(protocol, endpoint.protocol) && Objects.equals(auth, endpoint.auth) && Objects.equals(extensions, endpoint.extensions);
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Endpoint)) {
+                return false;
+            }
+            final Endpoint endpoint = (Endpoint) o;
+            return port == endpoint.port && Objects.equals(id, endpoint.id) && Objects.equals(host, endpoint.host)
+                    && Objects.equals(protocol, endpoint.protocol) && Objects.equals(auth, endpoint.auth)
+                    && Objects.equals(extensions, endpoint.extensions);
         }
 
         @Override
@@ -175,8 +181,12 @@ public final class BookieServiceInfo {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BookieServiceInfo)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BookieServiceInfo)) {
+            return false;
+        }
         final BookieServiceInfo that = (BookieServiceInfo) o;
         return Objects.equals(properties, that.properties) && Objects.equals(endpoints, that.endpoints);
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/discover/BookieServiceInfoTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/discover/BookieServiceInfoTest.java
@@ -22,14 +22,14 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.bookkeeper.discover.BookieServiceInfo.Endpoint;
 import org.apache.bookkeeper.net.BookieId;
 import org.junit.Assert;


### PR DESCRIPTION
### Motivation

The `BookieServerInfo` class is exposed to the metadata store plugin. We need to support `equalsAndHashcode` to help other plugins encode or decode it with comparison. 

FYI: https://github.com/apache/pulsar/pull/25001

### Changes

- Support `equalsAndHashcode` method for `BookieServerInfo` and underlying `Endpoint`