### PR TITLE
site3: add docusaurus-plugin-copy-page-button

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
   favicon: 'img/favicon.ico',
   organizationName: 'apache',
   projectName: 'bookkeeper',
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: ['docusaurus-plugin-sass', 'docusaurus-plugin-copy-page-button'],
   markdown: {
     format: 'detect',
     hooks: {

--- a/site3/website/package.json
+++ b/site3/website/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "docusaurus-plugin-sass": "^0.2.5",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.2.0",

--- a/site3/website/package.json
+++ b/site3/website/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "docusaurus-plugin-sass": "^0.2.5",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Apache BookKeeper docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for BookKeeper

BookKeeper is the kind of distributed systems codebase that devs ask AI assistants about constantly: protocol details, configuration tuning, deployment patterns, and the various API surface for the client SDKs. A one-click handoff from any docs page into Claude or ChatGPT removes the friction of "select all, strip out the nav, paste."

The plugin auto-injects into the table-of-contents sidebar — no further config needed and no new build step.

## Production users

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, Kurtosis, and Dagger docs. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `site3/website/package.json` dependencies
- Adds the plugin string to the existing `plugins` array in `site3/website/docusaurus.config.js`

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.