### PR TITLE
build(deps): bump org.apache.commons:commons-lang3 from 3.17.0 to 3.20.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-configuration2-2.12.0.jar [7]
-- lib/org.apache.commons-commons-lang3-3.17.0.jar [58]
+- lib/org.apache.commons-commons-lang3-3.20.0.jar [58]
 - lib/org.apache.commons-commons-text-1.13.1.jar [61]
 - lib/org.apache.zookeeper-zookeeper-3.9.5.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.5.jar [21]
@@ -415,7 +415,7 @@ Apache Software License, Version 2.
 [55] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v2.2.21
 [57] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
-[58] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
+[58] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [59] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.21.0
 [60] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
 [61] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -241,7 +241,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [16]
 - lib/org.apache.commons-commons-collections4-4.1.jar [18]
 - lib/org.apache.commons-commons-configuration2-2.12.0.jar [7]
-- lib/org.apache.commons-commons-lang3-3.17.0.jar [55]
+- lib/org.apache.commons-commons-lang3-3.20.0.jar [55]
 - lib/org.apache.commons-commons-text-1.13.1.jar [56]
 - lib/org.apache.zookeeper-zookeeper-3.9.5.jar [20]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.5.jar [20]
@@ -351,7 +351,7 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
-[55] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
+[55] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [56] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [58] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -260,7 +260,7 @@ Apache Software License, Version 2.
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [17]
 - lib/org.apache.commons-commons-collections4-4.1.jar [19]
 - lib/org.apache.commons-commons-configuration2-2.12.0.jar [7]
-- lib/org.apache.commons-commons-lang3-3.17.0.jar [57]
+- lib/org.apache.commons-commons-lang3-3.20.0.jar [57]
 - lib/org.apache.commons-commons-text-1.13.1.jar [60]
 - lib/org.apache.zookeeper-zookeeper-3.9.5.jar [21]
 - lib/org.apache.zookeeper-zookeeper-jute-3.9.5.jar [21]
@@ -410,7 +410,7 @@ Apache Software License, Version 2.
 [54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v2.2.21
 [56] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
-[57] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.17.0
+[57] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [58] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.21.0
 [59] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
 [60] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <commons-configuration2.version>2.12.0</commons-configuration2.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-compress.version>1.27.1</commons-compress.version>
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <commons-io.version>2.19.0</commons-io.version>
     <bouncycastle.version>1.0.2.5</bouncycastle.version>


### PR DESCRIPTION
Fixes CVE-2025-48924