### PR TITLE
[feat][bk] Add per-read no-read-ahead hint

### DIFF
--- a/bookkeeper-proto/src/main/proto/BookkeeperProtocol.proto
+++ b/bookkeeper-proto/src/main/proto/BookkeeperProtocol.proto
@@ -115,6 +115,8 @@ message ReadRequest {
     optional int64 previousLAC = 4;
     // Used as a timeout (in milliseconds) for the long polling request
     optional int64 timeOut = 5;
+    // Bitmask of additional read flags from BookieProtocol.FLAG_*.
+    optional int32 readFlags = 6;
 }
 
 message AddRequest {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Bookie.java
@@ -57,6 +57,12 @@ public interface Bookie {
     // TODO: Shouldn't this be async?
     ByteBuf readEntry(long ledgerId, long entryId)
             throws IOException, NoLedgerException, BookieException;
+
+    default ByteBuf readEntry(long ledgerId, long entryId, boolean noReadAhead)
+            throws IOException, NoLedgerException, BookieException {
+        return readEntry(ledgerId, entryId);
+    }
+
     long readLastAddConfirmed(long ledgerId) throws IOException, BookieException;
     PrimitiveIterator.OfLong getListOfEntriesOfLedger(long ledgerId) throws IOException, NoLedgerException;
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -1158,6 +1158,12 @@ public class BookieImpl implements Bookie {
 
     public ByteBuf readEntry(long ledgerId, long entryId)
             throws IOException, NoLedgerException, BookieException {
+        return readEntry(ledgerId, entryId, false);
+    }
+
+    @Override
+    public ByteBuf readEntry(long ledgerId, long entryId, boolean noReadAhead)
+            throws IOException, NoLedgerException, BookieException {
         long requestNanos = MathUtils.nowInNano();
         boolean success = false;
         int entrySize = 0;
@@ -1167,7 +1173,7 @@ public class BookieImpl implements Bookie {
                     .attr("entryId", entryId)
                     .attr("ledgerId", ledgerId)
                     .log("Reading entry");
-            ByteBuf entry = handle.readEntry(entryId);
+            ByteBuf entry = handle.readEntry(entryId, noReadAhead);
             entrySize = entry.readableBytes();
             bookieStats.getReadBytes().addCount(entrySize);
             success = true;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptor.java
@@ -78,6 +78,10 @@ public abstract class LedgerDescriptor {
     abstract long addEntry(ByteBuf entry) throws IOException, BookieException;
     abstract ByteBuf readEntry(long entryId) throws IOException, BookieException;
 
+    ByteBuf readEntry(long entryId, boolean noReadAhead) throws IOException, BookieException {
+        return readEntry(entryId);
+    }
+
     abstract long getLastAddConfirmed() throws IOException, BookieException;
     abstract boolean waitForLastAddConfirmedUpdate(long previousLAC,
                                                    Watcher<LastAddConfirmedUpdateNotification> watcher)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerDescriptorImpl.java
@@ -163,6 +163,11 @@ public class LedgerDescriptorImpl extends LedgerDescriptor {
     }
 
     @Override
+    ByteBuf readEntry(long entryId, boolean noReadAhead) throws IOException, BookieException {
+        return ledgerStorage.getEntry(ledgerId, entryId, noReadAhead);
+    }
+
+    @Override
     long getLastAddConfirmed() throws IOException, BookieException {
         return ledgerStorage.getLastAddConfirmed(ledgerId);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -145,6 +145,15 @@ public interface LedgerStorage {
     ByteBuf getEntry(long ledgerId, long entryId) throws IOException, BookieException;
 
     /**
+     * Read an entry from storage with options that apply to this request.
+     *
+     * @param noReadAhead whether this request should avoid triggering read-ahead
+     */
+    default ByteBuf getEntry(long ledgerId, long entryId, boolean noReadAhead) throws IOException, BookieException {
+        return getEntry(ledgerId, entryId);
+    }
+
+    /**
      * Get last add confirmed.
      *
      * @param ledgerId ledger id.

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -362,6 +362,11 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
+    public ByteBuf getEntry(long ledgerId, long entryId, boolean noReadAhead) throws IOException, BookieException {
+        return getLedgerStorage(ledgerId).getEntry(ledgerId, entryId, noReadAhead);
+    }
+
+    @Override
     public long getLastAddConfirmed(long ledgerId) throws IOException, BookieException {
         return getLedgerStorage(ledgerId).getLastAddConfirmed(ledgerId);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -568,9 +568,14 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
     @Override
     public ByteBuf getEntry(long ledgerId, long entryId) throws IOException, BookieException {
+        return getEntry(ledgerId, entryId, false);
+    }
+
+    @Override
+    public ByteBuf getEntry(long ledgerId, long entryId, boolean noReadAhead) throws IOException, BookieException {
         long startTime = MathUtils.nowInNano();
         try {
-            ByteBuf entry = doGetEntry(ledgerId, entryId);
+            ByteBuf entry = doGetEntry(ledgerId, entryId, noReadAhead);
             recordSuccessfulEvent(dbLedgerStorageStats.getReadEntryStats(), startTime);
             return entry;
         } catch (IOException e) {
@@ -579,7 +584,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         }
     }
 
-    private ByteBuf doGetEntry(long ledgerId, long entryId) throws IOException, BookieException {
+    private ByteBuf doGetEntry(long ledgerId, long entryId, boolean noReadAhead) throws IOException, BookieException {
         log.debug()
                 .attr("ledgerId", ledgerId)
                 .attr("entryId", entryId)
@@ -658,8 +663,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         readCache.put(ledgerId, entryId, entry);
 
         // Try to read more entries
-        long nextEntryLocation = entryLocation + 4 /* size header */ + entry.readableBytes();
-        fillReadAheadCache(ledgerId, entryId + 1, nextEntryLocation);
+        if (!noReadAhead) {
+            long nextEntryLocation = entryLocation + 4 /* size header */ + entry.readableBytes();
+            fillReadAheadCache(ledgerId, entryId + 1, nextEntryLocation);
+        }
 
         return entry;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -72,6 +72,7 @@ import org.apache.bookkeeper.client.api.BKException.Code;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.client.api.ReadOptions;
 import org.apache.bookkeeper.client.api.WriteFlag;
 import org.apache.bookkeeper.client.api.WriteHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
@@ -638,9 +639,26 @@ public class LedgerHandle implements WriteHandle {
      */
     public Enumeration<LedgerEntry> readEntries(long firstEntry, long lastEntry)
             throws InterruptedException, BKException {
+        return readEntries(firstEntry, lastEntry, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries synchronously with options that apply to this request.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence (included)
+     * @param lastEntry
+     *          id of last entry of sequence (included)
+     * @param options
+     *          options for this read request
+     *
+     * @see #asyncReadEntries(long, long, ReadCallback, Object, ReadOptions)
+     */
+    public Enumeration<LedgerEntry> readEntries(long firstEntry, long lastEntry, ReadOptions options)
+            throws InterruptedException, BKException {
         CompletableFuture<Enumeration<LedgerEntry>> result = new CompletableFuture<>();
 
-        asyncReadEntries(firstEntry, lastEntry, new SyncReadCallback(result), null);
+        asyncReadEntries(firstEntry, lastEntry, new SyncReadCallback(result), null, options);
 
         return SyncCallbackUtils.waitForResult(result);
     }
@@ -681,9 +699,29 @@ public class LedgerHandle implements WriteHandle {
      */
     public Enumeration<LedgerEntry> readUnconfirmedEntries(long firstEntry, long lastEntry)
             throws InterruptedException, BKException {
+        return readUnconfirmedEntries(firstEntry, lastEntry, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries synchronously with options that apply to this request, allowing to read after the
+     * LastAddConfirmed range.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence (included)
+     * @param lastEntry
+     *          id of last entry of sequence (included)
+     * @param options
+     *          options for this read request
+     *
+     * @see #readEntries(long, long, ReadOptions)
+     * @see #asyncReadUnconfirmedEntries(long, long, ReadCallback, java.lang.Object, ReadOptions)
+     * @see #asyncReadLastConfirmed(ReadLastConfirmedCallback, java.lang.Object)
+     */
+    public Enumeration<LedgerEntry> readUnconfirmedEntries(long firstEntry, long lastEntry, ReadOptions options)
+            throws InterruptedException, BKException {
         CompletableFuture<Enumeration<LedgerEntry>> result = new CompletableFuture<>();
 
-        asyncReadUnconfirmedEntries(firstEntry, lastEntry, new SyncReadCallback(result), null);
+        asyncReadUnconfirmedEntries(firstEntry, lastEntry, new SyncReadCallback(result), null, options);
 
         return SyncCallbackUtils.waitForResult(result);
     }
@@ -722,6 +760,24 @@ public class LedgerHandle implements WriteHandle {
      *          control object
      */
     public void asyncReadEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
+        asyncReadEntries(firstEntry, lastEntry, cb, ctx, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries asynchronously with options that apply to this request.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence
+     * @param cb
+     *          object implementing read callback interface
+     * @param ctx
+     *          control object
+     * @param options
+     *          options for this read request
+     */
+    public void asyncReadEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx, ReadOptions options) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             log.error()
@@ -742,7 +798,7 @@ public class LedgerHandle implements WriteHandle {
             return;
         }
 
-        asyncReadEntriesInternal(firstEntry, lastEntry, cb, ctx, false);
+        asyncReadEntriesInternal(firstEntry, lastEntry, cb, ctx, false, options);
     }
 
     /**
@@ -819,6 +875,30 @@ public class LedgerHandle implements WriteHandle {
      * @see #readUnconfirmedEntries(long, long)
      */
     public void asyncReadUnconfirmedEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx) {
+        asyncReadUnconfirmedEntries(firstEntry, lastEntry, cb, ctx, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries asynchronously with options that apply to this request, allowing to read after the
+     * LastAddConfirmed range.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence
+     * @param cb
+     *          object implementing read callback interface
+     * @param ctx
+     *          control object
+     * @param options
+     *          options for this read request
+     *
+     * @see #asyncReadEntries(long, long, ReadCallback, Object, ReadOptions)
+     * @see #asyncReadLastConfirmed(ReadLastConfirmedCallback, Object)
+     * @see #readUnconfirmedEntries(long, long, ReadOptions)
+     */
+    public void asyncReadUnconfirmedEntries(long firstEntry, long lastEntry, ReadCallback cb, Object ctx,
+                                            ReadOptions options) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             log.error()
@@ -829,7 +909,7 @@ public class LedgerHandle implements WriteHandle {
             return;
         }
 
-        asyncReadEntriesInternal(firstEntry, lastEntry, cb, ctx, false);
+        asyncReadEntriesInternal(firstEntry, lastEntry, cb, ctx, false, options);
     }
 
     /**
@@ -886,6 +966,21 @@ public class LedgerHandle implements WriteHandle {
      */
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
+        return readAsync(firstEntry, lastEntry, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries asynchronously with options that apply to this request.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence
+     * @param options
+     *          options for this read request
+     */
+    @Override
+    public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry, ReadOptions options) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             log.error()
@@ -904,7 +999,7 @@ public class LedgerHandle implements WriteHandle {
             return FutureUtils.exception(new BKReadException());
         }
 
-        return readEntriesInternalAsync(firstEntry, lastEntry, false);
+        return readEntriesInternalAsync(firstEntry, lastEntry, false, options);
     }
 
     /**
@@ -973,6 +1068,10 @@ public class LedgerHandle implements WriteHandle {
         }
         LedgerMetadata ledgerMetadata = getLedgerMetadata();
         return ledgerMetadata.getEnsembleSize() != ledgerMetadata.getWriteQuorumSize();
+    }
+
+    private static ReadOptions readOptionsOrDefault(ReadOptions options) {
+        return options == null ? ReadOptions.DEFAULT : options;
     }
 
     private CompletableFuture<LedgerEntries> batchReadEntriesInternalAsync(long startEntry, int maxCount, long maxSize,
@@ -1059,6 +1158,27 @@ public class LedgerHandle implements WriteHandle {
      */
     @Override
     public CompletableFuture<LedgerEntries> readUnconfirmedAsync(long firstEntry, long lastEntry) {
+        return readUnconfirmedAsync(firstEntry, lastEntry, ReadOptions.DEFAULT);
+    }
+
+    /**
+     * Read a sequence of entries asynchronously with options that apply to this request, allowing to read after the
+     * LastAddConfirmed range.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence
+     * @param options
+     *          options for this read request
+     *
+     * @see #asyncReadEntries(long, long, ReadCallback, Object, ReadOptions)
+     * @see #asyncReadLastConfirmed(ReadLastConfirmedCallback, Object)
+     * @see #readUnconfirmedEntries(long, long, ReadOptions)
+     */
+    @Override
+    public CompletableFuture<LedgerEntries> readUnconfirmedAsync(long firstEntry, long lastEntry,
+                                                                 ReadOptions options) {
         // Little sanity check
         if (firstEntry < 0 || firstEntry > lastEntry) {
             log.error()
@@ -1068,13 +1188,18 @@ public class LedgerHandle implements WriteHandle {
             return FutureUtils.exception(new BKIncorrectParameterException());
         }
 
-        return readEntriesInternalAsync(firstEntry, lastEntry, false);
+        return readEntriesInternalAsync(firstEntry, lastEntry, false, options);
     }
 
     void asyncReadEntriesInternal(long firstEntry, long lastEntry, ReadCallback cb,
                                   Object ctx, boolean isRecoveryRead) {
+        asyncReadEntriesInternal(firstEntry, lastEntry, cb, ctx, isRecoveryRead, ReadOptions.DEFAULT);
+    }
+
+    void asyncReadEntriesInternal(long firstEntry, long lastEntry, ReadCallback cb,
+                                  Object ctx, boolean isRecoveryRead, ReadOptions options) {
         if (!clientCtx.isClientClosed()) {
-            readEntriesInternalAsync(firstEntry, lastEntry, isRecoveryRead)
+            readEntriesInternalAsync(firstEntry, lastEntry, isRecoveryRead, options)
                 .whenCompleteAsync(new FutureEventListener<LedgerEntries>() {
                     @Override
                     public void onSuccess(LedgerEntries entries) {
@@ -1174,8 +1299,15 @@ public class LedgerHandle implements WriteHandle {
     CompletableFuture<LedgerEntries> readEntriesInternalAsync(long firstEntry,
                                                               long lastEntry,
                                                               boolean isRecoveryRead) {
+        return readEntriesInternalAsync(firstEntry, lastEntry, isRecoveryRead, ReadOptions.DEFAULT);
+    }
+
+    CompletableFuture<LedgerEntries> readEntriesInternalAsync(long firstEntry,
+                                                              long lastEntry,
+                                                              boolean isRecoveryRead,
+                                                              ReadOptions options) {
         PendingReadOp op = new PendingReadOp(this, clientCtx,
-                                             firstEntry, lastEntry, isRecoveryRead);
+                                             firstEntry, lastEntry, isRecoveryRead, readOptionsOrDefault(options));
         if (!clientCtx.isClientClosed()) {
             // Waiting on the first one.
             // This is not very helpful if there are multiple ensembles or if bookie goes into unresponsive

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/PendingReadOp.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
+import org.apache.bookkeeper.client.api.ReadOptions;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.common.util.MathUtils;
@@ -47,14 +48,25 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
 
     protected boolean parallelRead = false;
     protected final LinkedList<SingleLedgerEntryRequest> seq;
+    private final ReadOptions readOptions;
 
     PendingReadOp(LedgerHandle lh,
                   ClientContext clientCtx,
                   long startEntryId,
                   long endEntryId,
                   boolean isRecoveryRead) {
+        this(lh, clientCtx, startEntryId, endEntryId, isRecoveryRead, ReadOptions.DEFAULT);
+    }
+
+    PendingReadOp(LedgerHandle lh,
+                  ClientContext clientCtx,
+                  long startEntryId,
+                  long endEntryId,
+                  boolean isRecoveryRead,
+                  ReadOptions readOptions) {
         super(lh, clientCtx, startEntryId, endEntryId, isRecoveryRead);
         this.seq = new LinkedList<>();
+        this.readOptions = readOptions;
         numPendingEntries = endEntryId - startEntryId + 1;
     }
 
@@ -178,13 +190,19 @@ class PendingReadOp extends ReadOpBase implements ReadEntryCallback  {
             lh.throttler.acquire();
         }
 
+        int flags = isRecoveryRead
+                ? BookieProtocol.FLAG_HIGH_PRIORITY | BookieProtocol.FLAG_DO_FENCING
+                : BookieProtocol.FLAG_NONE;
+        if (readOptions.isReadAheadDisabled()) {
+            flags |= BookieProtocol.FLAG_NO_READ_AHEAD;
+        }
+
         if (isRecoveryRead) {
-            int flags = BookieProtocol.FLAG_HIGH_PRIORITY | BookieProtocol.FLAG_DO_FENCING;
             clientCtx.getBookieClient().readEntry(to, lh.ledgerId, entry.eId,
                     this, new ReadContext(bookieIndex, to, entry), flags, lh.ledgerKey);
         } else {
             clientCtx.getBookieClient().readEntry(to, lh.ledgerId, entry.eId,
-                    this, new ReadContext(bookieIndex, to, entry), BookieProtocol.FLAG_NONE);
+                    this, new ReadContext(bookieIndex, to, entry), flags);
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadHandle.java
@@ -46,6 +46,21 @@ public interface ReadHandle extends Handle {
     CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry);
 
     /**
+     * Read a sequence of entries asynchronously with options that apply to this request.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence, inclusive
+     * @param options
+     *          options for this read request
+     * @return an handle to the result of the operation
+     */
+    default CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry, ReadOptions options) {
+        return readAsync(firstEntry, lastEntry);
+    }
+
+    /**
      * Read a sequence of entries asynchronously.
      *
      * @param startEntry
@@ -73,6 +88,23 @@ public interface ReadHandle extends Handle {
      */
     default LedgerEntries read(long firstEntry, long lastEntry) throws BKException, InterruptedException {
         return FutureUtils.<LedgerEntries, BKException>result(readAsync(firstEntry, lastEntry),
+                                                              BKException.HANDLER);
+    }
+
+    /**
+     * Read a sequence of entries synchronously with options that apply to this request.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence, inclusive
+     * @param options
+     *          options for this read request
+     * @return the result of the operation
+     */
+    default LedgerEntries read(long firstEntry, long lastEntry, ReadOptions options)
+            throws BKException, InterruptedException {
+        return FutureUtils.<LedgerEntries, BKException>result(readAsync(firstEntry, lastEntry, options),
                                                               BKException.HANDLER);
     }
 
@@ -117,6 +149,23 @@ public interface ReadHandle extends Handle {
     CompletableFuture<LedgerEntries> readUnconfirmedAsync(long firstEntry, long lastEntry);
 
     /**
+     * Read a sequence of entries asynchronously with options that apply to this request, allowing to read after the
+     * LastAddConfirmed range.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence, inclusive
+     * @param options
+     *          options for this read request
+     * @return an handle to the result of the operation
+     */
+    default CompletableFuture<LedgerEntries> readUnconfirmedAsync(long firstEntry, long lastEntry,
+                                                                  ReadOptions options) {
+        return readUnconfirmedAsync(firstEntry, lastEntry);
+    }
+
+    /**
      * Read a sequence of entries synchronously.
      *
      * @param firstEntry
@@ -130,6 +179,26 @@ public interface ReadHandle extends Handle {
     default LedgerEntries readUnconfirmed(long firstEntry, long lastEntry)
             throws BKException, InterruptedException {
         return FutureUtils.<LedgerEntries, BKException>result(readUnconfirmedAsync(firstEntry, lastEntry),
+                                                              BKException.HANDLER);
+    }
+
+    /**
+     * Read a sequence of entries synchronously with options that apply to this request, allowing to read after the
+     * LastAddConfirmed range.
+     *
+     * @param firstEntry
+     *          id of first entry of sequence
+     * @param lastEntry
+     *          id of last entry of sequence, inclusive
+     * @param options
+     *          options for this read request
+     * @return an handle to the result of the operation
+     *
+     * @see #readUnconfirmedAsync(long, long, ReadOptions)
+     */
+    default LedgerEntries readUnconfirmed(long firstEntry, long lastEntry, ReadOptions options)
+            throws BKException, InterruptedException {
+        return FutureUtils.<LedgerEntries, BKException>result(readUnconfirmedAsync(firstEntry, lastEntry, options),
                                                               BKException.HANDLER);
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadOptions.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/ReadOptions.java
@@ -1,0 +1,72 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client.api;
+
+import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
+import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
+
+/**
+ * Options that apply to a single read request.
+ */
+@Public
+@Unstable
+public final class ReadOptions {
+
+    /**
+     * Default read options. Read-ahead behavior is unchanged.
+     */
+    public static final ReadOptions DEFAULT = builder().build();
+
+    private final boolean disableReadAhead;
+
+    private ReadOptions(boolean disableReadAhead) {
+        this.disableReadAhead = disableReadAhead;
+    }
+
+    /**
+     * Whether this read should avoid triggering bookie-side read-ahead on cache miss.
+     *
+     * <p>This option does not bypass existing cache entries.
+     */
+    public boolean isReadAheadDisabled() {
+        return disableReadAhead;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private boolean disableReadAhead;
+
+        private Builder() {
+        }
+
+        public Builder disableReadAhead(boolean disableReadAhead) {
+            this.disableReadAhead = disableReadAhead;
+            return this;
+        }
+
+        public ReadOptions build() {
+            return new ReadOptions(disableReadAhead);
+        }
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessor.java
@@ -59,7 +59,8 @@ public class BatchedReadEntryProcessor extends ReadEntryProcessor {
         long frameSize = 24 + 8 + 4;
         for (int i = 0; i < maxCount; i++) {
             try {
-                ByteBuf entry = requestProcessor.getBookie().readEntry(request.getLedgerId(), request.getEntryId() + i);
+                ByteBuf entry = requestProcessor.getBookie().readEntry(request.getLedgerId(), request.getEntryId() + i,
+                        request.isNoReadAhead());
                 frameSize += entry.readableBytes() + 4;
                 if (data == null) {
                     data = ByteBufList.get(entry);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtocol.java
@@ -190,6 +190,7 @@ public interface BookieProtocol {
     short FLAG_DO_FENCING = 0x0001;
     short FLAG_RECOVERY_ADD = 0x0002;
     short FLAG_HIGH_PRIORITY = 0x0004;
+    short FLAG_NO_READ_AHEAD = 0x0008;
 
     /**
      * A Bookie request object.
@@ -243,6 +244,10 @@ public interface BookieProtocol {
 
         boolean isHighPriority() {
             return (flags & FLAG_HIGH_PRIORITY) == FLAG_HIGH_PRIORITY;
+        }
+
+        boolean isNoReadAhead() {
+            return (flags & FLAG_NO_READ_AHEAD) == FLAG_NO_READ_AHEAD;
         }
 
         @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/PerChannelBookieClient.java
@@ -964,6 +964,10 @@ public class PerChannelBookieClient extends ChannelInboundHandlerAdapter {
                     .setLedgerId(ledgerId)
                     .setEntryId(entryId);
 
+            if (((short) flags & BookieProtocol.FLAG_NO_READ_AHEAD) == BookieProtocol.FLAG_NO_READ_AHEAD) {
+                readBuilder = readBuilder.setReadFlags(BookieProtocol.FLAG_NO_READ_AHEAD);
+            }
+
             if (null != previousLAC) {
                 readBuilder = readBuilder.setPreviousLAC(previousLAC);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -137,7 +137,8 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
     }
 
     protected ReferenceCounted readData() throws Exception {
-        return requestProcessor.getBookie().readEntry(request.getLedgerId(), request.getEntryId());
+        return requestProcessor.getBookie().readEntry(request.getLedgerId(), request.getEntryId(),
+                request.isNoReadAhead());
     }
 
     private void sendResponse(ReferenceCounted data, int errorCode, long startTimeNanos) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -174,7 +174,8 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                                      boolean readLACPiggyBack,
                                      Stopwatch startTimeSw)
         throws IOException, BookieException {
-        ByteBuf entryBody = requestProcessor.getBookie().readEntry(ledgerId, entryId);
+        ByteBuf entryBody = requestProcessor.getBookie().readEntry(ledgerId, entryId,
+                RequestUtils.isNoReadAhead(readRequest));
         if (null != fenceResult) {
             handleReadResultForFenceRead(entryBody, readResponseBuilder, entryId, startTimeSw);
             return null;
@@ -382,4 +383,3 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
         return RequestUtils.toSafeString(request);
     }
 }
-

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/RequestUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/RequestUtils.java
@@ -40,6 +40,12 @@ class RequestUtils {
         return hasFlag(readRequest, BookkeeperProtocol.ReadRequest.Flag.ENTRY_PIGGYBACK);
     }
 
+    public static boolean isNoReadAhead(BookkeeperProtocol.ReadRequest readRequest) {
+        return readRequest.hasReadFlags()
+                && (readRequest.getReadFlags() & BookieProtocol.FLAG_NO_READ_AHEAD)
+                == BookieProtocol.FLAG_NO_READ_AHEAD;
+    }
+
     static boolean hasFlag(BookkeeperProtocol.ReadRequest request, BookkeeperProtocol.ReadRequest.Flag flag) {
         return request.hasFlag() && request.getFlag() == flag;
     }
@@ -75,6 +81,9 @@ class RequestUtils {
             stringHelper.add("entryId", readRequest.getEntryId());
             if (readRequest.hasFlag()) {
                 stringHelper.add("flag", readRequest.getFlag());
+            }
+            if (readRequest.hasReadFlags()) {
+                stringHelper.add("readFlags", readRequest.getReadFlags());
             }
             if (readRequest.hasPreviousLAC()) {
                 stringHelper.add("previousLAC", readRequest.getPreviousLAC());

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageReadCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageReadCacheTest.java
@@ -48,6 +48,78 @@ public class DbLedgerStorageReadCacheTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(DbLedgerStorageReadCacheTest.class);
 
     @Test
+    public void readMissTriggersReadAheadByDefault() throws Exception {
+        TestDB testDB = new TestDB();
+        try {
+            setup(testDB, 16L, 8, -1);
+            addEntries(testDB.getStorage(), 0, 1, 0, 4);
+            testDB.getStorage().flush();
+
+            SingleDirectoryDbLedgerStorage sdb = testDB.getStorage().getLedgerStorageList().get(0);
+            DbLedgerStorageStats stats = sdb.getDbLedgerStorageStats();
+            long missesBefore = stats.getReadCacheMissCounter().get();
+            long hitsBefore = stats.getReadCacheHitCounter().get();
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 0), 0, 0);
+            assertEquals(missesBefore + 1, stats.getReadCacheMissCounter().get().longValue());
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 1), 0, 1);
+            assertEquals(missesBefore + 1, stats.getReadCacheMissCounter().get().longValue());
+            assertEquals(hitsBefore + 1, stats.getReadCacheHitCounter().get().longValue());
+        } finally {
+            teardown(testDB.getStorage(), testDB.getTmpDir());
+        }
+    }
+
+    @Test
+    public void noReadAheadReadMissDoesNotPrefillFollowingEntries() throws Exception {
+        TestDB testDB = new TestDB();
+        try {
+            setup(testDB, 16L, 8, -1);
+            addEntries(testDB.getStorage(), 0, 1, 0, 4);
+            testDB.getStorage().flush();
+
+            SingleDirectoryDbLedgerStorage sdb = testDB.getStorage().getLedgerStorageList().get(0);
+            DbLedgerStorageStats stats = sdb.getDbLedgerStorageStats();
+            long missesBefore = stats.getReadCacheMissCounter().get();
+            long hitsBefore = stats.getReadCacheHitCounter().get();
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 0, true), 0, 0);
+            assertEquals(missesBefore + 1, stats.getReadCacheMissCounter().get().longValue());
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 1), 0, 1);
+            assertEquals(missesBefore + 2, stats.getReadCacheMissCounter().get().longValue());
+            assertEquals(hitsBefore, stats.getReadCacheHitCounter().get().longValue());
+        } finally {
+            teardown(testDB.getStorage(), testDB.getTmpDir());
+        }
+    }
+
+    @Test
+    public void noReadAheadStillUsesCachedTargetEntry() throws Exception {
+        TestDB testDB = new TestDB();
+        try {
+            setup(testDB, 16L, 8, -1);
+            addEntries(testDB.getStorage(), 0, 1, 0, 4);
+            testDB.getStorage().flush();
+
+            SingleDirectoryDbLedgerStorage sdb = testDB.getStorage().getLedgerStorageList().get(0);
+            DbLedgerStorageStats stats = sdb.getDbLedgerStorageStats();
+            long missesBefore = stats.getReadCacheMissCounter().get();
+            long hitsBefore = stats.getReadCacheHitCounter().get();
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 0, true), 0, 0);
+            assertEquals(missesBefore + 1, stats.getReadCacheMissCounter().get().longValue());
+
+            assertAndReleaseEntry(testDB.getStorage().getEntry(0, 0, true), 0, 0);
+            assertEquals(missesBefore + 1, stats.getReadCacheMissCounter().get().longValue());
+            assertEquals(hitsBefore + 1, stats.getReadCacheHitCounter().get().longValue());
+        } finally {
+            teardown(testDB.getStorage(), testDB.getTmpDir());
+        }
+    }
+
+    @Test
     public void chargeReadAheadCacheRegressionTest() {
         TestDB testDB = new TestDB();
         try {
@@ -245,6 +317,15 @@ public class DbLedgerStorageReadCacheTest {
         }
         assertEquals(4 * 1024, buffer.toString().length());
         return buffer.toString();
+    }
+
+    private void assertAndReleaseEntry(ByteBuf entry, long ledgerId, long entryId) {
+        try {
+            assertEquals(ledgerId, entry.getLong(0));
+            assertEquals(entryId, entry.getLong(8));
+        } finally {
+            entry.release();
+        }
     }
 
     private CacheResult readAheadCacheBatchBytesSize() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingReadOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/PendingReadOpTest.java
@@ -1,0 +1,111 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.client.api.ReadOptions;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.BookieProtocol;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class PendingReadOpTest {
+
+    @Test
+    public void testReadOptionsDisableReadAheadSetsBookieReadFlag() throws Exception {
+        BookieClient bookieClient = mock(BookieClient.class);
+
+        newPendingReadOp(bookieClient, false, ReadOptions.builder().disableReadAhead(true).build()).initiate();
+
+        ArgumentCaptor<Integer> flags = ArgumentCaptor.forClass(Integer.class);
+        verify(bookieClient).readEntry(any(BookieId.class), anyLong(), eq(0L), any(), any(), flags.capture());
+        assertEquals(BookieProtocol.FLAG_NO_READ_AHEAD, flags.getValue() & BookieProtocol.FLAG_NO_READ_AHEAD);
+    }
+
+    @Test
+    public void testDefaultReadOptionsDoNotSetNoReadAheadFlag() throws Exception {
+        BookieClient bookieClient = mock(BookieClient.class);
+
+        newPendingReadOp(bookieClient, false, ReadOptions.DEFAULT).initiate();
+
+        ArgumentCaptor<Integer> flags = ArgumentCaptor.forClass(Integer.class);
+        verify(bookieClient).readEntry(any(BookieId.class), anyLong(), eq(0L), any(), any(), flags.capture());
+        assertEquals(0, flags.getValue() & BookieProtocol.FLAG_NO_READ_AHEAD);
+    }
+
+    @Test
+    public void testRecoveryReadPreservesExistingFlagsWithNoReadAhead() throws Exception {
+        BookieClient bookieClient = mock(BookieClient.class);
+
+        newPendingReadOp(bookieClient, true, ReadOptions.builder().disableReadAhead(true).build()).initiate();
+
+        ArgumentCaptor<Integer> flags = ArgumentCaptor.forClass(Integer.class);
+        verify(bookieClient).readEntry(any(BookieId.class), anyLong(), eq(0L), any(), any(),
+                flags.capture(), isNull());
+        assertEquals(BookieProtocol.FLAG_HIGH_PRIORITY, flags.getValue() & BookieProtocol.FLAG_HIGH_PRIORITY);
+        assertEquals(BookieProtocol.FLAG_DO_FENCING, flags.getValue() & BookieProtocol.FLAG_DO_FENCING);
+        assertEquals(BookieProtocol.FLAG_NO_READ_AHEAD, flags.getValue() & BookieProtocol.FLAG_NO_READ_AHEAD);
+    }
+
+    private static PendingReadOp newPendingReadOp(BookieClient bookieClient,
+                                                 boolean recoveryRead,
+                                                 ReadOptions readOptions) throws Exception {
+        ClientContext clientContext = mock(ClientContext.class);
+        ClientConfiguration conf = new ClientConfiguration().setReorderReadSequenceEnabled(false);
+        doReturn(ClientInternalConf.fromConfig(conf)).when(clientContext).getConf();
+        doReturn(bookieClient).when(clientContext).getBookieClient();
+
+        LedgerHandle ledgerHandle = mock(LedgerHandle.class);
+        LedgerMetadata metadata = mock(LedgerMetadata.class);
+        BookieId bookie = BookieId.parse("127.0.0.1:3181");
+        List<BookieId> ensemble = Collections.singletonList(bookie);
+        TreeMap<Long, List<BookieId>> ensembles = new TreeMap<>();
+        ensembles.put(0L, ensemble);
+        RoundRobinDistributionSchedule schedule = new RoundRobinDistributionSchedule(1, 1, 1);
+
+        doReturn(metadata).when(ledgerHandle).getLedgerMetadata();
+        doReturn(1).when(metadata).getWriteQuorumSize();
+        doReturn(1).when(metadata).getAckQuorumSize();
+        doReturn(1).when(metadata).getEnsembleSize();
+        doReturn(ensemble).when(metadata).getEnsembleAt(0L);
+        doReturn(ensembles).when(metadata).getAllEnsembles();
+        doAnswer(invocation -> schedule.getWriteSet(invocation.getArgument(0))).when(ledgerHandle)
+                .getWriteSetForReadOperation(anyLong());
+
+        return new PendingReadOp(ledgerHandle, clientContext, 0, 0, recoveryRead, readOptions)
+                .parallelRead(true);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessorTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.proto;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -87,8 +88,8 @@ public class BatchedReadEntryProcessorTest {
         ByteBuf buffer3 = ByteBufAllocator.DEFAULT.buffer(4);
         ByteBuf buffer4 = ByteBufAllocator.DEFAULT.buffer(4);
 
-        when(bookie.readEntry(anyLong(), anyLong())).thenReturn(buffer0).thenReturn(buffer1).thenReturn(buffer2)
-                .thenReturn(buffer3).thenReturn(buffer4);
+        when(bookie.readEntry(anyLong(), anyLong(), anyBoolean()))
+                .thenReturn(buffer0).thenReturn(buffer1).thenReturn(buffer2).thenReturn(buffer3).thenReturn(buffer4);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieProtoEncodingTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/BookieProtoEncodingTest.java
@@ -19,8 +19,11 @@
 package org.apache.bookkeeper.proto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_HIGH_PRIORITY;
 import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_NONE;
+import static org.apache.bookkeeper.proto.BookieProtocol.FLAG_NO_READ_AHEAD;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -131,6 +134,22 @@ public class BookieProtoEncodingTest {
 
 
         v2ReqEncoder.decode((ByteBuf) v3ReqEncoder.encode(v3Req, UnpooledByteBufAllocator.DEFAULT));
+    }
+
+    @Test
+    public void testV2ReadRequestPreservesNoReadAheadFlag() throws Exception {
+        RequestEnDeCoderPreV3 v2ReqEncoder = new RequestEnDeCoderPreV3(registry);
+        short flags = FLAG_HIGH_PRIORITY | FLAG_NO_READ_AHEAD;
+        BookieProtocol.ReadRequest req = BookieProtocol.ReadRequest.create(
+                BookieProtocol.CURRENT_PROTOCOL_VERSION, 1L, 2L, flags, null);
+        ByteBuf buf = (ByteBuf) v2ReqEncoder.encode(req, UnpooledByteBufAllocator.DEFAULT);
+        buf.readInt(); // Skip the frame size.
+
+        BookieProtocol.ReadRequest reqDecoded = (BookieProtocol.ReadRequest) v2ReqEncoder.decode(buf);
+        assertEquals(flags, reqDecoded.getFlags());
+        assertTrue(reqDecoded.isHighPriority());
+        assertTrue(reqDecoded.isNoReadAhead());
+        reqDecoded.recycle();
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/LongPollReadEntryProcessorV3Test.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.proto;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -99,7 +100,7 @@ public class LongPollReadEntryProcessorV3Test {
 
         when(bookie.waitForLastAddConfirmedUpdate(anyLong(), anyLong(), any()))
             .thenReturn(true);
-        when(bookie.readEntry(anyLong(), anyLong())).thenReturn(Unpooled.buffer());
+        when(bookie.readEntry(anyLong(), anyLong(), anyBoolean())).thenReturn(Unpooled.buffer());
         when(bookie.readLastAddConfirmed(anyLong())).thenReturn(Long.valueOf(1));
 
         CompletableFuture<Void> cancelFuture = new CompletableFuture<>();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -202,6 +202,46 @@ public class ReadEntryProcessorTest {
         assertEquals(BookieProtocol.EOK, response.getErrorCode());
     }
 
+    @Test
+    public void testNoReadAheadFlagIsPassedToBookie() throws Exception {
+        ChannelPromise promise = new DefaultChannelPromise(channel);
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocationOnMock -> {
+            promise.setSuccess();
+            latch.countDown();
+            return promise;
+        }).when(channel).writeAndFlush(any(Response.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId,
+                1, BookieProtocol.FLAG_NO_READ_AHEAD, new byte[]{});
+        ReadEntryProcessor processor = ReadEntryProcessor.create(request, requestHandler, requestProcessor, null, true);
+        processor.run();
+
+        latch.await();
+        verify(bookie, times(1)).readEntry(ledgerId, 1, true);
+    }
+
+    @Test
+    public void testDefaultReadDoesNotPassNoReadAheadToBookie() throws Exception {
+        ChannelPromise promise = new DefaultChannelPromise(channel);
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocationOnMock -> {
+            promise.setSuccess();
+            latch.countDown();
+            return promise;
+        }).when(channel).writeAndFlush(any(Response.class));
+
+        long ledgerId = System.currentTimeMillis();
+        ReadRequest request = ReadRequest.create(BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId,
+                1, BookieProtocol.FLAG_NONE, new byte[]{});
+        ReadEntryProcessor processor = ReadEntryProcessor.create(request, requestHandler, requestProcessor, null, true);
+        processor.run();
+
+        latch.await();
+        verify(bookie, times(1)).readEntry(ledgerId, 1, false);
+    }
+
     /**
      * Test that when throttleReadResponses=true and the caller is not in the Netty event loop,
      * the read thread is not blocked by the write. onReadRequestFinish() should only be called

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3Test.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3Test.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.proto;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Stopwatch;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.BKPacketHeader;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.OperationType;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ProtocolVersion;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadRequest;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.ReadResponse;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.Request;
+import org.apache.bookkeeper.proto.BookkeeperProtocol.StatusCode;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test {@link ReadEntryProcessorV3}.
+ */
+public class ReadEntryProcessorV3Test {
+
+    private Bookie bookie;
+    private BookieRequestHandler requestHandler;
+    private BookieRequestProcessor requestProcessor;
+
+    @Before
+    public void setup() throws Exception {
+        Channel channel = mock(Channel.class);
+        requestHandler = mock(BookieRequestHandler.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        when(requestHandler.ctx()).thenReturn(ctx);
+
+        bookie = mock(Bookie.class);
+        requestProcessor = mock(BookieRequestProcessor.class);
+        when(requestProcessor.getBookie()).thenReturn(bookie);
+        when(requestProcessor.getRequestStats()).thenReturn(new RequestStats(NullStatsLogger.INSTANCE));
+    }
+
+    @Test
+    public void testNoReadAheadReadFlagIsPassedToBookie() throws Exception {
+        long ledgerId = 1L;
+        long entryId = 2L;
+        when(bookie.readEntry(ledgerId, entryId, true)).thenReturn(Unpooled.wrappedBuffer(new byte[] { 1 }));
+        when(bookie.readLastAddConfirmed(ledgerId)).thenReturn(entryId);
+
+        ReadEntryProcessorV3 processor = newProcessor(ReadRequest.newBuilder()
+                .setLedgerId(ledgerId)
+                .setEntryId(entryId)
+                .setReadFlags(BookieProtocol.FLAG_NO_READ_AHEAD)
+                .build());
+
+        ReadResponse response = processor.readEntry(ReadResponse.newBuilder()
+                .setLedgerId(ledgerId)
+                .setEntryId(entryId), entryId, Stopwatch.createStarted());
+
+        assertEquals(StatusCode.EOK, response.getStatus());
+        verify(bookie).readEntry(ledgerId, entryId, true);
+    }
+
+    @Test
+    public void testDefaultReadDoesNotPassNoReadAheadToBookie() throws Exception {
+        long ledgerId = 1L;
+        long entryId = 2L;
+        when(bookie.readEntry(ledgerId, entryId, false)).thenReturn(Unpooled.wrappedBuffer(new byte[] { 1 }));
+        when(bookie.readLastAddConfirmed(ledgerId)).thenReturn(entryId);
+
+        ReadEntryProcessorV3 processor = newProcessor(ReadRequest.newBuilder()
+                .setLedgerId(ledgerId)
+                .setEntryId(entryId)
+                .build());
+
+        ReadResponse response = processor.readEntry(ReadResponse.newBuilder()
+                .setLedgerId(ledgerId)
+                .setEntryId(entryId), entryId, Stopwatch.createStarted());
+
+        assertEquals(StatusCode.EOK, response.getStatus());
+        verify(bookie).readEntry(ledgerId, entryId, false);
+    }
+
+    private ReadEntryProcessorV3 newProcessor(ReadRequest readRequest) throws BookieException {
+        Request request = Request.newBuilder()
+                .setHeader(BKPacketHeader.newBuilder()
+                        .setTxnId(System.currentTimeMillis())
+                        .setVersion(ProtocolVersion.VERSION_THREE)
+                        .setOperation(OperationType.READ_ENTRY)
+                        .build())
+                .setReadRequest(readRequest)
+                .build();
+        return new ReadEntryProcessorV3(request, requestHandler, requestProcessor, null);
+    }
+}

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBookieRequestProcessor.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/TestBookieRequestProcessor.java
@@ -109,6 +109,15 @@ public class TestBookieRequestProcessor {
             .build();
         assertFalse(RequestUtils.hasFlag(read, ReadRequest.Flag.FENCE_LEDGER));
         assertFalse(RequestUtils.hasFlag(read, ReadRequest.Flag.ENTRY_PIGGYBACK));
+        assertFalse(RequestUtils.isNoReadAhead(read));
+
+        read = ReadRequest.newBuilder()
+            .setLedgerId(10).setEntryId(1)
+            .setFlag(ReadRequest.Flag.FENCE_LEDGER)
+            .setReadFlags(BookieProtocol.FLAG_NO_READ_AHEAD)
+            .build();
+        assertTrue(RequestUtils.hasFlag(read, ReadRequest.Flag.FENCE_LEDGER));
+        assertTrue(RequestUtils.isNoReadAhead(read));
 
         AddRequest add = AddRequest.newBuilder()
             .setLedgerId(10).setEntryId(1)
@@ -196,11 +205,13 @@ public class TestBookieRequestProcessor {
 
         readRequest = ReadRequest.newBuilder().setLedgerId(10).setEntryId(23).setPreviousLAC(2).setTimeOut(100)
                 .setMasterKey(ByteString.copyFrom("masterKey".getBytes())).setFlag(ReadRequest.Flag.ENTRY_PIGGYBACK)
+                .setReadFlags(BookieProtocol.FLAG_NO_READ_AHEAD)
                 .build();
         request = Request.newBuilder().setHeader(header).setReadRequest(readRequest).build();
         toString = RequestUtils.toSafeString(request);
         assertFalse("ReadRequest's safeString should have filtered out masterKey", toString.contains("masterKey"));
         assertTrue("ReadRequest's safeString shouldn contain flag", toString.contains("flag"));
+        assertTrue("ReadRequest's safeString should contain readFlags", toString.contains("readFlags"));
         assertTrue("ReadRequest's safeString shouldn contain previousLAC", toString.contains("previousLAC"));
         assertTrue("ReadRequest's safeString shouldn contain timeOut", toString.contains("timeOut"));
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

<!-- Either this PR fixes an issue, -->

Fix #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a BP, please add the BP link here -->

BP: #xyz

### Motivation

Pulsar delayed delivery uses `BucketDelayedDeliveryTracker` when there are too many delayed messages to keep all delayed indexes in broker memory. In that mode, delayed indexes are persisted as bucket snapshot segments in BookKeeper, and the broker lazily loads the next snapshot segment entry only after the current segment has been drained by time-driven delivery.

This access pattern is a sparse point-read workload, not a normal sequential scan. A single lazy-load read for snapshot entry `N` can currently trigger bookie-side `dbStorage_readAheadCache` prefill for `N+1`, `N+2`, and later entries, but those entries may not be read until much later, or may be evicted before use. This can waste bookie IO and direct memory, and can pollute the read-ahead cache needed by ordinary sequential reads such as backlog consumption, catch-up reads, and ledger scans.

This change adds a per-read no-read-ahead hint so callers such as Pulsar can opt out only for these point-read paths while preserving the default read-ahead behavior for normal sequential workloads.

### Changes

- Add `ReadOptions` with `ReadOptions.DEFAULT` and `ReadOptions.builder().disableReadAhead(true).build()` for request-scoped read options.
- Add `ReadOptions` overloads to `ReadHandle` and `LedgerHandle`, including legacy callback APIs and unconfirmed read APIs that share the same internal read path.
- Propagate the hint from `PendingReadOp` to bookies through a new `BookieProtocol.FLAG_NO_READ_AHEAD` bit.
- Extend v3 protobuf read requests with `ReadRequest.readFlags` so bitmask-style read flags can coexist with the existing single-value `ReadRequest.flag` enum.
- Pass the no-read-ahead hint through v2/v3 read processors into `Bookie.readEntry(..., noReadAhead)`.
- Add bookie, ledger descriptor, and ledger storage read overloads while keeping existing methods defaulting to normal read-ahead behavior.
- Update `DbLedgerStorage` / `SingleDirectoryDbLedgerStorage` so `noReadAhead=true` still uses and populates the target entry cache, but skips the extra `fillReadAheadCache(...)` prefill for following entries.
- Add focused tests for storage read-cache behavior, protocol flag propagation, request processor handling, and client-side `PendingReadOp` flag construction.
