### PR TITLE
fix Bookkeeper can't startup cause by 'IOException: Recovery log xxx is missing'

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -623,12 +623,7 @@ public class Journal implements CheckpointSource {
 
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
-    // Guards checkpointComplete to ensure lastMark only advances forward.
-    // When singleLedgerDirs=true, SyncThread.flush() takes a checkpoint, then calls
-    // ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush(), which internally
-    // takes a NEWER checkpoint and completes it (with garbage collection). When control
-    // returns, SyncThread completes its own OLDER checkpoint, overwriting lastMark backwards
-    // to a journal file already deleted by the inner garbage collection.
+    // Ensures lastMark only advances forward across concurrent checkpointComplete calls.
     private final Object checkpointLock = new Object();
     private final LogMark lastPersistedMark = new LogMark(0, 0);
 
@@ -775,9 +770,8 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
-     * <p>If the given checkpoint is not newer than the last persisted mark, the call is
-     * a no-op. This monotonic guarantee prevents lastMark from regressing backwards.
-     * See the comment on {@code checkpointLock} for the full scenario.
+     * <p>Skips if the checkpoint is not newer than the last persisted mark,
+     * preventing lastMark from regressing backwards.
      *
      * @throws IOException
      */
@@ -789,9 +783,7 @@ public class Journal implements CheckpointSource {
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
 
-        // Monotonic check: skip if this mark is not newer than what was already persisted.
-        // This prevents lastMark regression from nested checkpointComplete calls
-        // (see class-level comment on checkpointLock for the full scenario).
+        // Skip if this mark is not newer than what was already persisted.
         synchronized (checkpointLock) {
             if (mark.getCurMark().compare(lastPersistedMark) < 0) {
                 return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -624,9 +624,11 @@ public class Journal implements CheckpointSource {
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
     // Guards checkpointComplete to ensure lastMark only advances forward.
-    // Without this, concurrent checkpointComplete calls from SyncThread and
-    // SingleDirectoryDbLedgerStorage.flush() can overwrite lastMark backwards,
-    // causing journal files to be deleted while still referenced by the older mark.
+    // When singleLedgerDirs=true, SyncThread.flush() takes a checkpoint, then calls
+    // ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush(), which internally
+    // takes a NEWER checkpoint and completes it (with garbage collection). When control
+    // returns, SyncThread completes its own OLDER checkpoint, overwriting lastMark backwards
+    // to a journal file already deleted by the inner garbage collection.
     private final Object checkpointLock = new Object();
     private final LogMark lastPersistedMark = new LogMark(0, 0);
 
@@ -773,10 +775,9 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
-     * <p>Multiple threads (SyncThread and DbLedgerStorage flush) may call this concurrently.
-     * A monotonic check ensures the lastMark file only advances forward — a later call with
-     * an older mark is safely skipped. This prevents the race where a slower flush overwrites
-     * lastMark backwards, causing referenced journal files to be garbage collected prematurely.
+     * <p>If the given checkpoint is not newer than the last persisted mark, the call is
+     * a no-op. This monotonic guarantee prevents lastMark from regressing backwards.
+     * See the comment on {@code checkpointLock} for the full scenario.
      *
      * @throws IOException
      */
@@ -788,9 +789,11 @@ public class Journal implements CheckpointSource {
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
 
-        // Monotonic check: only advance lastMark forward, never backwards.
+        // Monotonic check: skip if this mark is not newer than what was already persisted.
+        // This prevents lastMark regression from nested checkpointComplete calls
+        // (see class-level comment on checkpointLock for the full scenario).
         synchronized (checkpointLock) {
-            if (mark.getCurMark().compare(lastPersistedMark) <= 0) {
+            if (mark.getCurMark().compare(lastPersistedMark) < 0) {
                 return;
             }
             lastPersistedMark.setLogMark(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -623,6 +623,13 @@ public class Journal implements CheckpointSource {
 
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
+    // Guards checkpointComplete to ensure lastMark only advances forward.
+    // Without this, concurrent checkpointComplete calls from SyncThread and
+    // SingleDirectoryDbLedgerStorage.flush() can overwrite lastMark backwards,
+    // causing journal files to be deleted while still referenced by the older mark.
+    private final Object checkpointLock = new Object();
+    private final LogMark lastPersistedMark = new LogMark(0, 0);
+
     private static final String LAST_MARK_DEFAULT_NAME = "lastMark";
 
     private final String lastMarkFileName;
@@ -766,6 +773,11 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
+     * <p>Multiple threads (SyncThread and DbLedgerStorage flush) may call this concurrently.
+     * A monotonic check ensures the lastMark file only advances forward — a later call with
+     * an older mark is safely skipped. This prevents the race where a slower flush overwrites
+     * lastMark backwards, causing referenced journal files to be garbage collected prematurely.
+     *
      * @throws IOException
      */
     @Override
@@ -775,6 +787,15 @@ public class Journal implements CheckpointSource {
         }
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
+
+        // Monotonic check: only advance lastMark forward, never backwards.
+        synchronized (checkpointLock) {
+            if (mark.getCurMark().compare(lastPersistedMark) <= 0) {
+                return;
+            }
+            lastPersistedMark.setLogMark(
+                    mark.getCurMark().getLogFileId(), mark.getCurMark().getLogFileOffset());
+        }
 
         mark.rollLog(mark);
         if (compact) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -709,6 +709,8 @@ public class Journal implements CheckpointSource {
             lastMarkFileName = LAST_MARK_DEFAULT_NAME + "." + journalIndex;
         }
         lastLogMark.readLog();
+        lastPersistedMark.setLogMark(
+                lastLogMark.getCurMark().getLogFileId(), lastLogMark.getCurMark().getLogFileOffset());
         log.debug().attr("lastMark", () -> lastLogMark.getCurMark()).log("Last Log Mark");
 
         try {
@@ -775,7 +777,7 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
-     * <p>Skips if the checkpoint is not newer than the last persisted mark,
+     * <p>Skips if the checkpoint is older than the last persisted mark,
      * preventing lastMark from regressing backwards.
      *
      * @throws IOException
@@ -788,16 +790,16 @@ public class Journal implements CheckpointSource {
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
 
-        // Skip if this mark is not newer than what was already persisted.
+        // See #4105: keep the monotonic decision and lastMark persistence together.
         synchronized (checkpointLock) {
             if (mark.getCurMark().compare(lastPersistedMark) < 0) {
                 return;
             }
+            persistLastLogMark(mark);
             lastPersistedMark.setLogMark(
                     mark.getCurMark().getLogFileId(), mark.getCurMark().getLogFileOffset());
         }
 
-        mark.rollLog(mark);
         if (compact) {
             // list the journals that have been marked
             List<Long> logs = listJournalIds(journalDirectory, new JournalRollingFilter(mark));
@@ -817,6 +819,16 @@ public class Journal implements CheckpointSource {
                 }
             }
         }
+    }
+
+    @VisibleForTesting
+    protected void persistLastLogMark(LastLogMark mark) throws NoWritableLedgerDirException {
+        mark.rollLog(mark);
+    }
+
+    @VisibleForTesting
+    protected boolean isCheckpointCompleteLockHeldByCurrentThread() {
+        return Thread.holdsLock(checkpointLock);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -629,9 +629,11 @@ public class Journal implements CheckpointSource {
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
     // Guards checkpointComplete to ensure lastMark only advances forward.
-    // Without this, concurrent checkpointComplete calls from SyncThread and
-    // SingleDirectoryDbLedgerStorage.flush() can overwrite lastMark backwards,
-    // causing journal files to be deleted while still referenced by the older mark.
+    // When singleLedgerDirs=true, SyncThread.flush() takes a checkpoint, then calls
+    // ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush(), which internally
+    // takes a NEWER checkpoint and completes it (with garbage collection). When control
+    // returns, SyncThread completes its own OLDER checkpoint, overwriting lastMark backwards
+    // to a journal file already deleted by the inner garbage collection.
     private final Object checkpointLock = new Object();
     private final LogMark lastPersistedMark = new LogMark(0, 0);
 
@@ -778,10 +780,9 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
-     * <p>Multiple threads (SyncThread and DbLedgerStorage flush) may call this concurrently.
-     * A monotonic check ensures the lastMark file only advances forward — a later call with
-     * an older mark is safely skipped. This prevents the race where a slower flush overwrites
-     * lastMark backwards, causing referenced journal files to be garbage collected prematurely.
+     * <p>If the given checkpoint is not newer than the last persisted mark, the call is
+     * a no-op. This monotonic guarantee prevents lastMark from regressing backwards.
+     * See the comment on {@code checkpointLock} for the full scenario.
      *
      * @throws IOException
      */
@@ -793,9 +794,11 @@ public class Journal implements CheckpointSource {
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
 
-        // Monotonic check: only advance lastMark forward, never backwards.
+        // Monotonic check: skip if this mark is not newer than what was already persisted.
+        // This prevents lastMark regression from nested checkpointComplete calls
+        // (see class-level comment on checkpointLock for the full scenario).
         synchronized (checkpointLock) {
-            if (mark.getCurMark().compare(lastPersistedMark) <= 0) {
+            if (mark.getCurMark().compare(lastPersistedMark) < 0) {
                 return;
             }
             lastPersistedMark.setLogMark(

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -628,12 +628,7 @@ public class Journal implements CheckpointSource {
 
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
-    // Guards checkpointComplete to ensure lastMark only advances forward.
-    // When singleLedgerDirs=true, SyncThread.flush() takes a checkpoint, then calls
-    // ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush(), which internally
-    // takes a NEWER checkpoint and completes it (with garbage collection). When control
-    // returns, SyncThread completes its own OLDER checkpoint, overwriting lastMark backwards
-    // to a journal file already deleted by the inner garbage collection.
+    // Ensures lastMark only advances forward across concurrent checkpointComplete calls.
     private final Object checkpointLock = new Object();
     private final LogMark lastPersistedMark = new LogMark(0, 0);
 
@@ -780,9 +775,8 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
-     * <p>If the given checkpoint is not newer than the last persisted mark, the call is
-     * a no-op. This monotonic guarantee prevents lastMark from regressing backwards.
-     * See the comment on {@code checkpointLock} for the full scenario.
+     * <p>Skips if the checkpoint is not newer than the last persisted mark,
+     * preventing lastMark from regressing backwards.
      *
      * @throws IOException
      */
@@ -794,9 +788,7 @@ public class Journal implements CheckpointSource {
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
 
-        // Monotonic check: skip if this mark is not newer than what was already persisted.
-        // This prevents lastMark regression from nested checkpointComplete calls
-        // (see class-level comment on checkpointLock for the full scenario).
+        // Skip if this mark is not newer than what was already persisted.
         synchronized (checkpointLock) {
             if (mark.getCurMark().compare(lastPersistedMark) < 0) {
                 return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -628,6 +628,13 @@ public class Journal implements CheckpointSource {
 
     private final LastLogMark lastLogMark = new LastLogMark(0, 0);
 
+    // Guards checkpointComplete to ensure lastMark only advances forward.
+    // Without this, concurrent checkpointComplete calls from SyncThread and
+    // SingleDirectoryDbLedgerStorage.flush() can overwrite lastMark backwards,
+    // causing journal files to be deleted while still referenced by the older mark.
+    private final Object checkpointLock = new Object();
+    private final LogMark lastPersistedMark = new LogMark(0, 0);
+
     private static final String LAST_MARK_DEFAULT_NAME = "lastMark";
 
     private final String lastMarkFileName;
@@ -771,6 +778,11 @@ public class Journal implements CheckpointSource {
     /**
      * Telling journal a checkpoint is finished.
      *
+     * <p>Multiple threads (SyncThread and DbLedgerStorage flush) may call this concurrently.
+     * A monotonic check ensures the lastMark file only advances forward — a later call with
+     * an older mark is safely skipped. This prevents the race where a slower flush overwrites
+     * lastMark backwards, causing referenced journal files to be garbage collected prematurely.
+     *
      * @throws IOException
      */
     @Override
@@ -780,6 +792,15 @@ public class Journal implements CheckpointSource {
         }
         LogMarkCheckpoint lmcheckpoint = (LogMarkCheckpoint) checkpoint;
         LastLogMark mark = lmcheckpoint.mark;
+
+        // Monotonic check: only advance lastMark forward, never backwards.
+        synchronized (checkpointLock) {
+            if (mark.getCurMark().compare(lastPersistedMark) <= 0) {
+                return;
+            }
+            lastPersistedMark.setLogMark(
+                    mark.getCurMark().getLogFileId(), mark.getCurMark().getLogFileOffset());
+        }
 
         mark.rollLog(mark);
         if (compact) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -909,7 +909,7 @@ public class DbLedgerStorageTest {
      * (5 &lt; lastPersistedMark 7), so lastMark stays at 7 and the restart succeeds.
      */
     @Test
-    public void testConcurrentCheckpointCompleteJournalMissing() throws Exception {
+    public void testNestedCheckpointCompleteLastMarkRegression() throws Exception {
         File baseDir = new File(tmpDir, "journalMissingTest");
         File ledgerDir = new File(baseDir, "ledger");
         File journalBaseDir = new File(baseDir, "journal");
@@ -947,17 +947,17 @@ public class DbLedgerStorageTest {
 
             // Step 1: SyncThread takes checkpoint at mark(5, 100) before calling ledgerStorage.flush()
             journal.getLastLogMark().getCurMark().setLogMark(5, 100);
-            CheckpointSource.Checkpoint cpFlush = checkpointSource.newCheckpoint();
+            CheckpointSource.Checkpoint outerCheckpoint = checkpointSource.newCheckpoint();
 
             // Step 2: Inside ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush()
             // takes a newer checkpoint at mark(7, 200)
             journal.getLastLogMark().getCurMark().setLogMark(7, 200);
-            CheckpointSource.Checkpoint cpSync = checkpointSource.newCheckpoint();
+            CheckpointSource.Checkpoint innerCheckpoint = checkpointSource.newCheckpoint();
 
             // Step 3: SingleDirectoryDbLedgerStorage.flush() completes its checkpoint FIRST
             // checkpointComplete(mark=7, compact=true)
             // rollLog to 7, garbage collects journals with id < 7 (deletes 3,4,5,6)
-            checkpointSource.checkpointComplete(cpSync, true);
+            checkpointSource.checkpointComplete(innerCheckpoint, true);
 
             LogMark markAfterSync = readLogMark(ledgerDirMark);
             assertEquals("lastMark should be at 7 after inner flush", 7, markAfterSync.getLogFileId());
@@ -978,7 +978,7 @@ public class DbLedgerStorageTest {
             // the regression is caused by rollLog overwriting the lastMark file backwards.
             // WITHOUT FIX: rollLog overwrites lastMark to 5, but journal 5 is already deleted!
             // WITH FIX: mark 5 < lastPersistedMark 7, so this is skipped entirely.
-            checkpointSource.checkpointComplete(cpFlush, false);
+            checkpointSource.checkpointComplete(outerCheckpoint, false);
 
             // Verify: lastMark must NOT regress to 5. Should stay at 7.
             LogMark markAfterFlush = readLogMark(ledgerDirMark);
@@ -986,7 +986,9 @@ public class DbLedgerStorageTest {
                     7, markAfterFlush.getLogFileId());
             assertEquals(200, markAfterFlush.getLogFileOffset());
 
-            // Step 7: Simulate bookie restart — read lastMark and check journal exists
+            // Step 5: Simulate bookie restart — reset curMark to (0,0) first so readLog()
+            // actually loads from disk rather than being a no-op due to the in-memory value.
+            journal.getLastLogMark().getCurMark().setLogMark(0, 0);
             journal.getLastLogMark().readLog();
             LogMark restartMark = journal.getLastLogMark().getCurMark();
             assertEquals("Reloaded lastMark should be 7", 7, restartMark.getLogFileId());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -884,32 +884,13 @@ public class DbLedgerStorageTest {
     }
 
     /**
-     * Simulates the journal-missing scenario caused by lastMark regression in single-dir
-     * mode (singleLedgerDirs=true) and verifies the monotonic fix prevents it.
-     *
-     * <p>The trigger is a single-thread nested call within SyncThread.flush():
-     * <pre>
-     * SyncThread.flush():
-     *   1. outerCheckpoint = newCheckpoint()          → captures mark(5, 100)
-     *   2. ledgerStorage.flush()                      → delegates to SingleDirectoryDbLedgerStorage.flush():
-     *      2a. innerCheckpoint = newCheckpoint()      → captures mark(7, 200), journal has advanced
-     *      2b. checkpoint(innerCheckpoint)            → flushes data to disk
-     *      2c. checkpointComplete(innerCheckpoint=7, compact=true)
-     *          → rollLog(7), garbage collects journal files 3,4,5,6 (id < 7)
-     *   3. checkpointComplete(outerCheckpoint=5, compact=false)
-     *      → rollLog(5) — OVERWRITES lastMark backwards from 7 to 5!
-     *      → journal file 5 was already deleted in step 2c
-     *   4. Bookie restarts: reads lastMark=5, looks for journal 5 → MISSING!
-     *      → throws "Recovery log 5 is missing"
-     * </pre>
-     *
-     * <p>This test simulates the core regression: a newer checkpoint is completed first
-     * (with garbage collection), then an older checkpoint attempts to overwrite lastMark
-     * backwards. With the monotonic fix, the older mark is skipped
-     * (5 &lt; lastPersistedMark 7), so lastMark stays at 7 and the restart succeeds.
+     * Verifies that the monotonic guard in checkpointComplete prevents lastMark regression.
+     * A newer checkpoint is completed first (with garbage collection deleting old journals),
+     * then a stale checkpoint attempts to overwrite lastMark backwards. The fix skips the
+     * stale mark, keeping lastMark at the newer position so restart succeeds.
      */
     @Test
-    public void testNestedCheckpointCompleteLastMarkRegression() throws Exception {
+    public void testConcurrentCheckpointCompleteLastMarkRegression() throws Exception {
         File baseDir = new File(tmpDir, "journalMissingTest");
         File ledgerDir = new File(baseDir, "ledger");
         File journalBaseDir = new File(baseDir, "journal");
@@ -943,25 +924,28 @@ public class DbLedgerStorageTest {
 
             CheckpointSource checkpointSource = new CheckpointSourceList(bookie.getJournals());
 
-            // === Simulate the lastMark regression ===
+            // === Simulate concurrent checkpointComplete causing lastMark regression ===
 
-            // Step 1: SyncThread takes checkpoint at mark(5, 100) before calling ledgerStorage.flush()
+            // Step 1: SyncThread.checkpoint() captures a checkpoint before heavy flush I/O.
+            // This mark becomes stale during the I/O as the journal continues advancing.
             journal.getLastLogMark().getCurMark().setLogMark(5, 100);
-            CheckpointSource.Checkpoint outerCheckpoint = checkpointSource.newCheckpoint();
+            CheckpointSource.Checkpoint staleCheckpoint = checkpointSource.newCheckpoint();
 
-            // Step 2: Inside ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush()
-            // takes a newer checkpoint at mark(7, 200)
+            // Step 2: During SyncThread's I/O, triggerFlushAndAddEntry fires on a separate
+            // thread. SingleDirectoryDbLedgerStorage.flush() captures a newer checkpoint
+            // (the journal has advanced to file 7 during the I/O).
             journal.getLastLogMark().getCurMark().setLogMark(7, 200);
-            CheckpointSource.Checkpoint innerCheckpoint = checkpointSource.newCheckpoint();
+            CheckpointSource.Checkpoint newerCheckpoint = checkpointSource.newCheckpoint();
 
-            // Step 3: SingleDirectoryDbLedgerStorage.flush() completes its checkpoint FIRST
+            // Step 3: After SyncThread releases flushMutex, the SingleDirectoryDbLedgerStorage
+            // executor wins the race and calls checkpointComplete first.
             // checkpointComplete(mark=7, compact=true)
             // rollLog to 7, garbage collects journals with id < 7 (deletes 3,4,5,6)
-            checkpointSource.checkpointComplete(innerCheckpoint, true);
+            checkpointSource.checkpointComplete(newerCheckpoint, true);
 
-            LogMark markAfterSync = readLogMark(ledgerDirMark);
-            assertEquals("lastMark should be at 7 after inner flush", 7, markAfterSync.getLogFileId());
-            assertEquals(200, markAfterSync.getLogFileOffset());
+            LogMark markAfterNewer = readLogMark(ledgerDirMark);
+            assertEquals("lastMark should be at 7 after newer checkpoint", 7, markAfterNewer.getLogFileId());
+            assertEquals(200, markAfterNewer.getLogFileOffset());
 
             // Verify journals 3,4,5,6 were garbage collected, 7,8 still exist
             for (long id = 3; id <= 6; id++) {
@@ -973,12 +957,12 @@ public class DbLedgerStorageTest {
                 assertTrue("Journal " + id + " should still exist", journalFile.exists());
             }
 
-            // Step 4: Control returns to SyncThread, which completes its OLDER checkpoint
-            // checkpointComplete(mark=5, compact=false). The compact value does not matter here —
-            // the regression is caused by rollLog overwriting the lastMark file backwards.
+            // Step 4: SyncThread then calls checkpointComplete with its stale mark.
+            // The compact value does not matter — the regression is caused by rollLog
+            // overwriting the lastMark file backwards.
             // WITHOUT FIX: rollLog overwrites lastMark to 5, but journal 5 is already deleted!
             // WITH FIX: mark 5 < lastPersistedMark 7, so this is skipped entirely.
-            checkpointSource.checkpointComplete(outerCheckpoint, false);
+            checkpointSource.checkpointComplete(staleCheckpoint, true);
 
             // Verify: lastMark must NOT regress to 5. Should stay at 7.
             LogMark markAfterFlush = readLogMark(ledgerDirMark);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.bookie.CheckpointSource;
 import org.apache.bookkeeper.bookie.CheckpointSourceList;
 import org.apache.bookkeeper.bookie.DefaultEntryLogger;
 import org.apache.bookkeeper.bookie.EntryLocation;
+import org.apache.bookkeeper.bookie.Journal;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.LogMark;
@@ -880,5 +881,122 @@ public class DbLedgerStorageTest {
         pendingDeletedLedgers.add(2L);
         bookie.getLedgerStorage().flush();
         Assert.assertEquals(pendingDeletedLedgers.size(), 0);
+    }
+
+    /**
+     * Simulates the full journal-missing scenario caused by concurrent checkpointComplete
+     * calls in single-dir mode and verifies the monotonic fix prevents it.
+     *
+     * <p>Timeline of the original bug:
+     * <pre>
+     * 1. SDLS.flush() starts: newCheckpoint → mark(5, 0), begins flushing data
+     * 2. SyncThread starts:   newCheckpoint → mark(7, 0), waits for flushMutex
+     * 3. SDLS.flush() completes flushing, releases flushMutex
+     * 4. SyncThread acquires flushMutex, finds writeCache empty, returns
+     * 5. SyncThread calls checkpointComplete(mark=7, compact=true) FIRST
+     *    → rollLog(7), GC deletes journal files 3,4,5,6 (all with id < 7)
+     * 6. SDLS.flush() calls checkpointComplete(mark=5, compact=true) SECOND
+     *    → rollLog(5) — OVERWRITES lastMark backwards from 7 to 5!
+     *    → journal file 5 was already deleted in step 5
+     * 7. Bookie restarts: reads lastMark=5, looks for journal file 5 → MISSING!
+     *    → throws "Recovery log 5 is missing"
+     * </pre>
+     *
+     * <p>With the monotonic fix, step 6 is skipped (mark 5 <= lastPersistedMark 7),
+     * so lastMark stays at 7 and the restart succeeds.
+     */
+    @Test
+    public void testConcurrentCheckpointCompleteJournalMissing() throws Exception {
+        File baseDir = new File(tmpDir, "journalMissingTest");
+        File ledgerDir = new File(baseDir, "ledger");
+        File journalBaseDir = new File(baseDir, "journal");
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setGcWaitTime(1000);
+        conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
+        conf.setProperty(DbLedgerStorage.READ_AHEAD_CACHE_MAX_SIZE_MB, 4);
+        conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        conf.setLedgerDirNames(new String[] { ledgerDir.getCanonicalPath() });
+        conf.setJournalDirName(journalBaseDir.getCanonicalPath());
+        // Set maxBackupJournals to 0 so GC aggressively deletes all old journals
+        conf.setMaxBackupJournals(0);
+
+        BookieImpl bookie = new TestBookieImpl(conf);
+        try {
+            Journal journal = bookie.getJournals().get(0);
+            File journalDir = journal.getJournalDirectory();
+            File ledgerDirMark = new File(ledgerDir + "/current", "lastMark");
+
+            // Create fake journal files: 3.txn, 4.txn, 5.txn, 6.txn, 7.txn, 8.txn
+            for (long id = 3; id <= 8; id++) {
+                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+                assertTrue("Failed to create journal file " + id, journalFile.createNewFile());
+            }
+
+            // Verify all journal files exist
+            for (long id = 3; id <= 8; id++) {
+                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+                assertTrue("Journal file " + id + " should exist", journalFile.exists());
+            }
+
+            CheckpointSource checkpointSource = new CheckpointSourceList(bookie.getJournals());
+
+            // === Simulate the race ===
+
+            // Step 1: SDLS.flush() captures checkpoint at mark(5, 100)
+            journal.getLastLogMark().getCurMark().setLogMark(5, 100);
+            CheckpointSource.Checkpoint cpFlush = checkpointSource.newCheckpoint();
+
+            // Step 2: SyncThread captures checkpoint at mark(7, 200) — newer position
+            journal.getLastLogMark().getCurMark().setLogMark(7, 200);
+            CheckpointSource.Checkpoint cpSync = checkpointSource.newCheckpoint();
+
+            // Step 5: SyncThread completes FIRST — checkpointComplete(mark=7, compact=true)
+            // This should: rollLog to 7, GC journals with id < 7 (deletes 3,4,5,6)
+            checkpointSource.checkpointComplete(cpSync, true);
+
+            LogMark markAfterSync = readLogMark(ledgerDirMark);
+            assertEquals("lastMark should be at 7 after SyncThread", 7, markAfterSync.getLogFileId());
+            assertEquals(200, markAfterSync.getLogFileOffset());
+
+            // Verify journals 3,4,5,6 were GC'd, 7,8 still exist
+            for (long id = 3; id <= 6; id++) {
+                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+                assertFalse("Journal " + id + " should have been GC'd", journalFile.exists());
+            }
+            for (long id = 7; id <= 8; id++) {
+                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+                assertTrue("Journal " + id + " should still exist", journalFile.exists());
+            }
+
+            // Step 6: SDLS.flush() completes SECOND — checkpointComplete(mark=5, compact=true)
+            // WITHOUT FIX: rollLog would overwrite lastMark to 5, but journal 5 is already deleted!
+            // WITH FIX: mark 5 <= lastPersistedMark 7, so this is skipped entirely.
+            checkpointSource.checkpointComplete(cpFlush, true);
+
+            // Verify: lastMark must NOT regress to 5. Should stay at 7.
+            LogMark markAfterFlush = readLogMark(ledgerDirMark);
+            assertEquals("lastMark must not regress after older checkpoint completes",
+                    7, markAfterFlush.getLogFileId());
+            assertEquals(200, markAfterFlush.getLogFileOffset());
+
+            // Step 7: Simulate bookie restart — read lastMark and check journal exists
+            journal.getLastLogMark().readLog();
+            LogMark restartMark = journal.getLastLogMark().getCurMark();
+            assertEquals("Reloaded lastMark should be 7", 7, restartMark.getLogFileId());
+
+            // The journal file pointed to by lastMark must exist
+            File markedJournal = new File(journalDir,
+                    Long.toHexString(restartMark.getLogFileId()) + ".txn");
+            assertTrue("Journal file " + restartMark.getLogFileId() + " must exist for recovery",
+                    markedJournal.exists());
+
+            // Verify that listJournalIds finds the expected journal for replay
+            List<Long> replayLogs = Journal.listJournalIds(journalDir,
+                    journalId -> journalId >= restartMark.getLogFileId());
+            assertTrue("Replay journal list must contain the marked journal",
+                    replayLogs.size() > 0 && replayLogs.get(0) == restartMark.getLogFileId());
+        } finally {
+            bookie.getLedgerStorage().shutdown();
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -884,26 +884,29 @@ public class DbLedgerStorageTest {
     }
 
     /**
-     * Simulates the full journal-missing scenario caused by concurrent checkpointComplete
-     * calls in single-dir mode and verifies the monotonic fix prevents it.
+     * Simulates the journal-missing scenario caused by lastMark regression in single-dir
+     * mode (singleLedgerDirs=true) and verifies the monotonic fix prevents it.
      *
-     * <p>Timeline of the original bug:
+     * <p>The trigger is a single-thread nested call within SyncThread.flush():
      * <pre>
-     * 1. SDLS.flush() starts: newCheckpoint → mark(5, 0), begins flushing data
-     * 2. SyncThread starts:   newCheckpoint → mark(7, 0), waits for flushMutex
-     * 3. SDLS.flush() completes flushing, releases flushMutex
-     * 4. SyncThread acquires flushMutex, finds writeCache empty, returns
-     * 5. SyncThread calls checkpointComplete(mark=7, compact=true) FIRST
-     *    → rollLog(7), GC deletes journal files 3,4,5,6 (all with id < 7)
-     * 6. SDLS.flush() calls checkpointComplete(mark=5, compact=true) SECOND
-     *    → rollLog(5) — OVERWRITES lastMark backwards from 7 to 5!
-     *    → journal file 5 was already deleted in step 5
-     * 7. Bookie restarts: reads lastMark=5, looks for journal file 5 → MISSING!
-     *    → throws "Recovery log 5 is missing"
+     * SyncThread.flush():
+     *   1. outerCheckpoint = newCheckpoint()          → captures mark(5, 100)
+     *   2. ledgerStorage.flush()                      → delegates to SingleDirectoryDbLedgerStorage.flush():
+     *      2a. innerCheckpoint = newCheckpoint()      → captures mark(7, 200), journal has advanced
+     *      2b. checkpoint(innerCheckpoint)            → flushes data to disk
+     *      2c. checkpointComplete(innerCheckpoint=7, compact=true)
+     *          → rollLog(7), garbage collects journal files 3,4,5,6 (id < 7)
+     *   3. checkpointComplete(outerCheckpoint=5, compact=false)
+     *      → rollLog(5) — OVERWRITES lastMark backwards from 7 to 5!
+     *      → journal file 5 was already deleted in step 2c
+     *   4. Bookie restarts: reads lastMark=5, looks for journal 5 → MISSING!
+     *      → throws "Recovery log 5 is missing"
      * </pre>
      *
-     * <p>With the monotonic fix, step 6 is skipped (mark 5 <= lastPersistedMark 7),
-     * so lastMark stays at 7 and the restart succeeds.
+     * <p>This test simulates the core regression: a newer checkpoint is completed first
+     * (with garbage collection), then an older checkpoint attempts to overwrite lastMark
+     * backwards. With the monotonic fix, the older mark is skipped
+     * (5 &lt; lastPersistedMark 7), so lastMark stays at 7 and the restart succeeds.
      */
     @Test
     public void testConcurrentCheckpointCompleteJournalMissing() throws Exception {
@@ -917,7 +920,7 @@ public class DbLedgerStorageTest {
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         conf.setLedgerDirNames(new String[] { ledgerDir.getCanonicalPath() });
         conf.setJournalDirName(journalBaseDir.getCanonicalPath());
-        // Set maxBackupJournals to 0 so GC aggressively deletes all old journals
+        // Set maxBackupJournals to 0 so garbage collection aggressively deletes all old journals
         conf.setMaxBackupJournals(0);
 
         BookieImpl bookie = new TestBookieImpl(conf);
@@ -940,38 +943,42 @@ public class DbLedgerStorageTest {
 
             CheckpointSource checkpointSource = new CheckpointSourceList(bookie.getJournals());
 
-            // === Simulate the race ===
+            // === Simulate the lastMark regression ===
 
-            // Step 1: SDLS.flush() captures checkpoint at mark(5, 100)
+            // Step 1: SyncThread takes checkpoint at mark(5, 100) before calling ledgerStorage.flush()
             journal.getLastLogMark().getCurMark().setLogMark(5, 100);
             CheckpointSource.Checkpoint cpFlush = checkpointSource.newCheckpoint();
 
-            // Step 2: SyncThread captures checkpoint at mark(7, 200) — newer position
+            // Step 2: Inside ledgerStorage.flush() → SingleDirectoryDbLedgerStorage.flush()
+            // takes a newer checkpoint at mark(7, 200)
             journal.getLastLogMark().getCurMark().setLogMark(7, 200);
             CheckpointSource.Checkpoint cpSync = checkpointSource.newCheckpoint();
 
-            // Step 5: SyncThread completes FIRST — checkpointComplete(mark=7, compact=true)
-            // This should: rollLog to 7, GC journals with id < 7 (deletes 3,4,5,6)
+            // Step 3: SingleDirectoryDbLedgerStorage.flush() completes its checkpoint FIRST
+            // checkpointComplete(mark=7, compact=true)
+            // rollLog to 7, garbage collects journals with id < 7 (deletes 3,4,5,6)
             checkpointSource.checkpointComplete(cpSync, true);
 
             LogMark markAfterSync = readLogMark(ledgerDirMark);
-            assertEquals("lastMark should be at 7 after SyncThread", 7, markAfterSync.getLogFileId());
+            assertEquals("lastMark should be at 7 after inner flush", 7, markAfterSync.getLogFileId());
             assertEquals(200, markAfterSync.getLogFileOffset());
 
-            // Verify journals 3,4,5,6 were GC'd, 7,8 still exist
+            // Verify journals 3,4,5,6 were garbage collected, 7,8 still exist
             for (long id = 3; id <= 6; id++) {
                 File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
-                assertFalse("Journal " + id + " should have been GC'd", journalFile.exists());
+                assertFalse("Journal " + id + " should have been garbage collected", journalFile.exists());
             }
             for (long id = 7; id <= 8; id++) {
                 File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
                 assertTrue("Journal " + id + " should still exist", journalFile.exists());
             }
 
-            // Step 6: SDLS.flush() completes SECOND — checkpointComplete(mark=5, compact=true)
-            // WITHOUT FIX: rollLog would overwrite lastMark to 5, but journal 5 is already deleted!
-            // WITH FIX: mark 5 <= lastPersistedMark 7, so this is skipped entirely.
-            checkpointSource.checkpointComplete(cpFlush, true);
+            // Step 4: Control returns to SyncThread, which completes its OLDER checkpoint
+            // checkpointComplete(mark=5, compact=false). The compact value does not matter here —
+            // the regression is caused by rollLog overwriting the lastMark file backwards.
+            // WITHOUT FIX: rollLog overwrites lastMark to 5, but journal 5 is already deleted!
+            // WITH FIX: mark 5 < lastPersistedMark 7, so this is skipped entirely.
+            checkpointSource.checkpointComplete(cpFlush, false);
 
             // Verify: lastMark must NOT regress to 5. Should stay at 7.
             LogMark markAfterFlush = readLogMark(ledgerDirMark);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -32,11 +32,17 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.Bookie.NoEntryException;
 import org.apache.bookkeeper.bookie.BookieException;
@@ -47,6 +53,7 @@ import org.apache.bookkeeper.bookie.DefaultEntryLogger;
 import org.apache.bookkeeper.bookie.EntryLocation;
 import org.apache.bookkeeper.bookie.Journal;
 import org.apache.bookkeeper.bookie.LedgerDirsManager;
+import org.apache.bookkeeper.bookie.LedgerDirsManager.NoWritableLedgerDirException;
 import org.apache.bookkeeper.bookie.LedgerStorage;
 import org.apache.bookkeeper.bookie.LogMark;
 import org.apache.bookkeeper.bookie.TestBookieImpl;
@@ -54,6 +61,7 @@ import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.proto.BookieProtocol;
+import org.apache.bookkeeper.util.DiskChecker;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -883,17 +891,12 @@ public class DbLedgerStorageTest {
         Assert.assertEquals(pendingDeletedLedgers.size(), 0);
     }
 
-    /**
-     * Verifies that the monotonic guard in checkpointComplete prevents lastMark regression.
-     * A newer checkpoint is completed first (with garbage collection deleting old journals),
-     * then a stale checkpoint attempts to overwrite lastMark backwards. The fix skips the
-     * stale mark, keeping lastMark at the newer position so restart succeeds.
-     */
     @Test
-    public void testConcurrentCheckpointCompleteLastMarkRegression() throws Exception {
-        File baseDir = new File(tmpDir, "journalMissingTest");
+    public void testCheckpointCompleteSkipsStaleCheckpointAfterNewerCheckpoint() throws Exception {
+        File baseDir = new File(tmpDir, "journalStaleCheckpointTest");
         File ledgerDir = new File(baseDir, "ledger");
         File journalBaseDir = new File(baseDir, "journal");
+        File journalDir = BookieImpl.getCurrentDirectory(journalBaseDir);
         ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
         conf.setGcWaitTime(1000);
         conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
@@ -901,95 +904,221 @@ public class DbLedgerStorageTest {
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         conf.setLedgerDirNames(new String[] { ledgerDir.getCanonicalPath() });
         conf.setJournalDirName(journalBaseDir.getCanonicalPath());
-        // Set maxBackupJournals to 0 so garbage collection aggressively deletes all old journals
         conf.setMaxBackupJournals(0);
 
-        BookieImpl bookie = new TestBookieImpl(conf);
+        BookieImpl.checkDirectoryStructure(journalDir);
+        LedgerDirsManager dirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(0.95f, 0.90f));
+        Journal journal = new Journal(0, journalDir, conf, dirsManager);
+        File ledgerDirMark = new File(BookieImpl.getCurrentDirectory(ledgerDir), "lastMark");
+        createJournalFiles(journalDir, 3, 10);
+
+        CheckpointSource checkpointSource = new CheckpointSourceList(Lists.newArrayList(journal));
+
+        journal.getLastLogMark().getCurMark().setLogMark(7, 100);
+        CheckpointSource.Checkpoint staleCheckpoint = checkpointSource.newCheckpoint();
+
+        journal.getLastLogMark().getCurMark().setLogMark(9, 300);
+        CheckpointSource.Checkpoint newerCheckpoint = checkpointSource.newCheckpoint();
+
+        checkpointSource.checkpointComplete(newerCheckpoint, true);
+        checkpointSource.checkpointComplete(staleCheckpoint, true);
+
+        LogMark markAfterStaleCheckpoint = readLogMark(ledgerDirMark);
+        assertEquals("lastMark must stay at newer checkpoint",
+                9, markAfterStaleCheckpoint.getLogFileId());
+        assertEquals(300, markAfterStaleCheckpoint.getLogFileOffset());
+
+        for (long id = 3; id <= 8; id++) {
+            File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+            assertFalse("Journal " + id + " should have been garbage collected", journalFile.exists());
+        }
+        for (long id = 9; id <= 10; id++) {
+            File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+            assertTrue("Journal " + id + " should still exist", journalFile.exists());
+        }
+    }
+
+    @Test
+    public void testCheckpointCompleteUsesReloadedLastMarkAsPersistedMark() throws Exception {
+        File baseDir = new File(tmpDir, "journalReloadedLastMarkTest");
+        File ledgerDir = new File(baseDir, "ledger");
+        File journalBaseDir = new File(baseDir, "journal");
+        File journalDir = BookieImpl.getCurrentDirectory(journalBaseDir);
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setGcWaitTime(1000);
+        conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
+        conf.setProperty(DbLedgerStorage.READ_AHEAD_CACHE_MAX_SIZE_MB, 4);
+        conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        conf.setLedgerDirNames(new String[] { ledgerDir.getCanonicalPath() });
+        conf.setJournalDirName(journalBaseDir.getCanonicalPath());
+        conf.setMaxBackupJournals(0);
+
+        BookieImpl.checkDirectoryStructure(journalDir);
+        LedgerDirsManager dirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(0.95f, 0.90f));
+        File ledgerDirMark = new File(BookieImpl.getCurrentDirectory(ledgerDir), "lastMark");
+        writeLogMark(ledgerDirMark, 9, 300);
+        createJournalFiles(journalDir, 7, 10);
+
+        Journal journal = new Journal(0, journalDir, conf, dirsManager);
+        CheckpointSource checkpointSource = new CheckpointSourceList(Lists.newArrayList(journal));
+
+        journal.getLastLogMark().getCurMark().setLogMark(7, 100);
+        CheckpointSource.Checkpoint staleCheckpoint = checkpointSource.newCheckpoint();
+        checkpointSource.checkpointComplete(staleCheckpoint, true);
+
+        LogMark markAfterStaleCheckpoint = readLogMark(ledgerDirMark);
+        assertEquals("Reloaded lastMark must seed the monotonic guard",
+                9, markAfterStaleCheckpoint.getLogFileId());
+        assertEquals(300, markAfterStaleCheckpoint.getLogFileOffset());
+    }
+
+    @Test
+    public void testConcurrentCheckpointCompleteLastMarkRegression() throws Exception {
+        File baseDir = new File(tmpDir, "journalMissingTest");
+        File ledgerDir = new File(baseDir, "ledger");
+        File journalBaseDir = new File(baseDir, "journal");
+        File journalDir = BookieImpl.getCurrentDirectory(journalBaseDir);
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
+        conf.setGcWaitTime(1000);
+        conf.setProperty(DbLedgerStorage.WRITE_CACHE_MAX_SIZE_MB, 4);
+        conf.setProperty(DbLedgerStorage.READ_AHEAD_CACHE_MAX_SIZE_MB, 4);
+        conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        conf.setLedgerDirNames(new String[] { ledgerDir.getCanonicalPath() });
+        conf.setJournalDirName(journalBaseDir.getCanonicalPath());
+        conf.setMaxBackupJournals(0);
+
+        BookieImpl.checkDirectoryStructure(journalDir);
+        LedgerDirsManager dirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
+                new DiskChecker(0.95f, 0.90f));
+        CountDownLatch stalePersistStarted = new CountDownLatch(1);
+        CountDownLatch releaseStalePersist = new CountDownLatch(1);
+        CountDownLatch newerPersisted = new CountDownLatch(1);
+        BlockingJournal journal = new BlockingJournal(0, journalDir, conf, dirsManager,
+                stalePersistStarted, releaseStalePersist, newerPersisted);
+        File ledgerDirMark = new File(BookieImpl.getCurrentDirectory(ledgerDir), "lastMark");
+        createJournalFiles(journalDir, 3, 10);
+
+        CheckpointSource checkpointSource = new CheckpointSourceList(Lists.newArrayList(journal));
+
+        journal.getLastLogMark().getCurMark().setLogMark(7, 100);
+        CheckpointSource.Checkpoint staleCheckpoint = checkpointSource.newCheckpoint();
+
+        journal.getLastLogMark().getCurMark().setLogMark(9, 300);
+        CheckpointSource.Checkpoint newerCheckpoint = checkpointSource.newCheckpoint();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
-            Journal journal = bookie.getJournals().get(0);
-            File journalDir = journal.getJournalDirectory();
-            File ledgerDirMark = new File(ledgerDir + "/current", "lastMark");
+            Future<?> staleFuture = executor.submit(() -> {
+                checkpointSource.checkpointComplete(staleCheckpoint, true);
+                return null;
+            });
+            assertTrue("Stale checkpoint should reach lastMark persistence",
+                    stalePersistStarted.await(10, TimeUnit.SECONDS));
 
-            // Create fake journal files: 3.txn, 4.txn, 5.txn, 6.txn, 7.txn, 8.txn
-            for (long id = 3; id <= 8; id++) {
-                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
-                assertTrue("Failed to create journal file " + id, journalFile.createNewFile());
-            }
+            Future<?> newerFuture = executor.submit(() -> {
+                checkpointSource.checkpointComplete(newerCheckpoint, true);
+                return null;
+            });
+            releaseStalePersist.countDown();
 
-            // Verify all journal files exist
-            for (long id = 3; id <= 8; id++) {
-                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
-                assertTrue("Journal file " + id + " should exist", journalFile.exists());
-            }
-
-            CheckpointSource checkpointSource = new CheckpointSourceList(bookie.getJournals());
-
-            // === Simulate concurrent checkpointComplete causing lastMark regression ===
-
-            // Step 1: SyncThread.checkpoint() captures a checkpoint before heavy flush I/O.
-            // This mark becomes stale during the I/O as the journal continues advancing.
-            journal.getLastLogMark().getCurMark().setLogMark(5, 100);
-            CheckpointSource.Checkpoint staleCheckpoint = checkpointSource.newCheckpoint();
-
-            // Step 2: During SyncThread's I/O, triggerFlushAndAddEntry fires on a separate
-            // thread. SingleDirectoryDbLedgerStorage.flush() captures a newer checkpoint
-            // (the journal has advanced to file 7 during the I/O).
-            journal.getLastLogMark().getCurMark().setLogMark(7, 200);
-            CheckpointSource.Checkpoint newerCheckpoint = checkpointSource.newCheckpoint();
-
-            // Step 3: After SyncThread releases flushMutex, the SingleDirectoryDbLedgerStorage
-            // executor wins the race and calls checkpointComplete first.
-            // checkpointComplete(mark=7, compact=true)
-            // rollLog to 7, garbage collects journals with id < 7 (deletes 3,4,5,6)
-            checkpointSource.checkpointComplete(newerCheckpoint, true);
-
-            LogMark markAfterNewer = readLogMark(ledgerDirMark);
-            assertEquals("lastMark should be at 7 after newer checkpoint", 7, markAfterNewer.getLogFileId());
-            assertEquals(200, markAfterNewer.getLogFileOffset());
-
-            // Verify journals 3,4,5,6 were garbage collected, 7,8 still exist
-            for (long id = 3; id <= 6; id++) {
-                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
-                assertFalse("Journal " + id + " should have been garbage collected", journalFile.exists());
-            }
-            for (long id = 7; id <= 8; id++) {
-                File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
-                assertTrue("Journal " + id + " should still exist", journalFile.exists());
-            }
-
-            // Step 4: SyncThread then calls checkpointComplete with its stale mark.
-            // The compact value does not matter — the regression is caused by rollLog
-            // overwriting the lastMark file backwards.
-            // WITHOUT FIX: rollLog overwrites lastMark to 5, but journal 5 is already deleted!
-            // WITH FIX: mark 5 < lastPersistedMark 7, so this is skipped entirely.
-            checkpointSource.checkpointComplete(staleCheckpoint, true);
-
-            // Verify: lastMark must NOT regress to 5. Should stay at 7.
-            LogMark markAfterFlush = readLogMark(ledgerDirMark);
-            assertEquals("lastMark must not regress after older checkpoint completes",
-                    7, markAfterFlush.getLogFileId());
-            assertEquals(200, markAfterFlush.getLogFileOffset());
-
-            // Step 5: Simulate bookie restart — reset curMark to (0,0) first so readLog()
-            // actually loads from disk rather than being a no-op due to the in-memory value.
-            journal.getLastLogMark().getCurMark().setLogMark(0, 0);
-            journal.getLastLogMark().readLog();
-            LogMark restartMark = journal.getLastLogMark().getCurMark();
-            assertEquals("Reloaded lastMark should be 7", 7, restartMark.getLogFileId());
-
-            // The journal file pointed to by lastMark must exist
-            File markedJournal = new File(journalDir,
-                    Long.toHexString(restartMark.getLogFileId()) + ".txn");
-            assertTrue("Journal file " + restartMark.getLogFileId() + " must exist for recovery",
-                    markedJournal.exists());
-
-            // Verify that listJournalIds finds the expected journal for replay
-            List<Long> replayLogs = Journal.listJournalIds(journalDir,
-                    journalId -> journalId >= restartMark.getLogFileId());
-            assertTrue("Replay journal list must contain the marked journal",
-                    replayLogs.size() > 0 && replayLogs.get(0) == restartMark.getLogFileId());
+            newerFuture.get(10, TimeUnit.SECONDS);
+            staleFuture.get(10, TimeUnit.SECONDS);
         } finally {
-            bookie.getLedgerStorage().shutdown();
+            executor.shutdownNow();
+        }
+
+        LogMark markAfterFlush = readLogMark(ledgerDirMark);
+        assertEquals("lastMark must not regress after concurrent checkpoints",
+                9, markAfterFlush.getLogFileId());
+        assertEquals(300, markAfterFlush.getLogFileOffset());
+
+        for (long id = 3; id <= 8; id++) {
+            File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+            assertFalse("Journal " + id + " should have been garbage collected", journalFile.exists());
+        }
+        for (long id = 9; id <= 10; id++) {
+            File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+            assertTrue("Journal " + id + " should still exist", journalFile.exists());
+        }
+
+        journal.getLastLogMark().getCurMark().setLogMark(0, 0);
+        journal.getLastLogMark().readLog();
+        LogMark restartMark = journal.getLastLogMark().getCurMark();
+        assertEquals("Reloaded lastMark should be 9", 9, restartMark.getLogFileId());
+        assertEquals("Reloaded lastMark offset should be restored from disk",
+                300, restartMark.getLogFileOffset());
+
+        File markedJournal = new File(journalDir,
+                Long.toHexString(restartMark.getLogFileId()) + ".txn");
+        assertTrue("Journal file " + restartMark.getLogFileId() + " must exist for recovery",
+                markedJournal.exists());
+
+        List<Long> replayLogs = Journal.listJournalIds(journalDir,
+                journalId -> journalId >= restartMark.getLogFileId());
+        assertTrue("Replay journal list must contain the marked journal",
+                replayLogs.size() > 0 && replayLogs.get(0) == restartMark.getLogFileId());
+    }
+
+    private static void createJournalFiles(File journalDir, long startId, long endId) throws IOException {
+        for (long id = startId; id <= endId; id++) {
+            File journalFile = new File(journalDir, Long.toHexString(id) + ".txn");
+            assertTrue("Failed to create journal file " + id, journalFile.createNewFile());
+        }
+    }
+
+    private static void writeLogMark(File file, long logFileId, long logFileOffset) throws IOException {
+        byte[] buff = new byte[16];
+        ByteBuffer bb = ByteBuffer.wrap(buff);
+        LogMark mark = new LogMark(logFileId, logFileOffset);
+        mark.writeLogMark(bb);
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(buff);
+            fos.getChannel().force(true);
+        }
+    }
+
+    private static void awaitLatch(CountDownLatch latch, String message) {
+        try {
+            assertTrue(message, latch.await(10, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(message, e);
+        }
+    }
+
+    private static final class BlockingJournal extends Journal {
+        private static final long STALE_LOG_ID = 7;
+        private static final long NEWER_LOG_ID = 9;
+
+        private final CountDownLatch stalePersistStarted;
+        private final CountDownLatch releaseStalePersist;
+        private final CountDownLatch newerPersisted;
+
+        BlockingJournal(int journalIndex, File journalDirectory, ServerConfiguration conf,
+                        LedgerDirsManager ledgerDirsManager, CountDownLatch stalePersistStarted,
+                        CountDownLatch releaseStalePersist, CountDownLatch newerPersisted) {
+            super(journalIndex, journalDirectory, conf, ledgerDirsManager);
+            this.stalePersistStarted = stalePersistStarted;
+            this.releaseStalePersist = releaseStalePersist;
+            this.newerPersisted = newerPersisted;
+        }
+
+        @Override
+        protected void persistLastLogMark(LastLogMark mark) throws NoWritableLedgerDirException {
+            long logFileId = mark.getCurMark().getLogFileId();
+            if (logFileId == STALE_LOG_ID) {
+                stalePersistStarted.countDown();
+                awaitLatch(releaseStalePersist, "Timed out waiting to release stale checkpoint");
+                if (!isCheckpointCompleteLockHeldByCurrentThread()) {
+                    awaitLatch(newerPersisted, "Timed out waiting for newer checkpoint to persist");
+                }
+            }
+            super.persistLastLogMark(mark);
+            if (logFileId == NEWER_LOG_ID) {
+                newerPersisted.countDown();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix #4105

### Motivation

A bookie may fail to restart with:

`IOException: Recovery log xxx is missing`

This can happen when the persisted journal `lastMark` moves backwards and points to a journal file that has already been garbage-collected.

### Root Cause

With `DbLedgerStorage` and a single ledger directory, one flush cycle may complete checkpoints out of order.

A possible sequence is:

1. `SyncThread.flush()` captures an older checkpoint, for example journal `5`.
2. It calls `ledgerStorage.flush()`.
3. `SingleDirectoryDbLedgerStorage.flush()` captures and completes a newer checkpoint, for example journal `7`.
4. Completing checkpoint `7` persists `lastMark=7`.
5. Journal GC may then delete older journal files, including journal `5`.
6. `SyncThread.flush()` resumes and completes the older checkpoint `5`.
7. The old code overwrites `lastMark` back to `5`.

If the bookie crashes after this, restart reads `lastMark=5`, but journal `5` may no longer exist, so recovery fails.

### Example

Assume the bookie currently has these journal files:

| Journal file | Status |
|---|---|
| `5.txn` | old journal, still needed if `lastMark=5` |
| `6.txn` | old journal |
| `7.txn` | newer journal |

A possible execution order:

| Step | Path | Action | Persisted `lastMark` | Result |
|---:|---|---|---|---|
| 1 | `SyncThread.flush()` | captures checkpoint at journal `5` | `5` | outer flush starts from an older checkpoint |
| 2 | `ledgerStorage.flush()` | single-dir DB storage captures newer checkpoint `7` | `5` | inner flush sees newer journal progress |
| 3 | `checkpointComplete(7)` | newer checkpoint completes first | `7` | recovery point moves forward |
| 4 | Journal GC | deletes journals older than `7` | `7` | `5.txn` may be deleted |
| 5 | `checkpointComplete(5)` | older outer checkpoint completes later | `5` before this patch | `lastMark` moves backwards |
| 6 | Bookie restart | reads `lastMark=5` | `5` | restart fails because `5.txn` is missing |

Checkpoint `5` is valid when it is created. It becomes stale only after checkpoint `7` completes first and allows journal GC to remove older logs.

### Race

The same issue can happen when two checkpoint completions are interleaved.

| Time | Thread A | Thread B | Persisted `lastMark` |
|---:|---|---|---|
| T1 | starts `checkpointComplete(7)` |  | `5` |
| T2 | checks current persisted mark: `5` |  | `5` |
| T3 |  | starts `checkpointComplete(9)` | `5` |
| T4 |  | checks current persisted mark: `5` | `5` |
| T5 |  | persists `lastMark=9` | `9` |
| T6 | persists `lastMark=7` |  | `7` before this patch |

Without holding the stale check, persist, and in-memory update under the same lock, an older checkpoint can pass the stale check before a newer checkpoint is persisted, then write later and move `lastMark` backwards.

### Changes

This patch makes journal checkpoint completion monotonic.

`Journal.checkpointComplete()` now:

- tracks the latest persisted `lastMark`;
- skips checkpoint completions older than the latest persisted mark;
- keeps the stale check, persist, and in-memory mark update under the same lock;
- initializes the tracked persisted mark from the `lastMark` loaded from disk during journal startup.

In other words, `lastMark` may move from `5` to `7` to `9`, but it must never move back from `9` to `7` or from `7` to `5`.

### Performance Impact

The impact should be negligible.

Checkpoint completion is not on the normal journal write hot path. The added comparison is in-memory and constant-time. The lock only protects checkpoint mark persistence, and stale checkpoints may now avoid unnecessary `lastMark` writes.

### Tests

Added coverage for:

- stale checkpoint completion after a newer checkpoint;
- initializing the monotonic guard from a reloaded `lastMark`;
- concurrent checkpoint completion where an older checkpoint finishes after a newer one.

Verified with:

`mvn -pl bookkeeper-server -am -P '!mac' -Dtest=DbLedgerStorageTest -Dsurefire.failIfNoSpecifiedTests=false test`

`mvn -pl bookkeeper-server -P '!mac' -DskipTests checkstyle:check`