### PR TITLE
Add in-memory cache for getLastEntryInLedger to reduce RocksDB getFloor CPU cost

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -47,7 +47,8 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 public class EntryLocationIndex implements Closeable {
 
     static final String LAST_ENTRY_CACHE_MAX_SIZE = "dbStorage_lastEntryCacheMaxSize";
-    private static final long DEFAULT_LAST_ENTRY_CACHE_MAX_SIZE = 10_000;
+    private static final long DEFAULT_LAST_ENTRY_CACHE_MAX_SIZE = 100_000;
+    private static final float LAST_ENTRY_CACHE_FILL_FACTOR = 0.66f;
 
     private final KeyValueStorage locationsDb;
     private final ConcurrentLongHashSet deletedLedgers = ConcurrentLongHashSet.newBuilder().build();
@@ -61,8 +62,12 @@ public class EntryLocationIndex implements Closeable {
         locationsDb = storageFactory.newKeyValueStorage(basePath, "locations", DbConfigType.EntryLocation, conf);
 
         this.lastEntryCacheMaxSize = conf.getLong(LAST_ENTRY_CACHE_MAX_SIZE, DEFAULT_LAST_ENTRY_CACHE_MAX_SIZE);
+        // Pre-size to avoid a resize right before we hit the cap and clear().
+        // ConcurrentLongLongHashMap resizes at size = expectedItems, so set expectedItems
+        // = max / fillFactor to keep the table stable for the lifetime of one fill cycle.
+        long expectedItems = (long) (lastEntryCacheMaxSize / LAST_ENTRY_CACHE_FILL_FACTOR);
         this.lastEntryCache = ConcurrentLongLongHashMap.newBuilder()
-                .expectedItems((int) Math.min(lastEntryCacheMaxSize, Integer.MAX_VALUE))
+                .expectedItems((int) Math.min(expectedItems, Integer.MAX_VALUE))
                 .build();
 
         this.stats = new EntryLocationIndexStats(
@@ -129,14 +134,15 @@ public class EntryLocationIndex implements Closeable {
         // ConcurrentLongLongHashMap.get() returns -1 if not found.
         long cachedLastEntry = lastEntryCache.get(ledgerId);
         if (cachedLastEntry >= 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("Found last entry for ledger {} in cache: {}", ledgerId, cachedLastEntry);
-            }
-            stats.getGetLastEntryInLedgerStats()
-                    .registerSuccessfulEvent(0, TimeUnit.NANOSECONDS);
+            log.debug()
+                .attr("ledgerId", ledgerId)
+                .attr("cacheLastEntry", cachedLastEntry)
+                .log("Found last entry");
+            stats.getLastEntryCacheHits().inc();
             return cachedLastEntry;
         }
 
+        stats.getLastEntryCacheMisses().inc();
         LongPairWrapper maxEntryId = LongPairWrapper.get(ledgerId, Long.MAX_VALUE);
 
         long startTimeNanos = MathUtils.nowInNano();
@@ -162,14 +168,45 @@ public class EntryLocationIndex implements Closeable {
                         .attr("ledgerId", ledgerId)
                         .attr("lastEntryId", lastEntryId)
                         .log("Found last page in storage db for ledger");
-                // Populate cache for future lookups
-                if (lastEntryCache.size() >= lastEntryCacheMaxSize) {
-                    lastEntryCache.clear();
-                }
-                lastEntryCache.put(ledgerId, lastEntryId);
+                // Populate cache only if no newer entry was inserted concurrently by an
+                // addLocation call between our cache miss above and this point. The
+                // CAS loop mirrors the pattern in WriteCache.put() (lines 168-178).
+                cacheLastEntryIfNewer(ledgerId, lastEntryId);
                 return lastEntryId;
             } else {
                 throw new Bookie.NoEntryException(ledgerId, -1);
+            }
+        }
+    }
+
+    /**
+     * Atomically set the cached last entry for ledgerId to newEntryId, but only if newEntryId
+     * is greater than whatever is currently cached. Bounded by lastEntryCacheMaxSize: when the
+     * cache is full and ledgerId is not yet present, the whole cache is cleared (working-set
+     * eviction) before insertion.
+     */
+    private void cacheLastEntryIfNewer(long ledgerId, long newEntryId) {
+        while (true) {
+            long currentLastEntry = lastEntryCache.get(ledgerId);
+            if (currentLastEntry >= newEntryId) {
+                // A newer or equal entry is already cached.
+                return;
+            }
+            if (currentLastEntry < 0) {
+                // Not in cache; enforce the size cap before inserting.
+                if (lastEntryCache.size() >= lastEntryCacheMaxSize) {
+                    lastEntryCache.clear();
+                }
+                // putIfAbsent so we don't race with a concurrent insert that beat us here.
+                long prior = lastEntryCache.putIfAbsent(ledgerId, newEntryId);
+                if (prior < 0 || prior >= newEntryId) {
+                    return;
+                }
+                // Lost the race and the winning value is still older — retry to overwrite.
+                continue;
+            }
+            if (lastEntryCache.compareAndSet(ledgerId, currentLastEntry, newEntryId)) {
+                return;
             }
         }
     }
@@ -202,17 +239,10 @@ public class EntryLocationIndex implements Closeable {
             value.recycle();
         }
 
-        // Update the last entry cache if this entry is newer.
-        // ConcurrentLongLongHashMap.get() returns -1 if not found.
-        long cachedLastEntry = lastEntryCache.get(ledgerId);
-        if (cachedLastEntry < entryId) {
-            // Clear the cache if it exceeds the max size to bound memory usage.
-            // The cache will quickly repopulate with hot ledgers on subsequent reads.
-            if (cachedLastEntry < 0 && lastEntryCache.size() >= lastEntryCacheMaxSize) {
-                lastEntryCache.clear();
-            }
-            lastEntryCache.put(ledgerId, entryId);
-        }
+        // Bump the cached last-entry id if this write extends it. CAS-protected so a
+        // concurrent read populating the cache from RocksDB can't regress us, and two
+        // concurrent writers can't let the lower entryId win.
+        cacheLastEntryIfNewer(ledgerId, entryId);
     }
 
     public void updateLocations(Iterable<EntryLocation> newLocations) throws IOException {
@@ -234,7 +264,11 @@ public class EntryLocationIndex implements Closeable {
 
     public void delete(long ledgerId) throws IOException {
         // We need to find all the LedgerIndexPage records belonging to one specific
-        // ledgers
+        // ledgers.
+        // Ordering: deletedLedgers.add() must precede the cache.remove(). Any reader that
+        // observes a removed cache entry will subsequently consult deletedLedgers via
+        // getLastEntryInLedger() and throw NoEntryException rather than re-caching from
+        // RocksDB (the actual row deletion happens later in removeOffsetFromDeletedLedgers).
         deletedLedgers.add(ledgerId);
         lastEntryCache.remove(ledgerId);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.collections.ConcurrentLongHashSet;
+import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 
 /**
  * Maintains an index of the entry locations in the EntryLogger.
@@ -45,14 +46,24 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongHashSet;
 @CustomLog
 public class EntryLocationIndex implements Closeable {
 
+    static final String LAST_ENTRY_CACHE_MAX_SIZE = "dbStorage_lastEntryCacheMaxSize";
+    private static final long DEFAULT_LAST_ENTRY_CACHE_MAX_SIZE = 10_000;
+
     private final KeyValueStorage locationsDb;
     private final ConcurrentLongHashSet deletedLedgers = ConcurrentLongHashSet.newBuilder().build();
+    private final ConcurrentLongLongHashMap lastEntryCache;
+    private final long lastEntryCacheMaxSize;
     private final EntryLocationIndexStats stats;
     private boolean isCompacting;
 
     public EntryLocationIndex(ServerConfiguration conf, KeyValueStorageFactory storageFactory, String basePath,
             StatsLogger stats) throws IOException {
         locationsDb = storageFactory.newKeyValueStorage(basePath, "locations", DbConfigType.EntryLocation, conf);
+
+        this.lastEntryCacheMaxSize = conf.getLong(LAST_ENTRY_CACHE_MAX_SIZE, DEFAULT_LAST_ENTRY_CACHE_MAX_SIZE);
+        this.lastEntryCache = ConcurrentLongLongHashMap.newBuilder()
+                .expectedItems((int) Math.min(lastEntryCacheMaxSize, Integer.MAX_VALUE))
+                .build();
 
         this.stats = new EntryLocationIndexStats(
             stats,
@@ -114,6 +125,18 @@ public class EntryLocationIndex implements Closeable {
     }
 
     private long getLastEntryInLedgerInternal(long ledgerId) throws IOException {
+        // Check in-memory cache first to avoid expensive getFloor() calls.
+        // ConcurrentLongLongHashMap.get() returns -1 if not found.
+        long cachedLastEntry = lastEntryCache.get(ledgerId);
+        if (cachedLastEntry >= 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("Found last entry for ledger {} in cache: {}", ledgerId, cachedLastEntry);
+            }
+            stats.getGetLastEntryInLedgerStats()
+                    .registerSuccessfulEvent(0, TimeUnit.NANOSECONDS);
+            return cachedLastEntry;
+        }
+
         LongPairWrapper maxEntryId = LongPairWrapper.get(ledgerId, Long.MAX_VALUE);
 
         long startTimeNanos = MathUtils.nowInNano();
@@ -139,6 +162,11 @@ public class EntryLocationIndex implements Closeable {
                         .attr("ledgerId", ledgerId)
                         .attr("lastEntryId", lastEntryId)
                         .log("Found last page in storage db for ledger");
+                // Populate cache for future lookups
+                if (lastEntryCache.size() >= lastEntryCacheMaxSize) {
+                    lastEntryCache.clear();
+                }
+                lastEntryCache.put(ledgerId, lastEntryId);
                 return lastEntryId;
             } else {
                 throw new Bookie.NoEntryException(ledgerId, -1);
@@ -173,6 +201,18 @@ public class EntryLocationIndex implements Closeable {
             key.recycle();
             value.recycle();
         }
+
+        // Update the last entry cache if this entry is newer.
+        // ConcurrentLongLongHashMap.get() returns -1 if not found.
+        long cachedLastEntry = lastEntryCache.get(ledgerId);
+        if (cachedLastEntry < entryId) {
+            // Clear the cache if it exceeds the max size to bound memory usage.
+            // The cache will quickly repopulate with hot ledgers on subsequent reads.
+            if (cachedLastEntry < 0 && lastEntryCache.size() >= lastEntryCacheMaxSize) {
+                lastEntryCache.clear();
+            }
+            lastEntryCache.put(ledgerId, entryId);
+        }
     }
 
     public void updateLocations(Iterable<EntryLocation> newLocations) throws IOException {
@@ -196,6 +236,7 @@ public class EntryLocationIndex implements Closeable {
         // We need to find all the LedgerIndexPage records belonging to one specific
         // ledgers
         deletedLedgers.add(ledgerId);
+        lastEntryCache.remove(ledgerId);
     }
 
     public String getEntryLocationDBPath() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexStats.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexStats.java
@@ -24,6 +24,7 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.CATEGORY_SERVER
 
 import java.util.function.Supplier;
 import lombok.Getter;
+import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -43,6 +44,8 @@ class EntryLocationIndexStats {
     private static final String ENTRIES_COUNT = "entries-count";
     private static final String LOOKUP_ENTRY_LOCATION = "lookup-entry-location";
     private static final String GET_LAST_ENTRY_IN_LEDGER = "get-last-entry-in-ledger";
+    private static final String LAST_ENTRY_CACHE_HITS = "last-entry-cache-hits";
+    private static final String LAST_ENTRY_CACHE_MISSES = "last-entry-cache-misses";
 
     @StatsDoc(
         name = ENTRIES_COUNT,
@@ -62,6 +65,18 @@ class EntryLocationIndexStats {
     )
     private final OpStatsLogger getLastEntryInLedgerStats;
 
+    @StatsDoc(
+            name = LAST_ENTRY_CACHE_HITS,
+            help = "number of last-entry lookups served from the in-memory cache"
+    )
+    private final Counter lastEntryCacheHits;
+
+    @StatsDoc(
+            name = LAST_ENTRY_CACHE_MISSES,
+            help = "number of last-entry lookups that fell through to RocksDB"
+    )
+    private final Counter lastEntryCacheMisses;
+
     EntryLocationIndexStats(StatsLogger statsLogger,
                             Supplier<Long> entriesCountSupplier) {
         entriesCountGauge = new Gauge<Long>() {
@@ -78,6 +93,8 @@ class EntryLocationIndexStats {
         statsLogger.registerGauge(ENTRIES_COUNT, entriesCountGauge);
         lookupEntryLocationStats = statsLogger.getOpStatsLogger(LOOKUP_ENTRY_LOCATION);
         getLastEntryInLedgerStats = statsLogger.getOpStatsLogger(GET_LAST_ENTRY_IN_LEDGER);
+        lastEntryCacheHits = statsLogger.getCounter(LAST_ENTRY_CACHE_HITS);
+        lastEntryCacheMisses = statsLogger.getCounter(LAST_ENTRY_CACHE_MISSES);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
@@ -22,9 +22,11 @@ package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider;
@@ -203,6 +205,52 @@ public class EntryLocationIndexTest {
         idx.delete(40313);
         idx.removeOffsetFromDeletedLedgers();
         assertEquals(0, idx.getLocation(40312, 10));
+    }
+
+    @Test
+    public void testGetLastEntryInLedgerCache() throws Exception {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
+
+        // Add entries for ledger 1
+        idx.addLocation(1, 0, 100);
+        idx.addLocation(1, 1, 101);
+        idx.addLocation(1, 2, 102);
+
+        // Add entries for ledger 2
+        idx.addLocation(2, 0, 200);
+        idx.addLocation(2, 5, 205);
+
+        // First call should hit RocksDB and populate cache
+        assertEquals(2, idx.getLastEntryInLedger(1));
+        assertEquals(5, idx.getLastEntryInLedger(2));
+
+        // Second call should hit cache and return same result
+        assertEquals(2, idx.getLastEntryInLedger(1));
+        assertEquals(5, idx.getLastEntryInLedger(2));
+
+        // Adding a newer entry should update cache
+        idx.addLocation(1, 10, 110);
+        assertEquals(10, idx.getLastEntryInLedger(1));
+
+        // Delete should invalidate cache
+        idx.delete(1);
+        try {
+            idx.getLastEntryInLedger(1);
+            fail("Should have thrown NoEntryException");
+        } catch (Bookie.NoEntryException e) {
+            // expected
+        }
+
+        // Ledger 2 should still work
+        assertEquals(5, idx.getLastEntryInLedger(2));
+
+        idx.close();
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
@@ -26,6 +26,11 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -249,6 +254,86 @@ public class EntryLocationIndexTest {
 
         // Ledger 2 should still work
         assertEquals(5, idx.getLastEntryInLedger(2));
+
+        idx.close();
+    }
+
+    /**
+     * Regression test for the cache-update races between getLastEntryInLedger and addLocation,
+     * and between concurrent addLocation calls. Without the CAS-loop guard, an interleaving can
+     * leave a stale (lower) entryId cached after a higher one was successfully written.
+     */
+    @Test
+    public void testGetLastEntryInLedgerCacheConcurrent() throws Exception {
+        File tmpDir = File.createTempFile("bkTest", ".dir");
+        tmpDir.delete();
+        tmpDir.mkdir();
+        tmpDir.deleteOnExit();
+
+        EntryLocationIndex idx = new EntryLocationIndex(serverConfiguration, KeyValueStorageRocksDB.factory,
+                tmpDir.getAbsolutePath(), NullStatsLogger.INSTANCE);
+
+        final long ledgerId = 42L;
+        final int writers = 4;
+        final int readers = 4;
+        final int entriesPerWriter = 2_000;
+        final AtomicLong highestWritten = new AtomicLong(-1);
+
+        ExecutorService pool = Executors.newFixedThreadPool(writers + readers);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(writers + readers);
+
+        // Writers interleave entry ids from disjoint ranges so any combination is monotone-ish
+        // but every writer occasionally produces both lower and higher ids than its peers.
+        for (int w = 0; w < writers; w++) {
+            final int writerIdx = w;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < entriesPerWriter; i++) {
+                        long entryId = (long) i * writers + writerIdx;
+                        idx.addLocation(ledgerId, entryId, 1000L + entryId);
+                        highestWritten.accumulateAndGet(entryId, Math::max);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        // Readers keep hammering getLastEntryInLedger to widen the race window between the
+        // cache-miss read of getFloor() and the cache-populate write.
+        for (int r = 0; r < readers; r++) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < entriesPerWriter; i++) {
+                        try {
+                            idx.getLastEntryInLedger(ledgerId);
+                        } catch (Bookie.NoEntryException ignored) {
+                            // first few reads may race ahead of any write
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertTrue(done.await(60, TimeUnit.SECONDS));
+        pool.shutdown();
+
+        // After all writers drained, the cache (if populated) must reflect the highest write.
+        // We trigger one more read; this returns the cached value if any, or falls through to
+        // RocksDB. Either way it must equal highestWritten.
+        long expected = highestWritten.get();
+        long observed = idx.getLastEntryInLedger(ledgerId);
+        assertEquals("cache regressed below the highest written entry", expected, observed);
 
         idx.close();
     }

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -766,6 +766,12 @@ gcEntryLogMetadataCacheEnabled=false
 # How many entries to pre-fill in cache after a read cache miss
 # dbStorage_readAheadCacheBatchSize=100
 
+# Maximum number of (ledgerId -> lastEntryId) mappings held in memory to short-circuit
+# RocksDB getFloor() lookups from getLastEntryInLedger(). When the cap is exceeded, the
+# entire cache is cleared and repopulates as hot ledgers are touched. Costs roughly
+# 16 bytes per entry plus hashmap overhead.
+# dbStorage_lastEntryCacheMaxSize=100000
+
 #############################################################################
 ## RocksDB specific configurations
 #############################################################################


### PR DESCRIPTION
### Motivation

  `EntryLocationIndex.getLastEntryInLedgerInternal()` calls `locationsDb.getFloor()` on every invocation, which is an expensive RocksDB seek operation. When a large number of ledgers query their last entry concurrently — for example, during a Pulsar broker failover where thousands of topics are loaded by another broker and send get-LAC requests — this causes severe CPU saturation on the bookie.
                                                                                                                                                                                                           
  In a production Pulsar cluster with 3000+ topics and a bookie configured with 1 CPU, a single broker OOM event triggered massive concurrent `getFloor()` calls that throttled the bookie CPU for over 1 hour.
                                                                                                                                                                                                           
  The existing `WriteCache` already caches last entry IDs for recent unflushed entries, but once entries are flushed to RocksDB, every `getLastEntryInLedger()` call falls through to the database with no caching layer.
                                                                                                                                                                                                           
 ### Changes                                                

  Add a bounded in-memory `ConcurrentLongLongHashMap` cache in `EntryLocationIndex` that maps `ledgerId → lastEntryId`:                                                                                    
   
  - **Read path (`getLastEntryInLedgerInternal`)**: Check the cache before calling `getFloor()`. On cache hit, return immediately without touching RocksDB. On cache miss, populate the cache after a      
  successful `getFloor()` lookup.                           
  - **Write path (`addLocation`)**: Eagerly update the cache when a newer entry is added, so the cache stays current even with interleaved reads and writes.                                               
  - **Delete path (`delete`)**: Remove the ledger from the cache.                                                                                                                                          
  - **Bounded size**: Configurable via `dbStorage_lastEntryCacheMaxSize` (default: 10,000). When the cache exceeds this limit and a new ledger needs to be inserted, the cache is cleared and repopulates  
  naturally with hot ledgers.                                                                                                                                                                              
                                                                                                                                                                                                           
  Using `ConcurrentLongLongHashMap` (lock-striped open hash map with primitive long keys/values) ensures minimal overhead on the write-hot path — no boxing, no LRU bookkeeping, no timestamp computation  
  per update.                                               
                                                                                                                                                                                                           
 ### Test plan                                              

  - [x] Added `testGetLastEntryInLedgerCache` covering cache hit, update on new entry, and invalidation on delete                                                                                          
  - [x] All existing `EntryLocationIndexTest` tests pass



