### PR TITLE
BP-69: Print slog context attrs in log4j2; add OTel JSON example

### DIFF
--- a/bookkeeper-benchmark/conf/log4j2.xml
+++ b/bookkeeper-benchmark/conf/log4j2.xml
@@ -22,13 +22,13 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="bookkeeper_trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="bookkeeper-benchmark.log" filePattern="bookkeeper-benchmark.log%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/bookkeeper-benchmark/conf/log4j2.xml
+++ b/bookkeeper-benchmark/conf/log4j2.xml
@@ -22,13 +22,13 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
         </Console>
         <File name="TRACEFILE" fileName="bookkeeper_trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m %X%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="bookkeeper-benchmark.log" filePattern="bookkeeper-benchmark.log%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/bookkeeper-server/src/main/resources/log4j2.xml
+++ b/bookkeeper-server/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/bookkeeper-server/src/main/resources/log4j2.xml
+++ b/bookkeeper-server/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="warn" monitorInterval="10">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/conf/log4j2.cli.xml
+++ b/conf/log4j2.cli.xml
@@ -34,7 +34,7 @@
             <PatternLayout pattern="%m%n"/>
         </Console>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}" filePattern="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/log4j2.cli.xml
+++ b/conf/log4j2.cli.xml
@@ -34,7 +34,7 @@
             <PatternLayout pattern="%m%n"/>
         </Console>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}" filePattern="${sys:bookkeeper.cli.log.dir}/${sys:bookkeeper.cli.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/log4j2.otel-json.xml
+++ b/conf/log4j2.otel-json.xml
@@ -24,9 +24,6 @@
     object aligned with the OpenTelemetry log data model
     (https://opentelemetry.io/docs/specs/otel/logs/data-model/).
 
-    The structured attributes set via slog ".attr(...)" calls are written to
-    Log4j2's ContextData and surface here under the "attributes" field.
-
     Required runtime dependency (NOT included by default in BookKeeper):
         org.apache.logging.log4j:log4j-layout-template-json:${log4j.version}
 
@@ -36,18 +33,23 @@
     there (e.g. add resource attributes, drop fields, rename keys) without
     touching this file.
 
-    Notes on the OTel mapping:
-      * "severity_text"       = log4j level name ("INFO", "WARN", ...).
-      * "severity_number"     = OTel severity number derived from the level
-                                (TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17).
-      * "body"                = the log message string.
-      * "trace_id"/"span_id"  = MDC keys conventionally set by the OpenTelemetry
-                                log appender bridge; omitted when absent.
-      * "attributes"          = the full ContextData map (slog attrs + any
-                                other entries placed in Log4j2 ThreadContext
-                                or SLF4J MDC).
-      * "resource"            = static attributes about the producer; populate
-                                via OTEL_SERVICE_NAME / HOSTNAME env vars.
+    Top-level fields follow the OTel data-model field naming (PascalCase):
+      * "Timestamp"           = event time, ISO-8601 UTC.
+      * "SeverityText"        = log4j level name ("INFO", "WARN", ...).
+      * "Body"                = the log message string.
+      * "TraceId" / "SpanId" / "TraceFlags"
+                              = MDC keys conventionally set by the
+                                OpenTelemetry log appender bridge; omitted
+                                when absent.
+      * "Attributes"          = OTel-semantic-conventions attributes for the
+                                event:
+                                  - thread.name / thread.id
+                                  - code.namespace (= the logger name)
+                                  - exception.type / .message / .stacktrace
+                                Plus the full Log4j2 ContextData map (every
+                                slog ".attr(...)" entry and any SLF4J MDC
+                                key) merged in via the "mdc" resolver with
+                                flatten=true.
 -->
 <Configuration status="warn" monitorInterval="10">
     <Properties>
@@ -56,8 +58,6 @@
         <Property name="bookkeeper.log.root.level">INFO</Property>
         <Property name="bookkeeper.log.root.appender">CONSOLE</Property>
         <Property name="otel.template">file:${sys:bookkeeper.conf.dir:-conf}/otel-log-template.json</Property>
-        <Property name="otel.service.name">${env:OTEL_SERVICE_NAME:-bookkeeper}</Property>
-        <Property name="otel.host.name">${env:HOSTNAME:-unknown}</Property>
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">

--- a/conf/log4j2.otel-json.xml
+++ b/conf/log4j2.otel-json.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Example log4j2 configuration that emits each log event as a single JSON
+    object aligned with the OpenTelemetry log data model
+    (https://opentelemetry.io/docs/specs/otel/logs/data-model/).
+
+    The structured attributes set via slog ".attr(...)" calls are written to
+    Log4j2's ContextData and surface here under the "attributes" field.
+
+    Required runtime dependency (NOT included by default in BookKeeper):
+        org.apache.logging.log4j:log4j-layout-template-json:${log4j.version}
+
+    Add it to the classpath alongside log4j-core to enable JsonTemplateLayout.
+
+    The event template lives in conf/otel-log-template.json. Customize it
+    there (e.g. add resource attributes, drop fields, rename keys) without
+    touching this file.
+
+    Notes on the OTel mapping:
+      * "severity_text"       = log4j level name ("INFO", "WARN", ...).
+      * "severity_number"     = OTel severity number derived from the level
+                                (TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17).
+      * "body"                = the log message string.
+      * "trace_id"/"span_id"  = MDC keys conventionally set by the OpenTelemetry
+                                log appender bridge; omitted when absent.
+      * "attributes"          = the full ContextData map (slog attrs + any
+                                other entries placed in Log4j2 ThreadContext
+                                or SLF4J MDC).
+      * "resource"            = static attributes about the producer; populate
+                                via OTEL_SERVICE_NAME / HOSTNAME env vars.
+-->
+<Configuration status="warn" monitorInterval="10">
+    <Properties>
+        <Property name="bookkeeper.log.dir">.</Property>
+        <Property name="bookkeeper.log.file">bookkeeper-server.json.log</Property>
+        <Property name="bookkeeper.log.root.level">INFO</Property>
+        <Property name="bookkeeper.log.root.appender">CONSOLE</Property>
+        <Property name="otel.template">file:${sys:bookkeeper.conf.dir:-conf}/otel-log-template.json</Property>
+        <Property name="otel.service.name">${env:OTEL_SERVICE_NAME:-bookkeeper}</Property>
+        <Property name="otel.host.name">${env:HOSTNAME:-unknown}</Property>
+    </Properties>
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <JsonTemplateLayout eventTemplateUri="${otel.template}"/>
+        </Console>
+        <RollingFile name="ROLLINGFILE"
+                     fileName="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}"
+                     filePattern="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}%d{.yyyy-MM-dd}">
+            <!--
+                Each line is an independent JSON object (ndjson), directly
+                consumable by log shippers (FluentBit, Vector, Fluentd,
+                Promtail, otel-collector, ...).
+            -->
+            <JsonTemplateLayout eventTemplateUri="${otel.template}"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy modulate="true"/>
+            </Policies>
+            <DefaultRolloverStrategy max="100"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="${sys:bookkeeper.log.root.level}">
+            <AppenderRef ref="${sys:bookkeeper.log.root.appender}"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/conf/log4j2.shell.xml
+++ b/conf/log4j2.shell.xml
@@ -31,7 +31,7 @@
             <PatternLayout pattern="%d{ABSOLUTE} %-5p %m%n"/>
         </Console>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}" filePattern="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/log4j2.shell.xml
+++ b/conf/log4j2.shell.xml
@@ -31,7 +31,7 @@
             <PatternLayout pattern="%d{ABSOLUTE} %-5p %m%n"/>
         </Console>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}" filePattern="${sys:bookkeeper.shell.log.dir}/${sys:bookkeeper.shell.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -27,26 +27,20 @@
         <Property name="bookkeeper.log.root.appender">CONSOLE</Property>
     </Properties>
     <Appenders>
+        <!--
+            The "%X" pattern element renders the structured attributes attached
+            to each log event (slog ".attr(...)" calls and any java.util.MDC /
+            Log4j2 ThreadContext entries). It is rendered as "{key=value, ...}".
+            Drop or replace it with named keys (e.g. %X{ledgerId}) for a more
+            specific format.
+        -->
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
-        </Console>
-        <Console name="CONSOLEMDC" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:bookkeeper.log.dir}/bookkeeper-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
-        </File>
-        <File name="TRACEFILEMDC" fileName="${sys:bookkeeper.log.dir}/bookkeeper-trace.log">
             <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}" filePattern="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
-            <Policies>
-                <TimeBasedTriggeringPolicy modulate="true"/>
-            </Policies>
-            <DefaultRolloverStrategy max="100"/>
-        </RollingFile>
-        <RollingFile name="ROLLINGFILEMDC" fileName="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}" filePattern="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}%d{.yyyy-MM-dd}">
             <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
@@ -58,8 +52,5 @@
         <Root level="${sys:bookkeeper.log.root.level}">
             <AppenderRef ref="${sys:bookkeeper.log.root.appender}"/>
         </Root>
-        <Logger name="org.apache.bookkeeper.bookie.storage.directentrylogger" level="INFO">
-                <AppenderRef ref="${sys:bookkeeper.log.root.appender}MDC"/>
-        </Logger>
     </Loggers>
 </Configuration>

--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -35,13 +35,13 @@
             specific format.
         -->
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:bookkeeper.log.dir}/bookkeeper-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m %X%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}" filePattern="${sys:bookkeeper.log.dir}/${sys:bookkeeper.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/conf/otel-log-template.json
+++ b/conf/otel-log-template.json
@@ -1,0 +1,37 @@
+{
+  "timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {"format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "timeZone": "UTC"}
+  },
+  "observed_timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {"format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "timeZone": "UTC"}
+  },
+  "severity_text": {"$resolver": "level", "field": "name"},
+  "severity_number": {
+    "$resolver": "pattern",
+    "pattern": "%level{TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17, FATAL=21}"
+  },
+  "body": {"$resolver": "message", "stringified": true},
+  "trace_id": {"$resolver": "mdc", "key": "trace_id"},
+  "span_id": {"$resolver": "mdc", "key": "span_id"},
+  "trace_flags": {"$resolver": "mdc", "key": "trace_flags"},
+  "instrumentation_scope": {
+    "name": {"$resolver": "logger", "field": "name"}
+  },
+  "resource": {
+    "service.name": "${otel.service.name}",
+    "host.name": "${otel.host.name}"
+  },
+  "attributes": {"$resolver": "mdc", "flatten": true},
+  "thread_name": {"$resolver": "thread", "field": "name"},
+  "exception": {
+    "type": {"$resolver": "exception", "field": "className"},
+    "message": {"$resolver": "exception", "field": "message"},
+    "stack_trace": {
+      "$resolver": "exception",
+      "field": "stackTrace",
+      "stackTrace": {"stringified": true}
+    }
+  }
+}

--- a/conf/otel-log-template.json
+++ b/conf/otel-log-template.json
@@ -1,37 +1,63 @@
 {
-  "timestamp": {
+  "Timestamp": {
     "$resolver": "timestamp",
-    "pattern": {"format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "timeZone": "UTC"}
+    "pattern": {
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "timeZone": "UTC"
+    }
   },
-  "observed_timestamp": {
-    "$resolver": "timestamp",
-    "pattern": {"format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "timeZone": "UTC"}
+  "SeverityText": {
+    "$resolver": "level",
+    "field": "name"
   },
-  "severity_text": {"$resolver": "level", "field": "name"},
-  "severity_number": {
-    "$resolver": "pattern",
-    "pattern": "%level{TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17, FATAL=21}"
+  "Body": {
+    "$resolver": "message",
+    "stringified": true
   },
-  "body": {"$resolver": "message", "stringified": true},
-  "trace_id": {"$resolver": "mdc", "key": "trace_id"},
-  "span_id": {"$resolver": "mdc", "key": "span_id"},
-  "trace_flags": {"$resolver": "mdc", "key": "trace_flags"},
-  "instrumentation_scope": {
-    "name": {"$resolver": "logger", "field": "name"}
+  "TraceId": {
+    "$resolver": "mdc",
+    "key": "trace_id"
   },
-  "resource": {
-    "service.name": "${otel.service.name}",
-    "host.name": "${otel.host.name}"
+  "SpanId": {
+    "$resolver": "mdc",
+    "key": "span_id"
   },
-  "attributes": {"$resolver": "mdc", "flatten": true},
-  "thread_name": {"$resolver": "thread", "field": "name"},
-  "exception": {
-    "type": {"$resolver": "exception", "field": "className"},
-    "message": {"$resolver": "exception", "field": "message"},
-    "stack_trace": {
+  "TraceFlags": {
+    "$resolver": "mdc",
+    "key": "trace_flags"
+  },
+  "Attributes": {
+    "thread.name": {
+      "$resolver": "thread",
+      "field": "name"
+    },
+    "thread.id": {
+      "$resolver": "thread",
+      "field": "id"
+    },
+    "code.namespace": {
+      "$resolver": "logger",
+      "field": "name"
+    },
+    "exception.type": {
+      "$resolver": "exception",
+      "field": "className"
+    },
+    "exception.message": {
+      "$resolver": "exception",
+      "field": "message"
+    },
+    "exception.stacktrace": {
       "$resolver": "exception",
       "field": "stackTrace",
-      "stackTrace": {"stringified": true}
+      "stackTrace": {
+        "stringified": true
+      }
+    },
+    "mdc": {
+      "$resolver": "mdc",
+      "flatten": true,
+      "stringified": true
     }
   }
 }

--- a/stream/conf/log4j2.cli.xml
+++ b/stream/conf/log4j2.cli.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/stream/conf/log4j2.cli.xml
+++ b/stream/conf/log4j2.cli.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m %X%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/stream/conf/log4j2.xml
+++ b/stream/conf/log4j2.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>

--- a/stream/conf/log4j2.xml
+++ b/stream/conf/log4j2.xml
@@ -28,13 +28,13 @@
     </Properties>
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m %X%n"/>
         </Console>
         <File name="TRACEFILE" fileName="${sys:streamstorage.log.dir}/streamstorage-trace.log">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L][%ndc] - %m %X%n"/>
         </File>
         <RollingFile name="ROLLINGFILE" fileName="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}" filePattern="${sys:streamstorage.log.dir}/${sys:streamstorage.log.file}%d{.yyyy-MM-dd}">
-            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] %X - %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m %X%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy modulate="true"/>
             </Policies>


### PR DESCRIPTION
## Summary

- Slog attributes are forwarded to log4j2 as ContextData (the same channel SLF4J's MDC uses). Add `%X` to every PatternLayout in the user-facing log4j2 configs (`conf/`, `bookkeeper-server/src/main/resources/`, `stream/conf/`, `bookkeeper-benchmark/conf/`) so that the structured attrs attached via `.attr(...)` show up in log output by default.
- Drop the now-redundant `*MDC` variant appenders in `conf/log4j2.xml` and the `directentrylogger` override that targeted them — every appender renders the context map now.
- Add `conf/log4j2.otel-json.xml` plus `conf/otel-log-template.json` as an example layout that emits each event as a single JSON object aligned with the [OpenTelemetry log data model](https://opentelemetry.io/docs/specs/otel/logs/data-model/): `timestamp`, `severity_text`, `severity_number`, `body`, `instrumentation_scope.name`, `resource.{service.name,host.name}`, `attributes` (the full ContextData map), `trace_id`/`span_id`/`trace_flags` from MDC, plus `exception.{type,message,stack_trace}`.
- The OTel example uses `JsonTemplateLayout`, which requires `org.apache.logging.log4j:log4j-layout-template-json` on the classpath at runtime (not bundled by default — the example header notes this).

## Test plan

- [x] `xmllint --noout` validates every modified XML config.
- [x] `python3 -m json.tool` validates `conf/otel-log-template.json`.
- [ ] Confirm via existing test runs that the log4j2 configuration still loads cleanly.