### PR TITLE
Issue 2422: Fix SyncLedgerIterator.hasNext() failing to iterate across ZK ledger ranges

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -1583,17 +1583,20 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             this.parent = parent;
         }
 
-        @Override
+        /**
+         * ZooKeeper stores ledgers in a hierarchical tree (e.g. /ledgers/00/0000/...).
+         * {@code iterator} (LedgerRangeIterator) traverses the intermediate tree nodes (ranges/buckets),
+         * while {@code currentRange} iterates over the leaf-level ledger IDs within a single range.
+         *
+         * Therefore, when {@code currentRange} has no more leaf nodes, we need to check
+         * {@code iterator.hasNext()} to determine if there are more ranges to advance to.
+         */
         public boolean hasNext() throws IOException {
             parent.checkClosed();
-            if (currentRange != null) {
-                if (currentRange.hasNext()) {
-                    return true;
-                }
-            } else if (iterator.hasNext()) {
+            if (currentRange != null && currentRange.hasNext()) {
                 return true;
             }
-            return false;
+            return iterator.hasNext();
         }
 
         @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/LedgerMetadataTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/LedgerMetadataTest.java
@@ -190,4 +190,150 @@ public class LedgerMetadataTest extends BookKeeperClusterTestCase {
         }
     }
 
+    /**
+     * Unlike {@link #testListLedgers()} which only uses 10 ledgers within a single ZK range,
+     * this test creates 10010 ledgers to verify cross-range iteration.
+     *
+     * <p>The HierarchicalLedgerManager stores ledgers in a ZK tree where each range (znode)
+     * holds at most 10,000 leaf nodes. This limit is determined by the 4-digit last level of
+     * the ledger ID path (0000-9999), as defined in:
+     * <ul>
+     *   <li>{@code LegacyHierarchicalLedgerManager} — 2-4-4 split,
+     *       path: {root}/{level1}/{level2}/L{level3}</li>
+     *   <li>{@code LongHierarchicalLedgerManager} — 3-4-4-4-4 split,
+     *       path: {root}/{level0}/{level1}/{level2}/{level3}/L{level4}</li>
+     * </ul>
+     *
+     * <p>By using numOfLedgers = 10010 (> 10000), ledgers will span across multiple ranges,
+     * exercising the SyncLedgerIterator's ability to advance from one exhausted range to the
+     * next via LedgerRangeIterator.
+     */
+    @Test
+    public void testListLedgersLargeScale()
+            throws Exception {
+        // 10010 > 10000 (max ledgers per ZK range, determined by 4-digit last level 0000-9999),
+        // ensuring cross-range iteration is covered
+        int numOfLedgers = 10010;
+
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(zkUtil.getMetadataServiceUri());
+
+        try (BookKeeper bkc = BookKeeper.newBuilder(conf).build();) {
+            long[] ledgerIds = new long[numOfLedgers];
+            for (int i = 0; i < numOfLedgers; i++) {
+
+                try (WriteHandle l = bkc
+                        .newCreateLedgerOp()
+                        .withDigestType(DigestType.CRC32)
+                        .withPassword("testPasswd".getBytes())
+                        .execute()
+                        .get();) {
+                    ledgerIds[i] = l.getId();
+                }
+            }
+
+            try (ListLedgersResult result = FutureUtils.result(bkc.newListLedgersOp().execute());) {
+                int count = 0;
+
+                for (long ledgerId : result.toIterable()) {
+                    assertEquals(ledgerIds[count++], ledgerId);
+                }
+
+                assertEquals(numOfLedgers, count, "Unexpected ledgers count");
+                try {
+                    result.iterator();
+                    fail("Should thrown error");
+                } catch (IllegalStateException e) {
+                    // ok
+                }
+                try {
+                    result.toIterable();
+                    fail("Should thrown error");
+                } catch (IllegalStateException e) {
+                    // ok
+                }
+            }
+
+            try (ListLedgersResult result = FutureUtils.result(bkc.newListLedgersOp().execute());) {
+                int count = 0;
+
+                for (LedgersIterator iterator = result.iterator(); iterator.hasNext();) {
+                    long ledgerId = iterator.next();
+                    assertEquals(ledgerIds[count++], ledgerId);
+
+                }
+                assertEquals(numOfLedgers, count, "Unexpected ledgers count");
+                try {
+                    result.iterator();
+                    fail("Should thrown error");
+                } catch (IllegalStateException e) {
+                    // ok
+                }
+                try {
+                    result.toIterable();
+                    fail("Should thrown error");
+                } catch (IllegalStateException e) {
+                    // ok
+                }
+            }
+        }
+
+        // check closed
+        {
+            ListLedgersResult result = FutureUtils.result(bkc.newListLedgersOp().execute());
+            result.close();
+            try {
+                result.toIterable();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+
+            try {
+                result.iterator();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+        }
+
+        { // iterator
+            ListLedgersResult result = FutureUtils.result(bkc.newListLedgersOp().execute());
+            LedgersIterator it = result.iterator();
+            result.close();
+            try {
+                it.hasNext();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+
+            try {
+                it.next();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+        }
+
+        { // iterable
+            ListLedgersResult result = FutureUtils.result(bkc.newListLedgersOp().execute());
+            Iterator<Long> it = result.toIterable().iterator();
+            result.close();
+            try {
+                it.hasNext();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+
+            try {
+                it.next();
+                fail("Should thrown error");
+            } catch (IllegalStateException e) {
+                // ok
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fix #2422

Related PR: #2457

### Motivation

The `SyncLedgerIterator.hasNext()` method in `BookKeeper.java` has a logic bug that causes it to stop iterating prematurely when ledgers span across multiple ZooKeeper ranges.

ZooKeeper stores ledgers in a hierarchical tree structure (e.g. `/ledgers/00/0000/...`). Each range (znode) holds at most 10,000 leaf-level ledger IDs.
The 10,000 limit is determined by the 4-digit last level (0000-9999) as defined in `LegacyHierarchicalLedgerManager` (2-4-4 split) and `LongHierarchicalLedgerManager` (3-4-4-4-4 split). When the number of ledgers exceeds 10,000, they are distributed across multiple ranges.
<img width="974" height="1202" alt="image" src="https://github.com/user-attachments/assets/38e845bc-ff16-479a-8b94-c0acd0391076" />


The original `hasNext()` implementation had the following logic:
```Java
@Override
public boolean hasNext() throws IOException {
    parent.checkClosed();
    if (currentRange != null) {
        if (currentRange.hasNext()) {
            return true;
        }
    } else if (iterator.hasNext()) {
        return true;
    }
    return false;
}
```
When `currentRange` is non-null but exhausted (no more elements), it falls through to `return false` **without** checking `iterator.hasNext()` for more ranges.


### Changes

1. Fix `SyncLedgerIterator.hasNext()` in `BookKeeper.java`:
Simplified the conditional logic to properly fall through to `iterator.hasNext()` when the current range is exhausted
2. Add `testListLedgersLargeScale()` test in `LedgerMetadataTest.java`
Added a new test case with `numOfLedgers = 10010` (> 10,000 per-range limit) to verify cross-range iteration works correctly.



  