### PR TITLE
Fix the stream client python package name

### DIFF
--- a/stream/clients/python/setup.py
+++ b/stream/clients/python/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 # Package metadata.
 
-name = 'apache-bookkeeper-client'
+name = 'apache_bookkeeper_client'
 description = 'Apache BookKeeper client library'
 version = '4.18.0'
 # Should be one of:


### PR DESCRIPTION
---

### Motivation

```
WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Filename 'apache-bookkeeper-client-4.17.3.tar.gz' is invalid, should be 'apache_bookkeeper_client-4.17.3.tar.gz'.
```
