### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://bookkeeper.apache.org/img/bk-logo.svg" alt="logo" width="64"/>&nbsp;&nbsp;[![Maven Central](https://img.shields.io/maven-central/v/org.apache.bookkeeper/bookkeeper-server.svg)](https://central.sonatype.com/artifact/org.apache.bookkeeper/bookkeeper-server)
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.bookkeeper/bookkeeper-server.svg)](https://central.sonatype.com/artifact/org.apache.bookkeeper/bookkeeper-server)
 
-# Apache BookKeeper
+# <img src="https://bookkeeper.apache.org/img/bk-logo.svg" alt="logo" width="50"/> Apache BookKeeper
 
 Apache BookKeeper is a scalable, fault-tolerant and low latency storage service optimized for append-only workloads.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<img src="https://pbs.twimg.com/profile_images/545716709311520769/piLLa1iC_400x400.png" alt="logo" style="width: 32px;"/>
-
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.bookkeeper/bookkeeper/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.bookkeeper/bookkeeper)
+<img src="https://bookkeeper.apache.org/img/bk-logo.svg" alt="logo" width="64"/>&nbsp;&nbsp;[![Maven Central](https://img.shields.io/maven-central/v/org.apache.bookkeeper/bookkeeper-server.svg)](https://central.sonatype.com/artifact/org.apache.bookkeeper/bookkeeper-server)
 
 # Apache BookKeeper
 


### PR DESCRIPTION
### Motivation

The badge in the header of the README file is outdated

### Changes

- use shields.io for the badge
- update the logo to use the website logo svg