### PR TITLE
BP-69: Inherit LedgerHandle logger context in ledger operations

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -216,7 +216,7 @@ Apache Software License, Version 2.
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.github.merlimat.slog-slog-0.9.8.jar [64]
+- lib/io.github.merlimat.slog-slog-0.9.9.jar [64]
 - lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
 - lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
 - lib/io.netty-netty-codec-compression-4.2.12.Final.jar [11]
@@ -423,7 +423,7 @@ Apache Software License, Version 2.
 [61] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [63] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
-[64] Source available at https://github.com/merlimat/slog/tree/v0.9.8
+[64] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -216,7 +216,7 @@ Apache Software License, Version 2.
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.github.merlimat.slog-slog-0.9.8.jar [59]
+- lib/io.github.merlimat.slog-slog-0.9.9.jar [59]
 - lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
 - lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
 - lib/io.netty-netty-common-4.2.12.Final.jar [11]
@@ -356,7 +356,7 @@ Apache Software License, Version 2.
 [56] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [58] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
-[59] Source available at https://github.com/merlimat/slog/tree/v0.9.8
+[59] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -216,7 +216,7 @@ Apache Software License, Version 2.
 - lib/commons-codec-commons-codec-1.18.0.jar [6]
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
-- lib/io.github.merlimat.slog-slog-0.9.8.jar [63]
+- lib/io.github.merlimat.slog-slog-0.9.9.jar [63]
 - lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
 - lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
 - lib/io.netty-netty-codec-compression-4.2.12.Final.jar [11]
@@ -418,7 +418,7 @@ Apache Software License, Version 2.
 [60] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [62] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
-[63] Source available at https://github.com/merlimat/slog/tree/v0.9.8
+[63] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
 lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BatchedReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BatchedReadOp.java
@@ -79,7 +79,7 @@ public class BatchedReadOp extends ReadOpBase implements BatchedReadEntryCallbac
         long latencyNanos = MathUtils.elapsedNanos(requestTimeNanos);
         if (code != BKException.Code.OK) {
             log.error()
-                    .attr("ledgerId", lh.getId())
+                    .ctx(lh.log)
                     .attr("startEntryId", startEntryId)
                     .attr("entryId", startEntryId + maxCount - 1)
                     .attr("sentToHosts", sentToHosts)
@@ -278,6 +278,7 @@ public class BatchedReadOp extends ReadOpBase implements BatchedReadEntryCallbac
                 return to;
             } catch (InterruptedException ie) {
                 log.error()
+                        .ctx(lh.log)
                         .attr("readOp", this)
                         .exception(ie)
                         .log("Interrupted reading entry");
@@ -293,6 +294,7 @@ public class BatchedReadOp extends ReadOpBase implements BatchedReadEntryCallbac
             int replica = writeSet.indexOf(bookieIndex);
             if (replica == NOT_FOUND) {
                 log.error()
+                        .ctx(lh.log)
                         .attr("bookieAddr", host)
                         .attr("ensemble", ensemble)
                         .log("Received error from a host which is not in the ensemble");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ForceLedgerOp.java
@@ -71,7 +71,7 @@ class ForceLedgerOp implements Runnable, ForceLedgerCallback {
         this.currentNonDurableLastAddConfirmed = lh.pendingAddsSequenceHead;
 
         log.debug()
-        .attr("ledgerId", lh.ledgerId)
+        .ctx(lh.log)
         .attr("nonDurableLac", currentNonDurableLastAddConfirmed)
         .log("force clientNonDurableLac");
 
@@ -111,7 +111,7 @@ class ForceLedgerOp implements Runnable, ForceLedgerCallback {
                 // for every acknowledged entry before issuing the force() call
 
                 log.debug()
-                .attr("ledgerId", ledgerId)
+                .ctx(lh.log)
                 .attr("nonDurableLac", currentNonDurableLastAddConfirmed)
                 .log("After force on ledger, updating LastAddConfirmed");
 
@@ -122,7 +122,7 @@ class ForceLedgerOp implements Runnable, ForceLedgerCallback {
             // at least one bookie failed, as we are waiting for all the bookies
             // we can fail immediately
             log.error()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("bookieAddr", addr)
                     .log("ForceLedger did not succeed");
             errored = true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerRecoveryOp.java
@@ -18,9 +18,9 @@
 package org.apache.bookkeeper.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.github.merlimat.slog.Logger;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryListener;
@@ -32,9 +32,8 @@ import org.apache.bookkeeper.proto.checksum.DigestManager.RecoveryData;
  * starting from the last confirmed entry (from hints in the ledger entries),
  * it reads forward until it is not able to find a particular entry.
  */
+@CustomLog
 class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
-
-    private final Logger log;
 
     final LedgerHandle lh;
     final ClientContext clientCtx;
@@ -69,7 +68,6 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
     }
 
     public LedgerRecoveryOp(LedgerHandle lh, ClientContext clientCtx) {
-        this.log = Logger.get(LedgerRecoveryOp.class).with().attr("ledgerId", lh.getId()).build();
         readCount = new AtomicLong(0);
         writeCount = new AtomicLong(0);
         readDone = false;
@@ -196,6 +194,7 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
                 // check whether entry id is expected, so we won't overwritten any entries by mistake
                 if (entry.getEntryId() != lh.lastAddPushed + 1) {
                     log.error()
+                            .ctx(lh.log)
                             .attr("entryId", entry.getEntryId())
                             .attr("expectedEntryId", (lh.lastAddPushed + 1))
                             .log("Unexpected entryId during recovery add");
@@ -224,18 +223,18 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
         // otherwise, some other error, we can't handle
         if (BKException.Code.OK != rc && !promise.isDone()) {
             log.error()
+                    .ctx(lh.log)
                     .attr("getMessage", BKException.getMessage(rc))
                     .attr("startEntryId", startEntryToRead)
                     .attr("endEntryId", endEntryToRead)
-                    .attr("ledgerId", lh.getId())
                     .log("Failure while reading entries: ( - ), ledger: while recovering ledger");
             submitCallback(rc);
         } else if (BKException.Code.OK == rc) {
             // we are here is because we successfully read an entry but readDone was already set to true.
             // this would happen on recovery a ledger than has gaps in the tail.
             log.warn()
+                    .ctx(lh.log)
                     .attr("entryId", entry.getEntryId())
-                    .attr("ledgerId", lh.getId())
                     .attr("readDone", readDone)
                     .log("Successfully read entry, but readDone is already set");
         }
@@ -246,9 +245,9 @@ class LedgerRecoveryOp implements ReadEntryListener, AddCallback {
     public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
         if (rc != BKException.Code.OK) {
             log.error()
+                    .ctx(lh.log)
                     .attr("codeLogger", BKException.codeLogger(rc))
                     .attr("entryId", entryId + 1)
-                    .attr("ledgerId", lh.ledgerId)
                     .log("Failure while writing entry while recovering ledger");
             submitCallback(rc);
             return;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingAddOp.java
@@ -210,7 +210,7 @@ class PendingAddOp implements WriteCallback {
 
 
         log.debug()
-                .attr("ledgerId", lh.ledgerId)
+                .ctx(lh.log)
                 .attr("entryId", entryId)
                 .attr("bookieIndex", bookieIndex)
                 .log("Unsetting success");
@@ -270,7 +270,7 @@ class PendingAddOp implements WriteCallback {
             // ensemble has already changed, failure of this addr is immaterial
 
             log.debug()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("entryId", entryId)
                     .log("Write did not succeed. But we have already fixed it.");
 
@@ -330,7 +330,7 @@ class PendingAddOp implements WriteCallback {
             return;
         case BKException.Code.LedgerFencedException:
             log.warn()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("entryId", entryId)
                     .attr("bookieAddr", addr)
                     .log("Fencing exception on write");
@@ -338,7 +338,7 @@ class PendingAddOp implements WriteCallback {
             return;
         case BKException.Code.UnauthorizedAccessException:
             log.warn()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("entryId", entryId)
                     .attr("bookieAddr", addr)
                     .log("Unauthorized access exception on write");
@@ -350,7 +350,7 @@ class PendingAddOp implements WriteCallback {
                         || rc == BKException.Code.WriteOnReadOnlyBookieException) {
                     Map<Integer, BookieId> failedBookies = ackSet.getFailedBookies();
                     log.warn()
-                            .attr("ledgerId", ledgerId)
+                            .ctx(lh.log)
                             .attr("entryId", entryId)
                             .attr("failedBookies", failedBookies)
                             .log("Failed to write entry to bookies, handling failures");
@@ -358,7 +358,7 @@ class PendingAddOp implements WriteCallback {
                     lh.handleBookieFailure(failedBookies);
                 } else {
                     log.debug()
-                            .attr("ledgerId", ledgerId)
+                            .ctx(lh.log)
                             .attr("entryId", entryId)
                             .attr("bookieIndex", bookieIndex)
                             .attr("bookieAddr", addr)
@@ -368,7 +368,7 @@ class PendingAddOp implements WriteCallback {
                 }
             } else {
                 log.warn()
-                        .attr("ledgerId", ledgerId)
+                        .ctx(lh.log)
                         .attr("entryId", entryId)
                         .attr("bookieIndex", bookieIndex)
                         .attr("bookieAddr", addr)
@@ -386,7 +386,7 @@ class PendingAddOp implements WriteCallback {
                                                                         lh.getLedgerMetadata().getWriteQuorumSize(),
                                                                         lh.getLedgerMetadata().getAckQuorumSize()))) {
                 log.warn()
-                        .attr("ledgerId", ledgerId)
+                        .ctx(lh.log)
                         .attr("entryId", entryId)
                         .log("Write success for entry ID delayed, not acknowledged by bookies in enough fault domains");
                 // Increment to indicate write did not complete due to not enough fault domains
@@ -419,7 +419,7 @@ class PendingAddOp implements WriteCallback {
     synchronized void submitCallback(final int rc) {
 
         log.debug()
-                .attr("ledgerId", () -> lh.getId())
+                .ctx(lh.log)
                 .attr("entryId", entryId)
                 .attr("rc", rc)
                 .log("Submit callback");
@@ -429,7 +429,7 @@ class PendingAddOp implements WriteCallback {
         if (rc != BKException.Code.OK) {
             clientCtx.getClientStats().getAddOpLogger().registerFailedEvent(latencyNanos, TimeUnit.NANOSECONDS);
             log.error()
-                    .attr("ledgerId", lh.getId())
+                    .ctx(lh.log)
                     .attr("entryId", entryId)
                     .log("Write of ledger entry to quorum failed");
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadLacOp.java
@@ -121,7 +121,7 @@ class PendingReadLacOp implements ReadLacCallback {
                 // Too bad, this bookie did not give us a valid answer, we
                 // still might be able to recover. So, continue
                 log.error()
-                        .attr("ledgerId", ledgerId)
+                        .ctx(lh.log)
                         .attr("bookieAddr", currentEnsemble.get(bookieIndex))
                         .log("Mac mismatch while reading LAC from bookie");
                 rc = BKException.Code.DigestMatchException;
@@ -149,7 +149,7 @@ class PendingReadLacOp implements ReadLacCallback {
             completed = true;
 
             log.debug()
-            .attr("ledgerId", ledgerId)
+            .ctx(lh.log)
             .attr("maxLac", maxLac)
             .log("Read LAC complete with enough validResponse");
 
@@ -159,7 +159,7 @@ class PendingReadLacOp implements ReadLacCallback {
 
         if (numResponsesPending == 0 && !completed) {
             log.error()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("coverageSet", coverageSet)
                     .log("While readLac did not hear success responses from all of ensemble");
             cb.getLacComplete(lastSeenError, maxLac);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -118,7 +118,7 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
 
         if (numPendingEntries < 0) {
             log.error()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("startEntryId", startEntryId)
                     .attr("endEntryId", endEntryId)
                     .log("Read too many values");
@@ -153,7 +153,7 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
                 }
             }
             log.error()
-                    .attr("ledgerId", lh.getId())
+                    .ctx(lh.log)
                     .attr("startEntryId", startEntryId)
                     .attr("endEntryId", endEntryId)
                     .attr("sentToHosts", sentToHosts)
@@ -257,6 +257,7 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
                     sendReadTo(writeSet.get(i), to, this);
                 } catch (InterruptedException ie) {
                     log.error()
+                            .ctx(lh.log)
                             .exception(ie)
                             .attr("readOp", this)
                             .log("Interrupted reading entry");
@@ -375,6 +376,7 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
                 return to;
             } catch (InterruptedException ie) {
                 log.error()
+                        .ctx(lh.log)
                         .exception(ie)
                         .attr("readOp", this)
                         .log("Interrupted reading entry");
@@ -391,6 +393,7 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
             int replica = writeSet.indexOf(bookieIndex);
             if (replica == NOT_FOUND) {
                 log.error()
+                        .ctx(lh.log)
                         .attr("bookieAddr", host)
                         .attr("ensemble", ensemble)
                         .log("Received error from a host which is not in the ensemble");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingWriteLacOp.java
@@ -110,7 +110,7 @@ class PendingWriteLacOp implements WriteLacCallback {
             }
         } else {
             log.warn()
-                    .attr("ledgerId", ledgerId)
+                    .ctx(lh.log)
                     .attr("bookieAddr", addr)
                     .log("WriteLac did not succeed");
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -21,7 +21,6 @@
 package org.apache.bookkeeper.client;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import java.util.BitSet;
 import java.util.List;
@@ -29,6 +28,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.common.util.MathUtils;
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.proto.checksum.DigestManager;
 /**
  * Long poll read operation.
  */
+@CustomLog
 class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEntryCallback,
                                              SpeculativeRequestExecutor {
 
@@ -64,7 +65,6 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
     private long timeOutInMillis;
     private final List<BookieId> currentEnsemble;
     private ScheduledFuture<?> speculativeTask = null;
-    protected final Logger log;
 
     abstract class ReadLACAndEntryRequest implements AutoCloseable {
 
@@ -203,6 +203,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
 
 
             log.debug()
+                    .ctx(lh.log)
                     .attr("error", errMsg)
                     .attr("entryId", () -> entryImpl.getEntryId())
                     .attr("bookieAddr", host)
@@ -261,6 +262,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                     sendReadTo(orderedEnsemble.get(i), to, this);
                 } catch (InterruptedException ie) {
                     log.error()
+                            .ctx(lh.log)
                             .exception(ie)
                             .log("Interrupted reading entry");
                     Thread.currentThread().interrupt();
@@ -387,6 +389,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                 return to;
             } catch (InterruptedException ie) {
                 log.error()
+                        .ctx(lh.log)
                         .attr("addEntryOp", this)
                         .exception(ie)
                         .log("Interrupted reading entry");
@@ -403,6 +406,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
             int replica = getReplicaIndex(bookieIndex);
             if (replica == NOT_FOUND) {
                 log.error()
+                        .ctx(lh.log)
                         .attr("bookieAddr", host)
                         .attr("ensemble", ensemble)
                         .log("Received error from a host which is not in the ensemble");
@@ -463,11 +467,6 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
             - getLedgerMetadata().getAckQuorumSize();
         heardFromHostsBitSet = new BitSet(getLedgerMetadata().getEnsembleSize());
         emptyResponsesFromHostsBitSet = new BitSet(getLedgerMetadata().getEnsembleSize());
-        this.log = Logger.get(ReadLastConfirmedAndEntryOp.class)
-                .with()
-                .attr("ledgerId", lh.getId())
-                .attr("prevEntryId", prevEntryId)
-                .build();
     }
 
     protected LedgerMetadata getLedgerMetadata() {
@@ -497,6 +496,8 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                         && (null != request.maybeSendSpeculativeRead(heardFromHostsBitSet))) {
 
                     log.debug()
+                            .ctx(lh.log)
+                            .attr("prevEntryId", prevEntryId)
                             .attr("request", request)
                             .attr("lastAddConfirmed", lastAddConfirmed)
                             .attr("heardFromHostsBitSet", heardFromHostsBitSet)
@@ -524,6 +525,8 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
 
     void sendReadTo(int bookieIndex, BookieId to, ReadLACAndEntryRequest entry) throws InterruptedException {
         log.debug()
+                .ctx(lh.log)
+                .attr("prevEntryId", prevEntryId)
                 .attr("timeOutInMillis", timeOutInMillis)
                 .attr("bookieAddr", to)
                 .attr("parallelRead", parallelRead)
@@ -571,7 +574,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
     @Override
     public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
         log.trace()
-                .attr("class", getClass().getName())
+                .ctx(lh.log)
                 .attr("entryId", entryId)
                 .attr("rc", rc)
                 .log("received response");
@@ -581,6 +584,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         numResponsesPending--;
         if (BKException.Code.OK == rc) {
             log.trace()
+                    .ctx(lh.log)
                     .attr("getLastAddConfirmed", () -> rCtx.getLastAddConfirmed())
                     .attr("bookieAddr", bookie)
                     .log("Received lastAddConfirmed");
@@ -619,6 +623,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                     completeRequest();
                 } else if (emptyResponsesFromHostsBitSet.cardinality() >= numEmptyResponsesAllowed) {
                     log.debug()
+                            .ctx(lh.log)
                             .attr("cardinality", () -> emptyResponsesFromHostsBitSet.cardinality())
                             .attr("emptyResponsesFromHostsBitSet", emptyResponsesFromHostsBitSet)
                             .log("Completed readLACAndEntry after received empty responses");
@@ -626,7 +631,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
                     completeRequest();
                 } else {
                     log.debug()
-                            .attr("bookieAddr", () -> rCtx.getBookieAddress())
+                            .ctx(lh.log)
                             .attr("bookieAddr", () -> rCtx.getBookieAddress())
                             .attr("lastAddConfirmed", lastAddConfirmed)
                             .log("Received empty response from bookie, reattempting reading next bookie");

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOpBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadOpBase.java
@@ -196,7 +196,7 @@ public abstract class ReadOpBase implements Runnable {
                 ++numBookiesMissingEntry;
 
                 log.debug()
-                .attr("ledgerId", lh.ledgerId)
+                .ctx(lh.log)
                 .attr("entryId", eId)
                 .attr("bookieAddr", host)
                 .log("No such entry found on bookie");
@@ -204,8 +204,8 @@ public abstract class ReadOpBase implements Runnable {
             } else {
 
                 log.info()
+                        .ctx(lh.log)
                         .attr("error", errMsg)
-                        .attr("ledgerId", lh.ledgerId)
                         .attr("entryId", eId)
                         .attr("bookieAddr", host)
                         .log("Error while reading from bookie");
@@ -262,6 +262,7 @@ public abstract class ReadOpBase implements Runnable {
                     if (!isComplete() && null != maybeSendSpeculativeRead(heardFromHostsBitSet)) {
 
                         log.debug()
+                                .ctx(lh.log)
                                 .attr("readOp", this)
                                 .attr("sentToHosts", sentToHosts)
                                 .attr("heardFromHostsBitSet", heardFromHostsBitSet)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TryReadLastConfirmedOp.java
@@ -67,7 +67,7 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
     public void readEntryComplete(int rc, long ledgerId, long entryId, ByteBuf buffer, Object ctx) {
 
         log.trace()
-                .attr("ledgerId", ledgerId)
+                .ctx(lh.log)
                 .attr("entryId", entryId)
                 .attr("rc", rc)
                 .log("TryReadLastConfirmed received response");
@@ -80,10 +80,10 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
                 RecoveryData recoveryData = lh.macManager.verifyDigestAndReturnLastConfirmed(buffer);
 
                 log.trace()
+                        .ctx(lh.log)
                         .attr("lastAddConfirmed", () -> recoveryData.getLastAddConfirmed())
                         .attr("length", () -> recoveryData.getLength())
                         .attr("bookieIndex", bookieIndex)
-                        .attr("ledgerId", ledgerId)
                         .log("Received lastAddConfirmed");
 
                 if (recoveryData.getLastAddConfirmed() > maxRecoveredData.getLastAddConfirmed()) {
@@ -94,7 +94,7 @@ class TryReadLastConfirmedOp implements ReadEntryCallback {
                 hasValidResponse = true;
             } catch (BKException.BKDigestMatchException e) {
                 log.error()
-                        .attr("ledgerId", ledgerId)
+                        .ctx(lh.log)
                         .attr("entryId", entryId)
                         .attr("bookieAddr", currentEnsemble.get(bookieIndex))
                         .log("Mac mismatch while reading last entry from bookie");

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <rocksdb.version>9.9.3</rocksdb.version>
     <shrinkwrap.version>3.3.0</shrinkwrap.version>
     <slf4j.version>2.0.12</slf4j.version>
-    <slog.version>0.9.8</slog.version>
+    <slog.version>0.9.9</slog.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <spotbugs-annotations.version>4.6.0</spotbugs-annotations.version>
     <spotless.version>2.43.0</spotless.version>


### PR DESCRIPTION
## Summary

- Operations created within the context of a `LedgerHandle` (PendingAddOp, PendingReadOp, BatchedReadOp, ReadOpBase, ForceLedgerOp, TryReadLastConfirmedOp, ReadLastConfirmedAndEntryOp, LedgerRecoveryOp, PendingReadLacOp, PendingWriteLacOp) now inherit the parent ledger's logger context on every emitted event, via `Event.ctx(lh.log)`.
- Static `@CustomLog` loggers are kept; using per-event `ctx()` rather than constructing a child `Logger` per op avoids per-operation `Logger` allocations while still propagating ledger-scoped attrs (`ledgerId`, etc.) to every log line.
- `ReadLastConfirmedAndEntryOp` and `LedgerRecoveryOp` previously built an instance-scoped `Logger`; they're switched to the static-logger + `ctx(lh.log)` pattern, removing one `Logger` allocation per operation.
- Redundant `.attr("ledgerId", ...)` calls — the value is already in `LedgerHandle.log`'s context — are removed at the same sites.

## Test plan

- [x] `mvn -pl bookkeeper-server compile` passes.
- [ ] Existing client integration tests continue to pass on CI.