### PR TITLE
[security] Replace net.jpountz.lz4:lz4 with at.yawk.lz4:lz4-java

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -276,7 +276,7 @@ Apache Software License, Version 2.
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
-- lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
+- lib/at.yawk.lz4-lz4-java-1.10.2.jar [26]
 - lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [28]
 - lib/com.google.code.gson-gson-2.11.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
@@ -383,7 +383,7 @@ Apache Software License, Version 2.
 [23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
-[26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
+[26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
 [28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
@@ -503,13 +503,13 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
     * deps/netty/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/jpountz/lz4-java
+    * https://github.com/yawkat/lz4-java
 
 lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -247,7 +247,7 @@ Apache Software License, Version 2.
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.3.jar [20]
 - lib/org.apache.zookeeper-zookeeper-3.9.3-tests.jar [20]
 - lib/com.beust-jcommander-1.82.jar [23]
-- lib/net.jpountz.lz4-lz4-1.3.0.jar [25]
+- lib/at.yawk.lz4-lz4-java-1.10.2.jar [25]
 - lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [27]
 - lib/com.google.code.gson-gson-2.11.0.jar [28]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [29]
@@ -325,7 +325,7 @@ Apache Software License, Version 2.
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
 [20] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [23] Source available at https://github.com/cbeust/jcommander/tree/1.82
-[25] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
+[25] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
 [27] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [28] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [29] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
@@ -440,13 +440,13 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
     * deps/netty/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/jpountz/lz4-java
+    * https://github.com/yawkat/lz4-java
 
 lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -276,7 +276,7 @@ Apache Software License, Version 2.
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
 - lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
-- lib/net.jpountz.lz4-lz4-1.3.0.jar [26]
+- lib/at.yawk.lz4-lz4-java-1.10.2.jar [26]
 - lib/com.google.api.grpc-proto-google-common-protos-2.51.0.jar [28]
 - lib/com.google.code.gson-gson-2.11.0.jar [29]
 - lib/io.opencensus-opencensus-api-0.31.1.jar [30]
@@ -379,7 +379,7 @@ Apache Software License, Version 2.
 [23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
-[26] Source available at https://github.com/lz4/lz4-java/tree/1.3.0
+[26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
 [28] Source available at https://github.com/googleapis/java-common-protos/tree/v2.51.0
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.11.0
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1
@@ -498,13 +498,13 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4', a LZ4 Java compression
+lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
     * deps/netty/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/jpountz/lz4-java
+    * https://github.com/yawkat/lz4-java
 
 lib/io.netty-netty-codec-4.1.121.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <libthrift.version>0.14.2</libthrift.version>
     <lombok.version>1.18.32</lombok.version>
     <log4j.version>2.23.1</log4j.version>
-    <lz4.version>1.3.0</lz4.version>
+    <lz4-java.version>1.10.2</lz4-java.version>
     <mockito.version>4.11.0</mockito.version>
     <netty.version>4.1.121.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
@@ -343,9 +343,9 @@
 
       <!-- compression libs -->
       <dependency>
-        <groupId>net.jpountz.lz4</groupId>
-        <artifactId>lz4</artifactId>
-        <version>${lz4.version}</version>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4-java.version}</version>
       </dependency>
 
       <!-- yaml dependencies -->

--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -74,7 +74,7 @@
                   <include>com.google.guava:failureaccess</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
-                  <include>net.jpountz.lz4:lz4</include>
+                  <include>at.yawk.lz4:lz4-java</include>
                   <include>org.apache.bookkeeper:bookkeeper-common</include>
                   <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
                   <include>org.apache.bookkeeper:native-library-common</include>

--- a/stream/distributedlog/common/pom.xml
+++ b/stream/distributedlog/common/pom.xml
@@ -70,8 +70,8 @@
       <artifactId>netty-buffer</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>


### PR DESCRIPTION
### Motivation

`net.jpountz.lz4:lz4` has been reported to contain multiple vulnerabilities, but it is no longer maintained and users are advised to migrate to the community version, `at.yawk.lz4:lz4-java`.
https://www.sonatype.com/security-advisories/cve-2025-12183

### Changes

Pulsar has already done this replacement, so I made a similar change.
https://github.com/apache/pulsar/pull/25032
Migrating to `at.yawk.lz4:lz4-java` will fix the vulnerabilities, but the security advisory also recommends replacing `.fastDecompressor()` with `.safeDecompressor()` for better performance.
