### PR TITLE
[fix] Fix issue where options for sanity test command are ignored

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieShell.java
@@ -1084,8 +1084,10 @@ public class BookieShell implements Tool {
 
         @Override
         int runCmd(CommandLine cmdLine) throws Exception {
-            SanityTestCommand command = new SanityTestCommand();
             SanityTestCommand.SanityFlags flags = new SanityTestCommand.SanityFlags();
+            flags.entries(getOptionIntValue(cmdLine, "e", 10));
+            flags.timeout(getOptionIntValue(cmdLine, "t", 1));
+            SanityTestCommand command = SanityTestCommand.newSanityTestCommand(flags);
             boolean result = command.apply(bkConf, flags);
             return (result) ? 0 : -1;
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/SanityTestCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/SanityTestCommand.java
@@ -61,12 +61,16 @@ public class SanityTestCommand extends BookieCommand<SanityFlags> {
         super(CliSpec.<SanityFlags>newBuilder().withFlags(flags).withName(NAME).withDescription(DESC).build());
     }
 
+    public static SanityTestCommand newSanityTestCommand(SanityFlags flags) {
+        return new SanityTestCommand(flags);
+    }
+
     /**
      * Flags for sanity command.
      */
     @Accessors(fluent = true)
     @Setter
-    public static class SanityFlags extends CliFlags{
+    public static class SanityFlags extends CliFlags {
 
         @Parameter(names = {"-e", "--entries"}, description = "Total entries to be added for the test (default 10)")
         private int entries = 10;
@@ -86,7 +90,7 @@ public class SanityTestCommand extends BookieCommand<SanityFlags> {
         }
     }
 
-    private static boolean handle(ServerConfiguration conf, SanityFlags cmdFlags) throws Exception {
+    public static boolean handle(ServerConfiguration conf, SanityFlags cmdFlags) throws Exception {
         try {
             return handleAsync(conf, cmdFlags).get();
         } catch (Exception e) {


### PR DESCRIPTION
### Motivation

The `bookiesanity` subcommand of Bookie Shell enables users to specify the number of entries and the timeout in seconds as command line options.
```sh
$ ./bin/bookkeeper shell bookiesanity -e 20 -t 5
```
However, in practice these options seem to be ignored and the default values (entries: 10, timeout: 1) always used.

### Changes

After creating an instance of the `SanityTestCommand.SanityFlags` class in the `BookieShell` class, the option values specified on the command line should be passed to it, but this was not actually done.