### PR TITLE
[improve] Update readledger command to read all the entries from a bookie when first entry and last entry ids are not provided

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/tools/cli/commands/bookie/ReadLedgerCommand.java
@@ -189,7 +189,13 @@ public class ReadLedgerCommand extends BookieCommand<ReadLedgerCommand.ReadLedge
                                                                  executor, scheduler, NullStatsLogger.INSTANCE,
                                                                  bk.getBookieAddressResolver());
 
-                LongStream.range(flags.firstEntryId, lastEntry).forEach(entryId -> {
+                // Determine the last ledger entry from ledger metadata if its is not provided
+                if (flags.lastEntryId == -1 && !flags.forceRecovery) {
+                    LedgerHandle lh = bk.openLedgerNoRecovery(flags.ledgerId);
+                    lastEntry = lh.getLastAddConfirmed();
+                }
+
+                LongStream.rangeClosed(flags.firstEntryId, lastEntry).forEach(entryId -> {
                     CompletableFuture<Void> future = new CompletableFuture<>();
 
                     bookieClient.readEntry(bookie, flags.ledgerId, entryId,


### PR DESCRIPTION
### Motivation

The bookkeeper shell read ledger commands ends without reading any entries when the first entry and last entry are not provided as part command while reading ledger for a specific bookie. The firstentry -fe and lastentry -le becomes mandatory while reading ledger for a specific bookie using the bookkeeper shell readledger command. Make changes to make the -fe and -le optional while reading ledger from a bookie using the readledger command. The readledger should automatically determine the entries to read when the first entry and last entry are not provided.

### Changes

- Update the ReadLedgerCommand to determine the last entry from ledger metadata when lastentry is not provided as part of the command.

### Test

Before:
``` 
bin/bookkeeper shell readledger -l 1234 -bookie 10.10.0.1:3181
17:47:48.786 [main] INFO  o.a.b.c.a.impl.ByteBufAllocatorImpl  - Setting Netty allocator leak detector to Simple
17:47:49.157 [main] INFO  o.a.b.c.RackawareEnsemblePlacementPolicyImpl - Initialize rackaware ensemble placement policy @ <Bookie:10.10.0.3:0> @ /default-rack : org.apache.bookkeeper.client.TopologyAwareEnsemblePlacementPolicy$DefaultResolver.
17:47:49.157 [main] INFO  o.a.b.c.RackawareEnsemblePlacementPolicyImpl - Not weighted
17:47:49.165 [main] INFO  o.a.bookkeeper.client.BookKeeper     - Weighted ledger placement is not enabled
17:47:49.232 [main-EventThread] INFO  o.a.b.discover.ZKRegistrationClient  - Update BookieInfoCache (writable bookie) 10.10.0.1:3181 -> BookieServiceInfo{properties={}, endpoints=[EndpointInfo{id=bookie, port=3181, host=10.10.0.1, protocol=bookie-rpc, auth=[], extensions=[tls]}]}
17:47:49.233 [main-EventThread] INFO  o.a.b.discover.ZKRegistrationClient  - Update BookieInfoCache (writable bookie) 10.10.0.2:3181 -> BookieServiceInfo{properties={}, endpoints=[EndpointInfo{id=bookie, port=3181, host=10.10.0.2, protocol=bookie-rpc, auth=[], extensions=[tls]}]}
17:47:49.233 [main-EventThread] INFO  o.a.b.discover.ZKRegistrationClient  - Update BookieInfoCache (writable bookie) 10.10.0.3:3181 -> BookieServiceInfo{properties={}, endpoints=[EndpointInfo{id=bookie, port=3181, host=10.10.0.3, protocol=bookie-rpc, auth=[], extensions=[tls]}]}
17:47:49.238 [BookKeeperClientScheduler-OrderedScheduler-0-0] INFO  o.a.b.net.NetworkTopologyImpl        - Adding a new node: /default-rack/10.10.0.1:3181
17:47:49.238 [BookKeeperClientScheduler-OrderedScheduler-0-0] INFO  o.a.b.net.NetworkTopologyImpl        - Adding a new node: /default-rack/10.10.0.2:3181
17:47:49.238 [BookKeeperClientScheduler-OrderedScheduler-0-0] INFO  o.a.b.net.NetworkTopologyImpl        - Adding a new node: /default-rack/10.10.0.3:3181
17:47:49.282 [main] WARN  o.a.bookkeeper.client.BookKeeper     - The mainWorkerPool did not shutdown cleanly
```

After:
```
bin/bookkeeper shell readledger -l 1234 -bookie 10.10.0.1:3181
16:26:12.092 [main] INFO  o.a.b.c.a.impl.ByteBufAllocatorImpl  - Setting Netty allocator leak detector to Simple
16:26:12.966 [nioEventLoopGroup-12-1] INFO  o.a.b.proto.PerChannelBookieClient   - Successfully connected to bookie using TLS: 10.10.0.1:3181
16:26:12.988 [BookieClientScheduler-OrderedExecutor-0-0] INFO  o.a.b.t.c.c.bookie.ReadLedgerCommand - --------- Lid=1234, Eid=0 ---------
16:26:12.990 [BookieClientScheduler-OrderedExecutor-0-0] INFO  o.a.b.t.c.c.bookie.ReadLedgerCommand - --------- Lid=1234, Eid=1 ---------
16:26:12.991 [BookieClientScheduler-OrderedExecutor-0-0] INFO  o.a.b.t.c.c.bookie.ReadLedgerCommand - --------- Lid=1234, Eid=2 ---------
16:26:12.992 [BookieClientScheduler-OrderedExecutor-0-0] INFO  o.a.b.t.c.c.bookie.ReadLedgerCommand - --------- Lid=1234, Eid=3 ---------
16:26:22.785 [main] INFO  o.a.b.proto.PerChannelBookieClient   - Closing the per channel bookie client for 10.10.0.1:3181
16:26:22.790 [main] WARN  o.a.bookkeeper.client.BookKeeper     - The mainWorkerPool did not shutdown cleanly
```