### PR TITLE
Optimize cache miss read path

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/HandleFactoryImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/HandleFactoryImpl.java
@@ -72,8 +72,12 @@ class HandleFactoryImpl implements HandleFactory, LedgerDeletionListener {
         LedgerDescriptor handle = readOnlyLedgers.get(ledgerId);
 
         if (handle == null) {
-            handle = LedgerDescriptor.createReadOnly(ledgerId, ledgerStorage);
-            readOnlyLedgers.putIfAbsent(ledgerId, handle);
+            synchronized (this) {
+                if ((handle = readOnlyLedgers.get(ledgerId)) == null) {
+                    handle = LedgerDescriptor.createReadOnly(ledgerId, ledgerStorage);
+                    readOnlyLedgers.putIfAbsent(ledgerId, handle);
+                }
+            }
         }
 
         return handle;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/EntryLogger.java
@@ -24,8 +24,10 @@ import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.bookkeeper.bookie.AbstractLogCompactor;
+import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.Bookie.NoEntryException;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
+import org.apache.commons.lang3.tuple.Pair;
 
 
 /**
@@ -56,6 +58,10 @@ public interface EntryLogger extends AutoCloseable {
      */
     ByteBuf readEntry(long entryLocation)
             throws IOException, NoEntryException;
+    Pair<Integer, ByteBuf> readEntryAndExtraBytes(long ledgerId, long entryId, long entryLocation,
+                                                         int extraBytes)
+            throws IOException, Bookie.NoEntryException;
+
     /**
      * Read an entry from an entrylog location, and verify that is matches the
      * expected ledger and entry ID.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/directentrylogger/DirectEntryLogger.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.bookie.AbstractLogCompactor;
+import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.Bookie.NoEntryException;
 import org.apache.bookkeeper.bookie.EntryLogMetadata;
 import org.apache.bookkeeper.bookie.storage.CompactionEntryLog;
@@ -59,6 +60,7 @@ import org.apache.bookkeeper.common.util.nativeio.NativeIO;
 import org.apache.bookkeeper.slogger.Slogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.LedgerDirUtil;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * DirectEntryLogger.
@@ -209,6 +211,13 @@ public class DirectEntryLogger implements EntryLogger {
     public ByteBuf readEntry(long ledgerId, long entryId, long entryLocation)
             throws IOException, NoEntryException {
         return internalReadEntry(ledgerId, entryId, entryLocation, true);
+    }
+
+    @Override
+    public Pair<Integer, ByteBuf> readEntryAndExtraBytes(long ledgerId, long entryId, long entryLocation,
+                                                         int readBufferSize)
+        throws IOException, Bookie.NoEntryException {
+        throw new UnsupportedOperationException("readEntryAndExtraBytes is not supported in DirectEntryLogger");
     }
 
     private LogReader getReader(int logId) throws IOException {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageStats.java
@@ -88,13 +88,13 @@ class DbLedgerStorageStats {
             help = "time spent reading entries from the locations index of the db ledger storage engine",
             parent = READ_ENTRY
     )
-    private final Counter readFromLocationIndexTime;
+    private final OpStatsLogger readFromLocationIndexTime;
     @StatsDoc(
             name = READ_ENTRYLOG_TIME,
             help = "time spent reading entries from the entry log files of the db ledger storage engine",
             parent = READ_ENTRY
     )
-    private final Counter readFromEntryLogTime;
+    private final OpStatsLogger readFromEntryLogTime;
     @StatsDoc(
             name = WRITE_CACHE_HITS,
             help = "number of write cache hits (on reads)",
@@ -133,7 +133,7 @@ class DbLedgerStorageStats {
             name = READAHEAD_TIME,
             help = "Time spent on readahead operations"
     )
-    private final Counter readAheadTime;
+    private final OpStatsLogger readAheadTime;
     @StatsDoc(
         name = FLUSH,
         help = "operation stats of flushing write cache to entry log files"
@@ -203,15 +203,15 @@ class DbLedgerStorageStats {
                          Supplier<Long> readCacheCountSupplier) {
         addEntryStats = stats.getThreadScopedOpStatsLogger(ADD_ENTRY);
         readEntryStats = stats.getThreadScopedOpStatsLogger(READ_ENTRY);
-        readFromLocationIndexTime = stats.getThreadScopedCounter(READ_ENTRY_LOCATIONS_INDEX_TIME);
-        readFromEntryLogTime = stats.getThreadScopedCounter(READ_ENTRYLOG_TIME);
+        readFromLocationIndexTime = stats.getThreadScopedOpStatsLogger(READ_ENTRY_LOCATIONS_INDEX_TIME);
+        readFromEntryLogTime = stats.getThreadScopedOpStatsLogger(READ_ENTRYLOG_TIME);
         readCacheHitCounter = stats.getCounter(READ_CACHE_HITS);
         readCacheMissCounter = stats.getCounter(READ_CACHE_MISSES);
         writeCacheHitCounter = stats.getCounter(WRITE_CACHE_HITS);
         writeCacheMissCounter = stats.getCounter(WRITE_CACHE_MISSES);
         readAheadBatchCountStats = stats.getOpStatsLogger(READAHEAD_BATCH_COUNT);
         readAheadBatchSizeStats = stats.getOpStatsLogger(READAHEAD_BATCH_SIZE);
-        readAheadTime = stats.getThreadScopedCounter(READAHEAD_TIME);
+        readAheadTime = stats.getOpStatsLogger(READAHEAD_TIME);
         flushStats = stats.getOpStatsLogger(FLUSH);
         flushEntryLogStats = stats.getOpStatsLogger(FLUSH_ENTRYLOG);
         flushLocationIndexStats = stats.getOpStatsLogger(FLUSH_LOCATIONS_INDEX);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DisableReadCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DisableReadCache.java
@@ -1,0 +1,47 @@
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * Disable read cache.
+ */
+public class DisableReadCache extends ReadCache {
+    public DisableReadCache(ByteBufAllocator allocator, long maxCacheSize) {
+        super(allocator, 0);
+    }
+
+    @Override
+    public void put(long ledgerId, long entryId, ByteBuf entry) {
+        // do nothing
+    }
+
+    @Override
+    public ByteBuf get(long ledgerId, long entryId) {
+        // do nothing
+        return null;
+    }
+
+    @Override
+    public boolean hasEntry(long ledgerId, long entryId) {
+        // do nothing
+        return false;
+    }
+
+    @Override
+    public long size() {
+        // do nothing
+        return 0;
+    }
+
+    @Override
+    public long count() {
+        // do nothing
+        return 0;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationCache.java
@@ -20,11 +20,13 @@
  */
 package org.apache.bookkeeper.bookie.storage.ldb;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Location cache.
@@ -33,29 +35,131 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p> The location of an entry is the position of the entry in the entry logger.
  */
-public class LocationCache {
-    private static final Logger log = LoggerFactory.getLogger(LocationCache.class);
 
-    private final Map<Long, Map<Long, Long>> cache = new ConcurrentHashMap<>();
+/**
+ * LocationCache with composite key (ledgerId | entryId) using SkipList
+ */
+public class LocationCache {
+    private final static int MAX_ENTRIES = 1000000;
+    private static final long TIME_WINDOW_MS = 100;
+    private final NavigableMap<CompositeKey, Long> skipMap = new ConcurrentSkipListMap<>();
+    private final long maxEntries;
+    private final NavigableMap<Long, Set<Long>> createTime2LedgerIds = new ConcurrentSkipListMap<>();
+    private final ConcurrentHashMap<Long, Long> ledgerId2CreateTime = new ConcurrentHashMap<>();
+    private final ThreadLocal<CompositeKey> queryKey =
+            ThreadLocal.withInitial(() -> new CompositeKey(0, 0));
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    static class CompositeKey implements Comparable<CompositeKey> {
+        long ledgerId;
+        long entryId;
+
+        CompositeKey(long ledgerId, long entryId) {
+            this.ledgerId = ledgerId;
+            this.entryId = entryId;
+        }
+
+        void set(long ledgerId, long entryId) {
+            this.ledgerId = ledgerId;
+            this.entryId = entryId;
+        }
+
+        @Override
+        public int compareTo(CompositeKey other) {
+            int cmp = Long.compare(this.ledgerId, other.ledgerId);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Long.compare(this.entryId, other.entryId);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CompositeKey that = (CompositeKey) o;
+            return ledgerId == that.ledgerId && entryId == that.entryId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(ledgerId, entryId);
+        }
+    }
+
+    public LocationCache() {
+        this(MAX_ENTRIES);
+    }
+
+    public LocationCache(long maxEntries) {
+        this.maxEntries = maxEntries;
+    }
 
     public long getIfExists(long ledgerId, long entryId) {
-        Map<Long, Long> innerMap = cache.get(ledgerId);
-        if (innerMap != null) {
-            Long aLong = innerMap.get(entryId);
-            return aLong == null ? 0L : aLong;
-        }
-        return 0L;
+        CompositeKey key = queryKey.get();
+        key.set(ledgerId, entryId);
+        Long position = skipMap.get(key);
+        return position != null ? position : 0L;
     }
 
     public void put(long ledgerId, long entryId, long position) {
-        cache.computeIfAbsent(ledgerId, k -> new ConcurrentHashMap<>())
-                .put(entryId, position);
+        CompositeKey key = new CompositeKey(ledgerId, entryId);
+        if (skipMap.containsKey(key)) {
+            skipMap.put(key, position);
+            return;
+        }
+        if (skipMap.size() >= maxEntries) {
+            evictOldestEntries();
+        }
+
+        lock.readLock().lock();
+        try {
+            skipMap.put(key, position);
+            Long timeStamp = ledgerId2CreateTime.computeIfAbsent(ledgerId,
+                    __ -> System.currentTimeMillis() / TIME_WINDOW_MS);
+            createTime2LedgerIds.computeIfAbsent(timeStamp,
+                    __ -> ConcurrentHashMap.newKeySet()).add(ledgerId);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+
+    private void evictOldestEntries() {
+        lock.writeLock().lock();
+        try {
+            if (skipMap.size() < maxEntries) {
+                return;
+            }
+            Map.Entry<Long, Set<Long>> firstEntry = createTime2LedgerIds.pollFirstEntry();
+            if (firstEntry != null) {
+                Long createTime = firstEntry.getKey();
+                Set<Long> ledgerIds = firstEntry.getValue();
+                for (Long ledgerId : ledgerIds) {
+                    removeLedger(ledgerId);
+                }
+                createTime2LedgerIds.remove(createTime);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public void removeLedger(long ledgerId) {
-        Map<Long, Long> remove = cache.remove(ledgerId);
-        if (remove != null) {
-            remove.clear();
+        lock.writeLock().lock();
+        try {
+            CompositeKey startKey = new CompositeKey(ledgerId, 0);
+            CompositeKey endKey = new CompositeKey(ledgerId, Long.MAX_VALUE);
+            NavigableMap<CompositeKey, Long> ledgerEntries =
+                    skipMap.subMap(startKey, true, endKey, true);
+            ledgerEntries.clear();
+            ledgerId2CreateTime.remove(ledgerId);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationCache.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/LocationCache.java
@@ -1,0 +1,61 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Location cache.
+ *
+ * <p> This class is used to cache the location of entries in the entry logger.
+ *
+ * <p> The location of an entry is the position of the entry in the entry logger.
+ */
+public class LocationCache {
+    private static final Logger log = LoggerFactory.getLogger(LocationCache.class);
+
+    private final Map<Long, Map<Long, Long>> cache = new ConcurrentHashMap<>();
+
+    public long getIfExists(long ledgerId, long entryId) {
+        Map<Long, Long> innerMap = cache.get(ledgerId);
+        if (innerMap != null) {
+            Long aLong = innerMap.get(entryId);
+            return aLong == null ? 0L : aLong;
+        }
+        return 0L;
+    }
+
+    public void put(long ledgerId, long entryId, long position) {
+        cache.computeIfAbsent(ledgerId, k -> new ConcurrentHashMap<>())
+                .put(entryId, position);
+    }
+
+    public void removeLedger(long ledgerId) {
+        Map<Long, Long> remove = cache.remove(ledgerId);
+        if (remove != null) {
+            remove.clear();
+        }
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -56,7 +56,8 @@ public class DbLedgerStorageWriteCacheTest {
         protected SingleDirectoryDbLedgerStorage newSingleDirectoryDbLedgerStorage(ServerConfiguration conf,
             LedgerManager ledgerManager, LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
             EntryLogger entryLogger, StatsLogger statsLogger,
-            long writeCacheSize, long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
+            long writeCacheSize, long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize,
+            boolean disableReadCache, boolean enableLocationCache)
                 throws IOException {
             return new MockedSingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerDirsManager, indexDirsManager,
                 entryLogger, statsLogger, allocator, writeCacheSize,
@@ -72,7 +73,7 @@ public class DbLedgerStorageWriteCacheTest {
                     throws IOException {
                 super(conf, ledgerManager, ledgerDirsManager, indexDirsManager, entryLogger,
                       statsLogger, allocator, writeCacheSize, readCacheSize, readAheadCacheBatchSize,
-                      readAheadCacheBatchBytesSize);
+                      readAheadCacheBatchBytesSize, false, false);
             }
 
           @Override


### PR DESCRIPTION
Descriptions of the changes in this PR:

<!-- Either this PR fixes an issue, -->

### Motivation

The current synchronous read-ahead implementation in BookKeeper has several limitations:

1. Inefficient for sequential reads: Since reads are serialized within a ledger, sync read-ahead provides no benefit for sequential read patterns.
2. Read amplification: When read cache hit ratio falls below (n-1)/n (where n is read ahead size), we experience read amplification as each cache miss triggers a full batch read from disk, wasting I/O bandwidth.
3. RocksDB bottleneck: Cache misses require RocksDB lookups for entry locations, which will become a performance bottleneck.

### Changes

This PR proposes improvements to the miss cache read:
1. rely on OS page cache for read-ahead patterns instead of application-level batching.
2. when reading an entry, additionally read the next 20 bytes (containing ledgerId and entryId), caching the next location to reduce RocksDB queries.
3. particularly benefits sequential read patterns (common in Pulsar).
