### PR TITLE
chore: update groupId from org.apache to com.ascentstream

### DIFF
--- a/.github/workflows/bk-ci.yml
+++ b/.github/workflows/bk-ci.yml
@@ -22,10 +22,12 @@ name: BookKeeper CI
 on:
   pull_request:
     branches:
+      - as-master
       - master
       - branch-*
   push:
     branches:
+      - as-master
       - master
       - branch-*
   workflow_dispatch:

--- a/.github/workflows/bk-streamstorage-python.yml
+++ b/.github/workflows/bk-streamstorage-python.yml
@@ -21,6 +21,7 @@ name: BookKeeper StreamStorage Python Client
 on:
   pull_request:
     branches:
+      - as-master
       - master
       - branch-*
     paths:

--- a/.github/workflows/dead-link-checker.yaml
+++ b/.github/workflows/dead-link-checker.yaml
@@ -20,6 +20,7 @@ on:
   push:
   pull_request:
     branches:
+      - as-master
       - master
       - branch-*
     paths:

--- a/.github/workflows/website-pr-validation.yml
+++ b/.github/workflows/website-pr-validation.yml
@@ -23,6 +23,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
+      - as-master
       - master
       - branch-*
     paths:

--- a/bin/bkctl
+++ b/bin/bkctl
@@ -28,7 +28,7 @@ source ${BK_HOME}/bin/common.sh
 source ${BK_HOME}/conf/bk_cli_env.sh
 
 CLI_MODULE_PATH=tools/all
-CLI_MODULE_NAME="(org.apache.bookkeeper-)?bookkeeper-tools"
+CLI_MODULE_NAME="(com.ascentstream.bookkeeper-)?bookkeeper-tools"
 CLI_MODULE_HOME=${BK_HOME}/${CLI_MODULE_PATH}
 
 # find the module jar

--- a/bin/bkperf
+++ b/bin/bkperf
@@ -27,7 +27,7 @@ source ${BK_HOME}/bin/common.sh
 source ${BK_HOME}/conf/bk_cli_env.sh
 
 CLI_MODULE_PATH=tools/perf
-CLI_MODULE_NAME="(org.apache.bookkeeper-)?bookkeeper-perf"
+CLI_MODULE_NAME="(com.ascentstream.bookkeeper-)?bookkeeper-perf"
 CLI_MODULE_HOME=${BK_HOME}/${CLI_MODULE_PATH}
 
 # find the module jar

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -116,8 +116,8 @@ CLI_GC_OPTS=${CLI_GC_OPTS:-"${DEFAULT_CLI_GC_OPTS}"}
 CLI_GC_LOGGING_OPTS=${CLI_GC_LOGGING_OPTS:-"${DEFAULT_CLI_GC_LOGGING_OPTS}"}
 
 # module names
-BOOKIE_SERVER_MODULE_NAME="(org.apache.bookkeeper-)?bookkeeper-server"
-TABLE_SERVICE_MODULE_NAME="(org.apache.bookkeeper-)?stream-storage-server"
+BOOKIE_SERVER_MODULE_NAME="(com.ascentstream.bookkeeper-)?bookkeeper-server"
+TABLE_SERVICE_MODULE_NAME="(com.ascentstream.bookkeeper-)?stream-storage-server"
 
 is_released_binary() {
   if [ -d ${BK_HOME}/lib ]; then

--- a/bin/dlog
+++ b/bin/dlog
@@ -25,7 +25,7 @@ BK_HOME=`cd ${BINDIR}/..;pwd`
 
 source ${BK_HOME}/bin/common.sh
 
-DLOG_MODULE_NAME="(org.apache.distributedlog-)?distributedlog-core"
+DLOG_MODULE_NAME="(com.ascentstream.distributedlog-)?distributedlog-core"
 DLOG_MODULE_PATH=stream/distributedlog/core
 DLOG_MODULE_HOME=${BK_HOME}/${DLOG_MODULE_PATH}
 

--- a/bookkeeper-benchmark/pom.xml
+++ b/bookkeeper-benchmark/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-benchmark</artifactId>
@@ -43,12 +43,12 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
@@ -72,14 +72,14 @@
        <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/bookkeeper-common-allocator/pom.xml
+++ b/bookkeeper-common-allocator/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -31,7 +31,7 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>cpu-affinity</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -102,7 +102,7 @@
       <artifactId>rxjava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -33,7 +33,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -81,14 +81,14 @@
 
     <!-- bookkeeper.tools (new CLI) -->
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <!-- dlog -->
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -96,20 +96,20 @@
 
     <!-- stream.storage -->
     <dependency>
-       <groupId>org.apache.bookkeeper</groupId>
+       <groupId>com.ascentstream.bookkeeper</groupId>
        <artifactId>stream-storage-server</artifactId>
        <version>${project.version}</version>
     </dependency>
 
     <!-- bookkeeper benchmark -->
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-benchmark</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-perf</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bookkeeper-dist/bkctl/pom.xml
+++ b/bookkeeper-dist/bkctl/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -34,7 +34,7 @@
   <dependencies>
     <!-- bookkeeper.tools (new CLI) -->
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/bookkeeper-dist/pom.xml
+++ b/bookkeeper-dist/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -33,7 +33,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -69,21 +69,21 @@
 
     <!-- stream.storage -->
     <dependency>
-       <groupId>org.apache.bookkeeper</groupId>
+       <groupId>com.ascentstream.bookkeeper</groupId>
        <artifactId>stream-storage-server</artifactId>
        <version>${project.version}</version>
     </dependency>
 
     <!-- bookkeeper.tools (new CLI) -->
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <!-- dlog -->
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bookkeeper-dist/src/assemble/bin-all.xml
+++ b/bookkeeper-dist/src/assemble/bin-all.xml
@@ -105,11 +105,11 @@
       <outputFileNameMapping>${artifact.groupId}-${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
       <excludes>
         <!-- All these dependencies are already included in stream-storage-java-client -->
-        <exclude>org.apache.bookkeeper:stream-storage-common</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-proto</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-api</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-java-client-base</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-java-kv-client</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-common</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-proto</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-api</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-java-client-base</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-java-kv-client</exclude>
         <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
       </excludes>
     </dependencySet>

--- a/bookkeeper-dist/src/assemble/bin-server.xml
+++ b/bookkeeper-dist/src/assemble/bin-server.xml
@@ -91,11 +91,11 @@
       <excludes>
         <exclude>com.google.code.findbugs:jsr305</exclude>
         <!-- All these dependencies are already included in stream-storage-java-client -->
-        <exclude>org.apache.bookkeeper:stream-storage-common</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-proto</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-api</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-java-client-base</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-java-kv-client</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-common</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-proto</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-api</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-java-client-base</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-java-kv-client</exclude>
         <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
       </excludes>
     </dependencySet>

--- a/bookkeeper-dist/src/assemble/bkctl.xml
+++ b/bookkeeper-dist/src/assemble/bkctl.xml
@@ -108,10 +108,10 @@
       <excludes>
         <exclude>com.google.code.findbugs:jsr305</exclude>
         <!-- All these dependencies are already included in stream-storage-java-client -->
-        <exclude>org.apache.bookkeeper:stream-storage-common</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-proto</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-api</exclude>
-        <exclude>org.apache.bookkeeper:stream-storage-java-client-base</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-common</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-proto</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-api</exclude>
+        <exclude>com.ascentstream.bookkeeper:stream-storage-java-client-base</exclude>
         <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
         <!-- exclude server-side dependencies -->
         <exclude>org.rocksdb:rocksdbjni</exclude>

--- a/bookkeeper-http/http-server/pom.xml
+++ b/bookkeeper-http/http-server/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/bookkeeper-http/pom.xml
+++ b/bookkeeper-http/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/bookkeeper-http/servlet-http-server/pom.xml
+++ b/bookkeeper-http/servlet-http-server/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>bookkeeper</artifactId>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <version>4.18.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>

--- a/bookkeeper-http/vertx-http-server/pom.xml
+++ b/bookkeeper-http/vertx-http-server/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/bookkeeper-proto/pom.xml
+++ b/bookkeeper-proto/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-proto</artifactId>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -19,44 +19,44 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-server</artifactId>
   <name>Apache BookKeeper :: Server</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common-allocator</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-proto</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-slogger-slf4j</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-slogger-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>native-io</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -65,7 +65,7 @@
       <artifactId>rocksdbjni</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
@@ -102,7 +102,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>circe-checksum</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -176,7 +176,7 @@
     </dependency>
     <!-- testing dependencies -->
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/bookkeeper-slogger/api/pom.xml
+++ b/bookkeeper-slogger/api/pom.xml
@@ -17,11 +17,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>bookkeeper-slogger-parent</artifactId>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <version>4.18.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper-slogger-api</artifactId>
     <name>Apache BookKeeper :: Structured Logger :: API</name>
 </project>

--- a/bookkeeper-slogger/pom.xml
+++ b/bookkeeper-slogger/pom.xml
@@ -16,7 +16,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <artifactId>bookkeeper</artifactId>
         <version>4.18.0-SNAPSHOT</version>
         <relativePath>..</relativePath>

--- a/bookkeeper-slogger/slf4j/pom.xml
+++ b/bookkeeper-slogger/slf4j/pom.xml
@@ -17,16 +17,16 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>bookkeeper-slogger-parent</artifactId>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <version>4.18.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper-slogger-slf4j</artifactId>
     <name>Apache BookKeeper :: Structured Logger :: SLF4J Implementation</name>
     <dependencies>
         <dependency>
-            <groupId>org.apache.bookkeeper</groupId>
+            <groupId>com.ascentstream.bookkeeper</groupId>
             <artifactId>bookkeeper-slogger-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -40,7 +40,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>native-library-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -56,7 +56,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/cpu-affinity/pom.xml
+++ b/cpu-affinity/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -34,7 +34,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>native-library-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/dev/check-binary-license
+++ b/dev/check-binary-license
@@ -59,12 +59,12 @@ EXIT=0
 
 # Check all bundled jars are mentioned in LICENSE
 for J in $JARS; do
-    echo $J | grep -q "org.apache.bookkeeper"
+    echo $J | grep -q "com.ascentstream.bookkeeper"
     if [ $? == 0 ]; then
         continue
     fi
 
-    echo $J | grep -q "org.apache.distributedlog"
+    echo $J | grep -q "com.ascentstream.distributedlog"
     if [ $? == 0 ]; then
         continue
     fi

--- a/metadata-drivers/etcd/pom.xml
+++ b/metadata-drivers/etcd/pom.xml
@@ -28,7 +28,7 @@
   <name>Apache BookKeeper :: Metadata Drivers:: Etcd</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -63,20 +63,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/metadata-drivers/pom.xml
+++ b/metadata-drivers/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>bookkeeper</artifactId>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <version>4.18.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -39,7 +39,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.parent.version}</version>
       <scope>compile</scope>

--- a/native-io/pom.xml
+++ b/native-io/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -41,7 +41,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>native-library-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/native-library-common/pom.xml
+++ b/native-library-common/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <version>31</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.bookkeeper</groupId>
+  <groupId>com.ascentstream.bookkeeper</groupId>
   <version>4.18.0-SNAPSHOT</version>
   <artifactId>bookkeeper</artifactId>
   <packaging>pom</packaging>

--- a/shaded/bookkeeper-server-shaded/pom.xml
+++ b/shaded/bookkeeper-server-shaded/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -30,7 +30,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <exclusions>
@@ -73,14 +73,14 @@
                   <include>com.google.guava:guava</include>
                   <include>com.google.guava:failureaccess</include>
                   <include>com.google.protobuf:protobuf-java</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
-                  <include>org.apache.bookkeeper:native-library-common</include>
-                  <include>org.apache.bookkeeper:cpu-affinity</include>
-                  <include>org.apache.bookkeeper:bookkeeper-tools-framework</include>
-                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
-                  <include>org.apache.bookkeeper:bookkeeper-server</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-common</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-common-allocator</include>
+                  <include>com.ascentstream.bookkeeper:native-library-common</include>
+                  <include>com.ascentstream.bookkeeper:cpu-affinity</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-tools-framework</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-proto</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-server</include>
+                  <include>com.ascentstream.bookkeeper:circe-checksum</include>
                   <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
                 </includes>
               </artifactSet>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -30,7 +30,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>
@@ -52,23 +52,23 @@
           <artifactId>reload4j</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>bookkeeper-common</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>bookkeeper-tools-framework</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>bookkeeper-proto</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>bookkeeper-server</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>circe-checksum</artifactId>
         </exclusion>
         <exclusion>
@@ -97,7 +97,7 @@
                 <includes>
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
-                  <include>org.apache.bookkeeper:bookkeeper-server:test-jar:tests</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-server:test-jar:tests</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -18,12 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <groupId>org.apache.distributedlog</groupId>
+  <groupId>com.ascentstream.distributedlog</groupId>
   <artifactId>distributedlog-core-shaded</artifactId>
   <name>Apache BookKeeper :: Shaded :: distributedlog-core-shaded</name>
   <properties>
@@ -31,7 +31,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.version}</version>
       <exclusions>
@@ -75,14 +75,14 @@
                   <include>com.google.guava:guava</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>at.yawk.lz4:lz4-java</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
-                  <include>org.apache.bookkeeper:native-library-common</include>
-                  <include>org.apache.bookkeeper:cpu-affinity</include>
-                  <include>org.apache.bookkeeper:bookkeeper-tools-framework</include>
-                  <include>org.apache.bookkeeper:bookkeeper-proto</include>
-                  <include>org.apache.bookkeeper:bookkeeper-server</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-common</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-common-allocator</include>
+                  <include>com.ascentstream.bookkeeper:native-library-common</include>
+                  <include>com.ascentstream.bookkeeper:cpu-affinity</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-tools-framework</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-proto</include>
+                  <include>com.ascentstream.bookkeeper:bookkeeper-server</include>
+                  <include>com.ascentstream.bookkeeper:circe-checksum</include>
                   <include>org.apache.bookkeeper.http:http-server</include>
                   <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
                   <include>org.apache.commons:commons-collections4</include>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -19,7 +19,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/stream/api/pom.xml
+++ b/stream/api/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>stream-storage-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -27,12 +27,12 @@
   <name>Apache BookKeeper :: Stream Storage :: API</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/stream/bk-grpc-name-resolver/pom.xml
+++ b/stream/bk-grpc-name-resolver/pom.xml
@@ -21,7 +21,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>stream-storage-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -29,23 +29,23 @@
   <name>Apache BookKeeper :: Stream Storage :: Common :: BK Grpc Name Resolver</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
@@ -69,7 +69,7 @@
        <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/stream/clients/java/all/pom.xml
+++ b/stream/clients/java/all/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -27,18 +27,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-kv-client</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
@@ -62,7 +62,7 @@
               <minimizeJar>false</minimizeJar>
               <artifactSet>
                 <includes>
-                  <include>org.apache.bookkeeper:stream-storage-*</include>
+                  <include>com.ascentstream.bookkeeper:stream-storage-*</include>
                 </includes>
               </artifactSet>
             </configuration>

--- a/stream/clients/java/base/pom.xml
+++ b/stream/clients/java/base/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -27,12 +27,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-proto</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -42,7 +42,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stream/clients/java/kv/pom.xml
+++ b/stream/clients/java/kv/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -27,18 +27,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/stream/clients/java/pom.xml
+++ b/stream/clients/java/pom.xml
@@ -19,7 +19,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-clients-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>

--- a/stream/clients/pom.xml
+++ b/stream/clients/pom.xml
@@ -19,7 +19,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>stream-storage-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -27,7 +27,7 @@
   <name>Apache BookKeeper :: Stream Storage :: Common</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -51,7 +51,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/stream/distributedlog/common/pom.xml
+++ b/stream/distributedlog/common/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.distributedlog</groupId>
+    <groupId>com.ascentstream.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -49,7 +49,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/stream/distributedlog/core/pom.xml
+++ b/stream/distributedlog/core/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.distributedlog</groupId>
+    <groupId>com.ascentstream.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -26,7 +26,7 @@
   <name>Apache BookKeeper :: DistributedLog :: Core Library</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-protocol</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -39,7 +39,7 @@
       <artifactId>libthrift</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -50,7 +50,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
@@ -61,14 +61,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-common</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/stream/distributedlog/io/dlfs/pom.xml
+++ b/stream/distributedlog/io/dlfs/pom.xml
@@ -19,11 +19,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>distributedlog</artifactId>
-    <groupId>org.apache.distributedlog</groupId>
+    <groupId>com.ascentstream.distributedlog</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
-  <groupId>org.apache.distributedlog</groupId>
+  <groupId>com.ascentstream.distributedlog</groupId>
   <artifactId>dlfs</artifactId>
   <name>Apache BookKeeper :: DistributedLog :: IO :: FileSystem</name>
   <url>http://maven.apache.org</url>
@@ -33,7 +33,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -81,7 +81,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
       <classifier>tests</classifier>

--- a/stream/distributedlog/io/pom.xml
+++ b/stream/distributedlog/io/pom.xml
@@ -17,7 +17,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>org.apache.distributedlog</groupId>
+    <groupId>com.ascentstream.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/stream/distributedlog/pom.xml
+++ b/stream/distributedlog/pom.xml
@@ -18,12 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
-  <groupId>org.apache.distributedlog</groupId>
+  <groupId>com.ascentstream.distributedlog</groupId>
   <artifactId>distributedlog</artifactId>
   <packaging>pom</packaging>
   <name>Apache BookKeeper :: DistributedLog :: Parent</name>

--- a/stream/distributedlog/protocol/pom.xml
+++ b/stream/distributedlog/protocol/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.distributedlog</groupId>
+    <groupId>com.ascentstream.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -26,7 +26,7 @@
   <name>Apache BookKeeper :: DistributedLog :: Protocol</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-common</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -35,7 +35,7 @@
       <artifactId>netty-buffer</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -18,13 +18,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <packaging>pom</packaging>
-  <groupId>org.apache.bookkeeper</groupId>
+  <groupId>com.ascentstream.bookkeeper</groupId>
   <artifactId>stream-storage-parent</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Parent</name>
 

--- a/stream/proto/pom.xml
+++ b/stream/proto/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -47,7 +47,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stream/server/pom.xml
+++ b/stream/server/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -27,12 +27,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-service-impl</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -59,7 +59,7 @@
        <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <artifactId>stream-storage-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
@@ -28,27 +28,27 @@
   <name>Apache BookKeeper :: Stream Storage :: State Library</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-proto</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -65,7 +65,7 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
       <classifier>tests</classifier>
@@ -97,7 +97,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/stream/storage/api/pom.xml
+++ b/stream/storage/api/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -28,12 +28,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-proto</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/stream/storage/impl/pom.xml
+++ b/stream/storage/impl/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -28,17 +28,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-service-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>statelib</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -47,20 +47,20 @@
       <artifactId>curator-recipes</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.parent.version}</version>
       <classifier>tests</classifier>
@@ -72,7 +72,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client-base</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/stream/storage/pom.xml
+++ b/stream/storage/pom.xml
@@ -19,7 +19,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
     <relativePath>..</relativePath>

--- a/tests/backward-compat/bc-non-fips/pom.xml
+++ b/tests/backward-compat/bc-non-fips/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/tests/backward-compat/recovery-no-password/pom.xml
+++ b/tests/backward-compat/recovery-no-password/pom.xml
@@ -31,7 +31,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tests/docker-images/all-versions-image/pom.xml
+++ b/tests/docker-images/all-versions-image/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-dist-server</artifactId>
       <version>${project.parent.version}</version>
       <classifier>bin</classifier>

--- a/tests/docker-images/current-version-image/pom.xml
+++ b/tests/docker-images/current-version-image/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-dist-server</artifactId>
       <version>${project.parent.version}</version>
       <classifier>bin</classifier>

--- a/tests/integration/cluster/pom.xml
+++ b/tests/integration/cluster/pom.xml
@@ -32,21 +32,21 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -60,7 +60,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/tests/integration/smoke/pom.xml
+++ b/tests/integration/smoke/pom.xml
@@ -53,7 +53,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/tests/integration/standalone/pom.xml
+++ b/tests/integration/standalone/pom.xml
@@ -32,14 +32,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -19,7 +19,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>

--- a/tests/shaded/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/shaded/bookkeeper-server-shaded-test/pom.xml
@@ -27,7 +27,7 @@
   <name>Apache BookKeeper :: Tests :: bookkeeper-server-shaded test</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server-shaded</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/tests/shaded/bookkeeper-server-tests-shaded-test/pom.xml
+++ b/tests/shaded/bookkeeper-server-tests-shaded-test/pom.xml
@@ -27,7 +27,7 @@
   <name>Apache BookKeeper :: Tests :: bookkeeper-server-tests-shaded test</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server-shaded</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -47,7 +47,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server-tests-shaded</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/tests/shaded/distributedlog-core-shaded-test/pom.xml
+++ b/tests/shaded/distributedlog-core-shaded-test/pom.xml
@@ -27,7 +27,7 @@
   <name>Apache BookKeeper :: Tests :: distributedlog-core-shaded test</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core-shaded</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -37,7 +37,7 @@
            to verify protobuf and guava classes have been relocated -->
       <exclusions>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>bookkeeper-server</artifactId>
         </exclusion>
         <exclusion>
@@ -45,23 +45,23 @@
           <artifactId>bookkeeper-http</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>circe-checksum</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper</groupId>
+          <groupId>com.ascentstream.bookkeeper</groupId>
           <artifactId>native-library-common</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.distributedlog</groupId>
+          <groupId>com.ascentstream.distributedlog</groupId>
           <artifactId>distributedlog-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.distributedlog</groupId>
+          <groupId>com.ascentstream.distributedlog</groupId>
           <artifactId>distributedlog-common</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.distributedlog</groupId>
+          <groupId>com.ascentstream.distributedlog</groupId>
           <artifactId>distributedlog-protocol</artifactId>
         </exclusion>
         <exclusion>

--- a/testtools/pom.xml
+++ b/testtools/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>com.ascentstream.bookkeeper</groupId>
         <artifactId>bookkeeper</artifactId>
         <version>4.18.0-SNAPSHOT</version>
     </parent>

--- a/tools/all/pom.xml
+++ b/tools/all/pom.xml
@@ -21,19 +21,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools</artifactId>
   <name>Apache BookKeeper :: Tools</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools-ledger</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-cli</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tools/framework/pom.xml
+++ b/tools/framework/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-framework</artifactId>
@@ -30,12 +30,12 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>buildtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/tools/ledger/pom.xml
+++ b/tools/ledger/pom.xml
@@ -19,19 +19,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-ledger</artifactId>
   <name>Apache BookKeeper :: Tools :: Ledger</name>
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -46,19 +46,19 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>buildtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>testtools</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <type>test-jar</type>
       <version>${project.parent.version}</version>

--- a/tools/perf/pom.xml
+++ b/tools/perf/pom.xml
@@ -15,7 +15,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper-tools-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -24,17 +24,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>com.ascentstream.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bookkeeper</artifactId>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-parent</artifactId>

--- a/tools/stream/pom.xml
+++ b/tools/stream/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.bookkeeper</groupId>
+    <groupId>com.ascentstream.bookkeeper</groupId>
     <artifactId>bookkeeper-tools-parent</artifactId>
     <version>4.18.0-SNAPSHOT</version>
   </parent>
@@ -28,22 +28,22 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>stream-storage-service-impl</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>com.ascentstream.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
### Motivation

The project is transitioning to a new artifact publishing namespace under `com.ascentstream.*`. This requires updating all Maven coordinates to ensure correct dependency resolution. In addition, CI needs to cover the new `as-master` branch used for development.

### Changes

* Migrated Maven groupIds:

  * `org.apache.bookkeeper` → `com.ascentstream.bookkeeper`
  * `org.apache.distributedlog` → `com.ascentstream.distributedlog`
* Updated all related references in:

  * `pom.xml` files (parent and dependencies)
  * Assembly descriptors
* Updated GitHub Actions workflows to trigger on the `as-master` branch in addition to existing branches
