### PR TITLE
Fix read thread blocking in sendResponseAndWait causing READ_ENTRY_REQUEST p99 latency spike

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -1075,10 +1075,16 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     /**
      * Get max number of reads in progress. 0 == unlimited.
      *
+     * <p>This limit bounds the memory used by read responses that have been read from storage
+     * but not yet flushed to the network. Since read response writes are non-blocking,
+     * without this limit a slow consumer could cause unbounded memory growth.
+     * The default value of 10000 provides a reasonable balance between throughput and memory usage.
+     * Tune based on your average entry size: memoryBudget / avgEntrySize.
+     *
      * @return Max number of reads in progress.
      */
     public int getMaxReadsInProgressLimit() {
-        return this.getInt(MAX_READS_IN_PROGRESS_LIMIT, 0);
+        return this.getInt(MAX_READS_IN_PROGRESS_LIMIT, 10000);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PacketProcessorBase.java
@@ -19,8 +19,8 @@ package org.apache.bookkeeper.proto;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.proto.BookieProtocol.Request;
@@ -74,10 +74,12 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
     protected void sendReadReqResponse(int rc, Object response, OpStatsLogger statsLogger, boolean throttle) {
         if (throttle) {
             sendResponseAndWait(rc, response, statsLogger);
+            // onReadRequestFinish is called asynchronously in the ChannelFutureListener
+            // inside sendResponseAndWait to maintain throttling without blocking the thread.
         } else {
             sendResponse(rc, response, statsLogger);
+            requestProcessor.onReadRequestFinish();
         }
-        requestProcessor.onReadRequestFinish();
     }
 
     protected void sendResponse(int rc, Object response, OpStatsLogger statsLogger) {
@@ -150,27 +152,44 @@ abstract class PacketProcessorBase<T extends Request> implements Runnable {
     }
 
     /**
-     * Write on the channel and wait until the write is completed.
+     * Write on the channel and notify completion via a listener.
      *
-     * <p>That will make the thread to get blocked until we're able to
-     * write everything on the TCP stack, providing auto-throttling
-     * and avoiding using too much memory when handling read-requests.
+     * <p>This provides auto-throttling by holding the read semaphore until the write completes,
+     * without blocking the read thread pool thread. The read thread is freed immediately to
+     * process other requests, while the semaphore prevents unbounded read concurrency.
      */
     protected void sendResponseAndWait(int rc, Object response, OpStatsLogger statsLogger) {
+        // Capture fields before the processor may be recycled after this method returns.
+        final long capturedEnqueueNanos = this.enqueueNanos;
+        final BookieRequestProcessor processor = this.requestProcessor;
         try {
             Channel channel = requestHandler.ctx().channel();
             ChannelFuture future = channel.writeAndFlush(response);
-            if (!channel.eventLoop().inEventLoop()) {
-                future.get();
+            future.addListener((ChannelFutureListener) f -> {
+                if (!f.isSuccess() && logger.isDebugEnabled()) {
+                    logger.debug("Netty channel write exception. ", f.cause());
+                }
+                if (BookieProtocol.EOK == rc) {
+                    statsLogger.registerSuccessfulEvent(
+                            MathUtils.elapsedNanos(capturedEnqueueNanos), TimeUnit.NANOSECONDS);
+                } else {
+                    statsLogger.registerFailedEvent(
+                            MathUtils.elapsedNanos(capturedEnqueueNanos), TimeUnit.NANOSECONDS);
+                }
+                processor.onReadRequestFinish();
+            });
+        } catch (Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Netty channel write exception. ", e);
             }
-        } catch (ExecutionException | InterruptedException e) {
-            logger.debug("Netty channel write exception. ", e);
-            return;
-        }
-        if (BookieProtocol.EOK == rc) {
-            statsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
-        } else {
-            statsLogger.registerFailedEvent(MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
+            if (BookieProtocol.EOK == rc) {
+                statsLogger.registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(capturedEnqueueNanos), TimeUnit.NANOSECONDS);
+            } else {
+                statsLogger.registerFailedEvent(
+                        MathUtils.elapsedNanos(capturedEnqueueNanos), TimeUnit.NANOSECONDS);
+            }
+            processor.onReadRequestFinish();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.proto;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -39,10 +40,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieProtocol.ReadRequest;
 import org.apache.bookkeeper.proto.BookieProtocol.Response;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -294,5 +297,80 @@ public class ReadEntryProcessorTest {
         verify(channel, times(1)).writeAndFlush(any(), any(ChannelPromise.class));
         // onReadRequestFinish should have been called synchronously
         verify(requestProcessor, times(1)).onReadRequestFinish();
+    }
+
+    /**
+     * Verify that maxReadsInProgressLimit defaults to 10000 (enabled),
+     * ensuring non-blocking read response writes are bounded by default.
+     */
+    @Test
+    public void testDefaultMaxReadsInProgressLimitIsEnabled() {
+        ServerConfiguration conf = new ServerConfiguration();
+        assertEquals("maxReadsInProgressLimit should default to 10000",
+                10000, conf.getMaxReadsInProgressLimit());
+    }
+
+    /**
+     * Test that the read semaphore is held from request creation until the write future completes,
+     * not released when the read thread returns. This ensures that maxReadsInProgressLimit correctly
+     * bounds the number of read responses buffered in memory, even though the read thread is
+     * non-blocking.
+     */
+    @Test
+    public void testThrottledReadHoldsSemaphoreUntilWriteCompletes() throws Exception {
+        // Simulate maxReadsInProgressLimit=1 with a real semaphore
+        Semaphore readsSemaphore = new Semaphore(1);
+
+        doAnswer(inv -> {
+            readsSemaphore.acquireUninterruptibly();
+            return null;
+        }).when(requestProcessor).onReadRequestStart(any(Channel.class));
+        doAnswer(inv -> {
+            readsSemaphore.release();
+            return null;
+        }).when(requestProcessor).onReadRequestFinish();
+
+        // Setup non-event-loop thread
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doAnswer(inv -> {
+            ((Runnable) inv.getArgument(0)).run();
+            return null;
+        }).when(eventLoop).execute(any(Runnable.class));
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        // Controllable write future
+        DefaultChannelPromise writeFuture = new DefaultChannelPromise(channel);
+        doAnswer(inv -> writeFuture).when(channel).writeAndFlush(any(Response.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(
+                BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId, 1, (short) 0, new byte[]{});
+
+        // create() calls onReadRequestStart → semaphore acquired
+        ReadEntryProcessor processor = ReadEntryProcessor.create(
+                request, requestHandler, requestProcessor, null, true /* throttle */);
+
+        // Semaphore should be acquired (1 permit used)
+        assertEquals("semaphore should have 0 permits after read started",
+                0, readsSemaphore.availablePermits());
+
+        // Run the processor — thread returns immediately (non-blocking)
+        processor.run();
+
+        // Semaphore should STILL be held (write not completed)
+        assertEquals("semaphore should still have 0 permits while write is in progress",
+                0, readsSemaphore.availablePermits());
+
+        // A second read would be unable to acquire the semaphore
+        assertFalse("second read should not be able to acquire semaphore",
+                readsSemaphore.tryAcquire());
+
+        // Complete the write
+        writeFuture.setSuccess();
+
+        // Now semaphore should be released — a new read can proceed
+        assertEquals("semaphore should have 1 permit after write completes",
+                1, readsSemaphore.availablePermits());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -194,5 +195,104 @@ public class ReadEntryProcessorTest {
         assertEquals(ledgerId, response.getLedgerId());
         assertEquals(BookieProtocol.READENTRY, response.getOpCode());
         assertEquals(BookieProtocol.EOK, response.getErrorCode());
+    }
+
+    /**
+     * Test that when throttleReadResponses=true and the caller is not in the Netty event loop,
+     * the read thread is not blocked by the write. onReadRequestFinish() should only be called
+     * after the write future completes, preserving throttling without blocking the thread.
+     */
+    @Test
+    public void testThrottledReadNonBlockingOnSuccess() throws Exception {
+        // Setup event loop to simulate read worker thread (not event loop thread)
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doAnswer(inv -> {
+            ((Runnable) inv.getArgument(0)).run();
+            return null;
+        }).when(eventLoop).execute(any(Runnable.class));
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        // Use a controllable promise so we can verify deferred behavior
+        DefaultChannelPromise writeFuture = new DefaultChannelPromise(channel);
+        doAnswer(inv -> writeFuture).when(channel).writeAndFlush(any(Response.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(
+                BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId, 1, (short) 0, new byte[]{});
+        ReadEntryProcessor processor = ReadEntryProcessor.create(
+                request, requestHandler, requestProcessor, null, true /* throttle */);
+
+        // run() should return immediately without blocking on the write
+        processor.run();
+
+        // Write should have been issued
+        verify(channel, times(1)).writeAndFlush(any(Response.class));
+        // But onReadRequestFinish should NOT have been called yet — write not completed
+        verify(requestProcessor, never()).onReadRequestFinish();
+
+        // Complete the write
+        writeFuture.setSuccess();
+
+        // Now onReadRequestFinish should have been called
+        verify(requestProcessor, times(1)).onReadRequestFinish();
+    }
+
+    /**
+     * Test that onReadRequestFinish() is still called even when the write fails,
+     * so the read semaphore is always released.
+     */
+    @Test
+    public void testThrottledReadNonBlockingOnWriteFailure() throws Exception {
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doAnswer(inv -> {
+            ((Runnable) inv.getArgument(0)).run();
+            return null;
+        }).when(eventLoop).execute(any(Runnable.class));
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        DefaultChannelPromise writeFuture = new DefaultChannelPromise(channel);
+        doAnswer(inv -> writeFuture).when(channel).writeAndFlush(any(Response.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(
+                BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId, 1, (short) 0, new byte[]{});
+        ReadEntryProcessor processor = ReadEntryProcessor.create(
+                request, requestHandler, requestProcessor, null, true /* throttle */);
+
+        processor.run();
+
+        verify(channel, times(1)).writeAndFlush(any(Response.class));
+        verify(requestProcessor, never()).onReadRequestFinish();
+
+        // Fail the write
+        writeFuture.setFailure(new IOException("channel write failed"));
+
+        // onReadRequestFinish must still be called to release the read semaphore
+        verify(requestProcessor, times(1)).onReadRequestFinish();
+    }
+
+    /**
+     * Test that when throttleReadResponses=false, onReadRequestFinish() is called
+     * synchronously before run() returns.
+     */
+    @Test
+    public void testNonThrottledReadCallsOnFinishSynchronously() throws Exception {
+        // sendResponse (non-throttle path) uses channel.isActive() and two-arg writeAndFlush
+        when(channel.isActive()).thenReturn(true);
+        when(channel.writeAndFlush(any(), any(ChannelPromise.class))).thenReturn(mock(ChannelPromise.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(
+                BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId, 1, (short) 0, new byte[]{});
+        ReadEntryProcessor processor = ReadEntryProcessor.create(
+                request, requestHandler, requestProcessor, null, false /* no throttle */);
+
+        processor.run();
+
+        verify(channel, times(1)).writeAndFlush(any(), any(ChannelPromise.class));
+        // onReadRequestFinish should have been called synchronously
+        verify(requestProcessor, times(1)).onReadRequestFinish();
     }
 }


### PR DESCRIPTION


### Motivation

  During performance testing, we observed that bookkeeper_server_READ_ENTRY p99 latency is less than 100ms, but bookkeeper_server_READ_ENTRY_REQUEST p99 latency spikes to 3 seconds. The two metrics
  differ in scope:

  - READ_ENTRY measures the storage read time only (from before readData() to after it completes)
  - READ_ENTRY_REQUEST measures from request enqueue time (enqueueNanos) through response write

  The root cause is in PacketProcessorBase.sendResponseAndWait(). When readWorkerThreadsThrottlingEnabled=true (the default), read responses go through sendResponseAndWait, which calls future.get() to
  block the read thread pool thread until the Netty channel write completes.

  Under heavy read load, this causes a cascading failure:

  1. future.get() blocks each read thread waiting for Netty write completion
  2. If writes are slow (client backpressure, network congestion, event loop busy), threads pile up blocked
  3. The read thread pool becomes saturated — all threads blocked waiting for writes
  4. New read requests queue up, and their scheduling delay grows
  5. READ_ENTRY_REQUEST (measured from enqueueNanos) spikes, even for requests to healthy channels

  One slow consumer can block a thread pool thread, reducing capacity for all other channels — a classic head-of-line blocking problem.

### Changes
 **1. Non-blocking sendResponseAndWait (PacketProcessorBase.java)**

Replace the blocking future.get() in sendResponseAndWait() with a non-blocking ChannelFutureListener. The key design decisions:

  - Read thread freed immediately: After writeAndFlush, the thread returns to the pool and can process other requests instead of blocking on future.get()
  - Throttling semantics preserved: onReadRequestFinish() (which releases the read semaphore) is moved into the ChannelFutureListener, so it is only called after the write completes. This ensures the
  read concurrency limit still gates on write completion, without wasting a thread to enforce it.
  - Captured local variables: Since the processor may be recycled after sendResponseAndWait returns, enqueueNanos and requestProcessor are captured as local variables before the async callback.
  - Semaphore always released: Both the success and failure paths in the listener call onReadRequestFinish(), preventing semaphore leaks on write failure. (The previous code had a subtle issue: on
  ExecutionException/InterruptedException, sendResponseAndWait returned early without recording the metric, though onReadRequestFinish was still called by the caller.)

  **2. Enable maxReadsInProgressLimit by default (ServerConfiguration.java)**

  Changed the default of maxReadsInProgressLimit from 0 (unlimited) to 10000.

  With the old blocking sendResponseAndWait, the read thread pool (default 8 threads) acted as an implicit concurrency bound — each thread blocked on one write at a time, so at most 8 responses could be
  buffered. With the new non-blocking approach, threads are freed immediately and keep processing reads. Without a bound, a slow consumer could cause unbounded response buffer growth in Netty's write
  queue, leading to OOM.

  The maxReadsInProgressLimit semaphore now serves as the explicit bound. Since onReadRequestFinish() is called in the ChannelFutureListener (after the write completes), the semaphore precisely counts
  reads whose response data is in memory but not yet flushed. The default of 10,000 provides good throughput (~40MB at 4KB entries) while preventing unbounded memory growth. Users with larger entries
  should tune this lower (memoryBudget / avgEntrySize).

### Test Plan
  Added 5 new unit tests to ReadEntryProcessorTest:

  - testThrottledReadNonBlockingOnSuccess — verifies that with throttle=true, run() returns immediately and onReadRequestFinish() is deferred until the write future completes
  - testThrottledReadNonBlockingOnWriteFailure — verifies onReadRequestFinish() is still called when the write fails, ensuring the read semaphore is always released
  - testNonThrottledReadCallsOnFinishSynchronously — verifies that with throttle=false, onReadRequestFinish() is called synchronously
  - testDefaultMaxReadsInProgressLimitIsEnabled — verifies maxReadsInProgressLimit defaults to 10000
  - testThrottledReadHoldsSemaphoreUntilWriteCompletes — uses a real Semaphore(1) wired to onReadRequestStart/onReadRequestFinish to verify the full lifecycle: semaphore acquired at request creation,
  held through non-blocking run() return, blocks a second read while write is in progress, and released only when the write future completes


