### PR TITLE
ci: install native build toolchain in website PR validation workflow

### DIFF
--- a/.github/workflows/website-pr-validation.yml
+++ b/.github/workflows/website-pr-validation.yml
@@ -43,6 +43,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
+      - name: Set up native build toolchain
+        uses: ./.github/actions/setup-native-build
 
       - name: Setup NodeJS
         uses: actions/setup-node@v6


### PR DESCRIPTION
### Motivation

The `Website PR validation` workflow has been failing on every PR that touches `site3/**` since the native-io C→Rust migration ([#4738](https://github.com/apache/bookkeeper/pull/4738)):

```
error: no such command: `zigbuild`
```

Root cause: `site3/website/scripts/build-website.sh` invokes `javadoc-gen.sh`, which runs `mvn install` on `bookkeeper-server`. That transitively builds `native-io`, which after #4738 requires `cargo-zigbuild`, the Rust cross-compilation targets, and Zig. `.github/workflows/website-pr-validation.yml` never installs them.

Every recent PR touching `site3/**` fails here — e.g. #4751, plus two dependabot PRs (`follow-redirects`, `brace-expansion`).

### Summary

Add the existing `./.github/actions/setup-native-build` composite action to the website PR validation workflow, matching how other workflows that build `native-io` are set up.

### Test plan

- [ ] Confirm CI for this PR passes the `website-pull-validation` job.