### PR TITLE
[FIX] Fix IllegalThreadStateException in ComponentStarter shutdown hook

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/component/ComponentStarter.java
@@ -76,7 +76,12 @@ public class ComponentStarter {
                     component.getName(), t, e);
             System.err.println(e.getMessage());
             // start the shutdown hook when an uncaught exception happen in the lifecycle component.
-            shutdownHookThread.start();
+            try {
+                shutdownHookThread.start();
+            } catch (IllegalThreadStateException ise) {
+                // the shutdown hook thread is already running (e.g. triggered by a prior
+                // exception or by the JVM shutdown sequence), so there is nothing else to do.
+            }
         });
 
         component.publishInfo(new ComponentInfoPublisher());


### PR DESCRIPTION
## Summary
- The `UncaughtExceptionHandler` in `ComponentStarter` calls `shutdownHookThread.start()`, which throws `IllegalThreadStateException` if the thread was already started (by a prior exception or the JVM shutdown sequence)
- This causes the JVM to print `Exception: java.lang.IllegalThreadStateException thrown from the UncaughtExceptionHandler in thread "BookieDeathWatcher-<port>"`
- Fix: catch `IllegalThreadStateException` since it simply means shutdown is already in progress

## Test plan
- [ ] Verify the exception no longer appears when shutting down a bookie server
- [ ] Existing unit tests pass