### PR TITLE
Fix NPE in PendingAddOp.maybeTimeout() when clientCtx is null after recycling

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -66,7 +66,7 @@ class PendingAddOp implements WriteCallback {
     boolean completed = false;
 
     LedgerHandle lh;
-    ClientContext clientCtx;
+    volatile ClientContext clientCtx;
     boolean isRecoveryAdd = false;
     volatile long requestTimeNanos;
     long qwcLatency; // Quorum Write Completion Latency after response from quorum bookies.
@@ -154,6 +154,12 @@ class PendingAddOp implements WriteCallback {
     }
 
     boolean maybeTimeout() {
+        if (clientCtx == null) {
+            // Op has already been recycled: recyclePendAddOpObject() cleared clientCtx while
+            // monitorPendingAddOps() was still holding a reference to it from the iterator.
+            // The add-entry completed before the timeout monitor fired; nothing to time out.
+            return false;
+        }
         if (MathUtils.elapsedNanos(requestTimeNanos) >= clientCtx.getConf().addEntryQuorumTimeoutNanos) {
             timeoutQuorumWait();
             return true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -66,7 +66,7 @@ class PendingAddOp implements WriteCallback {
     boolean completed = false;
 
     LedgerHandle lh;
-    volatile ClientContext clientCtx;
+    ClientContext clientCtx;
     boolean isRecoveryAdd = false;
     volatile long requestTimeNanos;
     long qwcLatency; // Quorum Write Completion Latency after response from quorum bookies.
@@ -154,13 +154,16 @@ class PendingAddOp implements WriteCallback {
     }
 
     boolean maybeTimeout() {
-        if (clientCtx == null) {
-            // Op has already been recycled: recyclePendAddOpObject() cleared clientCtx while
-            // monitorPendingAddOps() was still holding a reference to it from the iterator.
-            // The add-entry completed before the timeout monitor fired; nothing to time out.
+        // Snapshot clientCtx into a local: recyclePendAddOpObject() may run on another thread
+        // and null the field while monitorPendingAddOps() still holds an iterator reference
+        // to this op. A single read prevents the field from going null between the guard and
+        // the getConf() dereference below.
+        ClientContext ctx = clientCtx;
+        if (ctx == null) {
+            // Already recycled — the add-entry completed before the timeout monitor fired.
             return false;
         }
-        if (MathUtils.elapsedNanos(requestTimeNanos) >= clientCtx.getConf().addEntryQuorumTimeoutNanos) {
+        if (MathUtils.elapsedNanos(requestTimeNanos) >= ctx.getConf().addEntryQuorumTimeoutNanos) {
             timeoutQuorumWait();
             return true;
         }
@@ -168,7 +171,11 @@ class PendingAddOp implements WriteCallback {
     }
 
     synchronized void timeoutQuorumWait() {
-        if (completed) {
+        // lh / clientCtx are nulled by recyclePendAddOpObject() under this same monitor.
+        // Once we hold the lock, a recycle has either not started or fully completed; if any
+        // of these are null, the op has been recycled and there is nothing to time out.
+        // (The completed flag alone is insufficient: recycle resets it to false.)
+        if (completed || lh == null || clientCtx == null) {
             return;
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
@@ -24,7 +24,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.netty.buffer.ByteBuf;
@@ -164,5 +167,34 @@ public class PendingAddOpTest {
         op.requestTimeNanos = 0L;
 
         assertTrue(op.maybeTimeout());
+    }
+
+    /**
+     * Verify that {@link PendingAddOp#timeoutQuorumWait()} is a no-op when the op has already
+     * been recycled (i.e. {@code lh} and {@code clientCtx} are {@code null}).
+     *
+     * <p>This covers the second concern raised in the review of #4760: even after
+     * {@link PendingAddOp#maybeTimeout()} captures a non-null {@code clientCtx} snapshot,
+     * {@code recyclePendAddOpObject()} may complete before {@code timeoutQuorumWait()}
+     * acquires the monitor. The pre-existing {@code if (completed) return;} guard does not
+     * cover this because recycling resets {@code completed} to {@code false}; without an
+     * explicit null check the method NPEs on {@code lh.getLedgerMetadata()} (or similar)
+     * and, worse, may invoke {@code handleUnrecoverableErrorDuringAdd} on a stale handle.
+     */
+    @Test
+    public void testTimeoutQuorumWaitIsNoOpWhenAlreadyRecycled() {
+        PendingAddOp op = PendingAddOp.create(
+                lh, mockClientContext, lh.getCurrentEnsemble(),
+                payload, WriteFlag.NONE,
+                (rc, handle, entryId, qwcLatency, ctx) -> {}, null);
+
+        // Simulate post-recycle state: recyclePendAddOpObject() has already nulled these fields.
+        op.lh = null;
+        op.clientCtx = null;
+
+        // Must not throw NPE — and must not invoke the unrecoverable-error handler on the
+        // (now-stale) ledger handle, which would cause spurious failures on a recycled op.
+        op.timeoutQuorumWait();
+        verify(lh, never()).handleUnrecoverableErrorDuringAdd(anyInt());
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingAddOpTest.java
@@ -20,8 +20,10 @@ package org.apache.bookkeeper.client;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,8 +31,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.client.BKException.Code;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.WriteFlag;
+import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Before;
@@ -87,4 +92,77 @@ public class PendingAddOpTest {
         assertNull(op.lh);
     }
 
+    /**
+     * Verify that {@link PendingAddOp#maybeTimeout()} returns {@code false} without throwing
+     * {@link NullPointerException} when {@code clientCtx} is {@code null}.
+     *
+     * <p>This is the exact scenario that caused the production NPE reported in
+     * apache/bookkeeper#4759: {@code monitorPendingAddOps()} holds an iterator reference to
+     * an op while {@code recyclePendAddOpObject()} runs concurrently on another thread and
+     * clears {@code clientCtx} to {@code null}. After recycling the op has already completed,
+     * so the correct behaviour is to skip the timeout check (return {@code false}).
+     */
+    @Test
+    public void testMaybeTimeoutReturnsFalseWhenClientCtxIsNull() {
+        PendingAddOp op = PendingAddOp.create(
+                lh, mockClientContext, lh.getCurrentEnsemble(),
+                payload, WriteFlag.NONE,
+                (rc, handle, entryId, qwcLatency, ctx) -> {}, null);
+
+        // Simulate the race: recyclePendAddOpObject() cleared clientCtx on the writer
+        // thread while monitorPendingAddOps() is still iterating the pendingAddOps queue
+        // on the scheduler thread.
+        op.clientCtx = null;
+
+        // Before the fix this threw NullPointerException; after the fix it must return false.
+        assertFalse(op.maybeTimeout());
+    }
+
+    /**
+     * Verify that {@link PendingAddOp#maybeTimeout()} returns {@code false} when
+     * {@code clientCtx} is non-null and the quorum timeout has not yet elapsed.
+     */
+    @Test
+    public void testMaybeTimeoutReturnsFalseWhenWithinQuorumTimeout() {
+        // Configure a 1-hour quorum timeout so the op will not have expired.
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setAddEntryQuorumTimeout(3600);
+        when(mockClientContext.getConf()).thenReturn(ClientInternalConf.fromConfig(conf));
+
+        PendingAddOp op = PendingAddOp.create(
+                lh, mockClientContext, lh.getCurrentEnsemble(),
+                payload, WriteFlag.NONE,
+                (rc, handle, entryId, qwcLatency, ctx) -> {}, null);
+        // Stamp the request as starting right now so elapsed time is effectively 0.
+        op.requestTimeNanos = MathUtils.nowInNano();
+
+        assertFalse(op.maybeTimeout());
+    }
+
+    /**
+     * Verify that {@link PendingAddOp#maybeTimeout()} returns {@code true} and triggers
+     * {@link PendingAddOp#timeoutQuorumWait()} when the quorum timeout has already elapsed.
+     */
+    @Test
+    public void testMaybeTimeoutReturnsTrueWhenQuorumTimeoutExpired() {
+        // Configure a 1-second quorum timeout.
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setAddEntryQuorumTimeout(1);
+        when(mockClientContext.getConf()).thenReturn(ClientInternalConf.fromConfig(conf));
+
+        LedgerMetadata meta = mock(LedgerMetadata.class);
+        when(lh.getLedgerMetadata()).thenReturn(meta);
+        // addEntrySuccessBookies starts empty (size 0 < ackQuorumSize 3),
+        // so the fault-domain stats branch is skipped and no extra mocking is needed.
+        when(meta.getAckQuorumSize()).thenReturn(3);
+
+        PendingAddOp op = PendingAddOp.create(
+                lh, mockClientContext, lh.getCurrentEnsemble(),
+                payload, WriteFlag.NONE,
+                (rc, handle, entryId, qwcLatency, ctx) -> {}, null);
+        // Set the request start time to 0 so that elapsed nanos is enormous (>> 1 second).
+        op.requestTimeNanos = 0L;
+
+        assertTrue(op.maybeTimeout());
+    }
 }


### PR DESCRIPTION
## Motivation

`monitorPendingAddOps()` iterates over the `pendingAddOps` queue and calls
`maybeTimeout()` on each op. Concurrently, `sendAddSuccessCallbacks()` can
remove a completed op from the queue, call `submitCallback()` on it, and
ultimately trigger `recyclePendAddOpObject()` which sets `clientCtx = null`
(and `lh = null`, etc.).

If the scheduler thread still holds a live iterator reference to the same op
and then calls `maybeTimeout()`, dereferencing `clientCtx` causes a
`NullPointerException`:

```
java.lang.NullPointerException
    at org.apache.bookkeeper.client.PendingAddOp.maybeTimeout(PendingAddOp.java:157)
    at org.apache.bookkeeper.client.LedgerHandle.monitorPendingAddOps(LedgerHandle.java:2063)
```

The race is only triggered when `addEntryQuorumTimeoutNanos > 0` (i.e. the
quorum-timeout monitor is actually scheduled). It became reliably observable
with **Netty 4.1.130**, which changed `Recycler` thread-scheduling behavior
and narrowed the window enough to expose the pre-existing race.

Closes #4759.

## Changes

### `PendingAddOp.java`

* **`maybeTimeout()` — snapshot `clientCtx` into a local.**
  A naive null-check at the top of the method does not close the race:
  `clientCtx` could still be nulled between the guard and the subsequent
  `clientCtx.getConf()` dereference. `volatile` does not help here — it
  only guarantees visibility, not atomicity across two reads. Reading the
  field once into a local variable makes the second access race-free
  (locals are not visible to other threads).

* **`timeoutQuorumWait()` — bail when already recycled.**
  Even after `maybeTimeout()` snapshots a non-null `clientCtx`,
  `recyclePendAddOpObject()` may complete before `timeoutQuorumWait()`
  acquires the monitor (both methods are `synchronized`). The pre-existing
  `if (completed) return;` guard does **not** cover this — recycling
  resets `completed` to `false`. Without an explicit null check the method
  NPEs on `lh.getLedgerMetadata()` and could invoke
  `handleUnrecoverableErrorDuringAdd` on a stale handle. Extended the
  early-return to `if (completed || lh == null || clientCtx == null)`.

### `PendingAddOpTest.java`

Four new unit tests:

| Test | What it verifies |
|---|---|
| `testMaybeTimeoutReturnsFalseWhenClientCtxIsNull` | The exact race: `clientCtx = null` must not NPE |
| `testMaybeTimeoutReturnsFalseWhenWithinQuorumTimeout` | Normal path — not yet timed out |
| `testMaybeTimeoutReturnsTrueWhenQuorumTimeoutExpired` | Normal path — timed out, `true` returned |
| `testTimeoutQuorumWaitIsNoOpWhenAlreadyRecycled` | Recycle wins the monitor race after `maybeTimeout()` already saw a non-null `clientCtx`: `timeoutQuorumWait()` must not NPE and must not invoke `handleUnrecoverableErrorDuringAdd` on the stale handle |