### PR TITLE
Upgrade zookeeper to 3.9.5 in docker-compose and integration tests

### DIFF
--- a/deploy/docker-compose/compose/values.yaml
+++ b/deploy/docker-compose/compose/values.yaml
@@ -32,7 +32,7 @@ networkMode: bridge
 
 zookeeper:
   size: 3
-  image: zookeeper:3.8.0
+  image: zookeeper:3.9.5
   adminPort: 8080
   clientPort: 2181
   peerPort: 2888

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -23,7 +23,7 @@ version: '3'
 
 services:
   zookeeper-1:
-    image: zookeeper:3.8.0
+    image: zookeeper:3.9.5
     ports:
       - "9080:8080"
       - "2181:2181"
@@ -39,7 +39,7 @@ services:
     restart: on-failure
   
   zookeeper-2:
-    image: zookeeper:3.8.0
+    image: zookeeper:3.9.5
     ports:
       - "9081:8080"
       - "2182:2181"
@@ -55,7 +55,7 @@ services:
     restart: on-failure
   
   zookeeper-3:
-    image: zookeeper:3.8.0
+    image: zookeeper:3.9.5
     ports:
       - "9082:8080"
       - "2183:2181"

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/3-node-all-version-unstarted.yaml
@@ -22,7 +22,7 @@ networks:
     driver: bridge
 
 zookeeper*:
-  image: zookeeper:3.9.3
+  image: zookeeper:3.9.5
   await:
     strategy: org.apache.bookkeeper.tests.integration.utils.ZooKeeperAwaitStrategy
   aliases:

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/MavenClassLoader.java
@@ -116,7 +116,7 @@ public class MavenClassLoader implements AutoCloseable {
         List<MavenDependency> deps = Lists.newArrayList(
                 dependency);
         // use newer zookeeper version in all cases
-        deps.add(MavenDependencies.createDependency("org.apache.zookeeper:zookeeper:3.9.3",
+        deps.add(MavenDependencies.createDependency("org.apache.zookeeper:zookeeper:3.9.5",
                 ScopeType.COMPILE, false));
         if (slf4jVersion.isPresent()) {
             deps.add(MavenDependencies.createDependency("org.slf4j:slf4j-simple:" + slf4jVersion.get(),


### PR DESCRIPTION
### Motivation

docker-compose examples and integration tests use older zookeeper versions

### Changes

upgrade to 3.9.5 in these cases