### PR TITLE
Upgrade OpenTelemetry libraries to 1.61.0 / 2.27.0

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -353,14 +353,13 @@ Apache Software License, Version 2.
 - lib/io.opentelemetry.semconv-opentelemetry-semconv-1.41.0.jar [55]
 - lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.27.0.jar [59]
 - lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.27.0-alpha.jar [59]
-- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.27.0-alpha.jar [59]
-- lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [55]
-- lib/io.prometheus-prometheus-metrics-config-1.3.10.jar [60]
-- lib/io.prometheus-prometheus-metrics-exporter-common-1.3.10.jar [60]
-- lib/io.prometheus-prometheus-metrics-exporter-httpserver-1.3.10.jar [60]
-- lib/io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.3.10.jar [60]
-- lib/io.prometheus-prometheus-metrics-exposition-textformats-1.3.10.jar [60]
-- lib/io.prometheus-prometheus-metrics-model-1.3.10.jar [60]
+- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-2.27.0-alpha.jar [59]
+- lib/io.prometheus-prometheus-metrics-config-1.5.1.jar [60]
+- lib/io.prometheus-prometheus-metrics-exporter-common-1.5.1.jar [60]
+- lib/io.prometheus-prometheus-metrics-exporter-httpserver-1.5.1.jar [60]
+- lib/io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.5.1.jar [60]
+- lib/io.prometheus-prometheus-metrics-exposition-textformats-1.5.1.jar [60]
+- lib/io.prometheus-prometheus-metrics-model-1.5.1.jar [60]
 - lib/org.jetbrains-annotations-13.0.jar [56]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-2.2.21.jar [56]
 - lib/com.lmax-disruptor-4.0.0.jar [57]
@@ -419,7 +418,7 @@ Apache Software License, Version 2.
 [57] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [58] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [59] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.27.0
-[60] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
+[60] Source available at https://github.com/prometheus/client_java/tree/v1.5.1
 [61] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [63] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -333,27 +333,27 @@ Apache Software License, Version 2.
 - lib/com.carrotsearch-hppc-0.9.1.jar [53]
 - lib/com.squareup.okhttp3-okhttp-jvm-5.3.1.jar [54]
 - lib/com.squareup.okio-okio-jvm-3.16.3.jar [54]
-- lib/io.opentelemetry-opentelemetry-api-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-api-incubator-1.56.0-alpha.jar [55]
-- lib/io.opentelemetry-opentelemetry-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-context-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-exporter-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-exporter-otlp-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-exporter-otlp-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-exporter-prometheus-1.56.0-alpha.jar [55]
-- lib/io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-logs-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-trace-1.56.0.jar [55]
-- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.52.0-alpha.jar [55]
-- lib/io.opentelemetry.semconv-opentelemetry-semconv-1.37.0.jar [55]
-- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.21.0.jar [59]
-- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.21.0-alpha.jar [59]
-- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.21.0-alpha.jar [59]
+- lib/io.opentelemetry-opentelemetry-api-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-api-incubator-1.61.0-alpha.jar [55]
+- lib/io.opentelemetry-opentelemetry-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-context-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-exporter-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-exporter-otlp-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-exporter-otlp-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-exporter-prometheus-1.61.0-alpha.jar [55]
+- lib/io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-logs-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-trace-1.61.0.jar [55]
+- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.56.0-alpha.jar [55]
+- lib/io.opentelemetry.semconv-opentelemetry-semconv-1.41.0.jar [55]
+- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.27.0.jar [59]
+- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.27.0-alpha.jar [59]
+- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.27.0-alpha.jar [59]
 - lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [55]
 - lib/io.prometheus-prometheus-metrics-config-1.3.10.jar [60]
 - lib/io.prometheus-prometheus-metrics-exporter-common-1.3.10.jar [60]
@@ -414,11 +414,11 @@ Apache Software License, Version 2.
 [52] Source available at https://github.com/HdrHistogram/HdrHistogram/tree/HdrHistogram-2.1.10
 [53] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [54] Source available at https://github.com/square/okio/releases/tag/parent-3.16.3
-[55] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
+[55] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0
 [56] Source available at https://github.com/JetBrains/kotlin/releases/tag/v2.2.21
 [57] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [58] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
-[59] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.21.0
+[59] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.27.0
 [60] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
 [61] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -295,20 +295,20 @@ Apache Software License, Version 2.
 - lib/io.reactivex.rxjava3-rxjava-3.0.1.jar [51]
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 - lib/com.lmax-disruptor-4.0.0.jar [53]
-- lib/io.opentelemetry-opentelemetry-api-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-common-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-context-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-api-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-context-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-common-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-logs-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.56.0.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-trace-1.56.0.jar [55]
-- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.52.0-alpha.jar [55]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.56.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-api-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-common-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-context-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-api-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-context-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-common-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-logs-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.61.0.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-trace-1.61.0.jar [55]
+- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.56.0-alpha.jar [55]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.61.0.jar [55]
 - lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [54]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
@@ -351,7 +351,7 @@ Apache Software License, Version 2.
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
-[54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
+[54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0
 [55] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [56] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -309,7 +309,6 @@ Apache Software License, Version 2.
 - lib/io.opentelemetry-opentelemetry-sdk-trace-1.61.0.jar [55]
 - lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.56.0-alpha.jar [55]
 - lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.61.0.jar [55]
-- lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [54]
 
 [1] Source available at https://github.com/FasterXML/jackson-annotations/tree/jackson-annotations-2.17.1
 [2] Source available at https://github.com/FasterXML/jackson-core/tree/jackson-core-2.17.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -347,16 +347,15 @@ Apache Software License, Version 2.
 - lib/io.opentelemetry-opentelemetry-sdk-trace-1.61.0.jar [54]
 - lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.27.0.jar [58]
 - lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.27.0-alpha.jar [58]
-- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.27.0-alpha.jar [58]
+- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-2.27.0-alpha.jar [58]
 - lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.56.0-alpha.jar [54]
 - lib/io.opentelemetry.semconv-opentelemetry-semconv-1.41.0.jar [54]
-- lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [54]
-- lib/io.prometheus-prometheus-metrics-config-1.3.10.jar [59]
-- lib/io.prometheus-prometheus-metrics-exporter-common-1.3.10.jar [59]
-- lib/io.prometheus-prometheus-metrics-exporter-httpserver-1.3.10.jar [59]
-- lib/io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.3.10.jar [59]
-- lib/io.prometheus-prometheus-metrics-exposition-textformats-1.3.10.jar [59]
-- lib/io.prometheus-prometheus-metrics-model-1.3.10.jar [59]
+- lib/io.prometheus-prometheus-metrics-config-1.5.1.jar [59]
+- lib/io.prometheus-prometheus-metrics-exporter-common-1.5.1.jar [59]
+- lib/io.prometheus-prometheus-metrics-exporter-httpserver-1.5.1.jar [59]
+- lib/io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.5.1.jar [59]
+- lib/io.prometheus-prometheus-metrics-exposition-textformats-1.5.1.jar [59]
+- lib/io.prometheus-prometheus-metrics-model-1.5.1.jar [59]
 - lib/org.jetbrains-annotations-13.0.jar [55]
 - lib/org.jetbrains.kotlin-kotlin-stdlib-2.2.21.jar [55]
 - lib/com.lmax-disruptor-4.0.0.jar [56]
@@ -414,7 +413,7 @@ Apache Software License, Version 2.
 [56] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [57] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
 [58] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.27.0
-[59] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
+[59] Source available at https://github.com/prometheus/client_java/tree/v1.5.1
 [60] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [62] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -329,27 +329,27 @@ Apache Software License, Version 2.
 - lib/com.carrotsearch-hppc-0.9.1.jar [52]
 - lib/com.squareup.okhttp3-okhttp-jvm-5.3.1.jar [53]
 - lib/com.squareup.okio-okio-jvm-3.16.3.jar [53]
-- lib/io.opentelemetry-opentelemetry-api-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-api-incubator-1.56.0-alpha.jar [54]
-- lib/io.opentelemetry-opentelemetry-common-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-context-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-exporter-common-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-exporter-otlp-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-exporter-otlp-common-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-exporter-prometheus-1.56.0-alpha.jar [54]
-- lib/io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-common-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-logs-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.56.0.jar [54]
-- lib/io.opentelemetry-opentelemetry-sdk-trace-1.56.0.jar [54]
-- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.21.0.jar [58]
-- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.21.0-alpha.jar [58]
-- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.21.0-alpha.jar [58]
-- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.52.0-alpha.jar [54]
-- lib/io.opentelemetry.semconv-opentelemetry-semconv-1.37.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-api-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-api-incubator-1.61.0-alpha.jar [54]
+- lib/io.opentelemetry-opentelemetry-common-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-context-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-exporter-common-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-exporter-otlp-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-exporter-otlp-common-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-exporter-prometheus-1.61.0-alpha.jar [54]
+- lib/io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-common-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-logs-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-metrics-1.61.0.jar [54]
+- lib/io.opentelemetry-opentelemetry-sdk-trace-1.61.0.jar [54]
+- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.27.0.jar [58]
+- lib/io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.27.0-alpha.jar [58]
+- lib/io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.27.0-alpha.jar [58]
+- lib/io.opentelemetry.contrib-opentelemetry-gcp-resources-1.56.0-alpha.jar [54]
+- lib/io.opentelemetry.semconv-opentelemetry-semconv-1.41.0.jar [54]
 - lib/com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar [54]
 - lib/io.prometheus-prometheus-metrics-config-1.3.10.jar [59]
 - lib/io.prometheus-prometheus-metrics-exporter-common-1.3.10.jar [59]
@@ -409,11 +409,11 @@ Apache Software License, Version 2.
 [51] Source available at https://github.com/ReactiveX/RxJava/tree/v3.0.1
 [52] Source available at https://github.com/carrotsearch/hppc/tree/0.9.1
 [53] Source available at https://github.com/square/okio/releases/tag/parent-3.16.3
-[54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0
+[54] Source available at https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0
 [55] Source available at https://github.com/JetBrains/kotlin/releases/tag/v2.2.21
 [56] Source available at https://github.com/LMAX-Exchange/disruptor/releases/tag/4.0.0
 [57] Source available at https://github.com/apache/commons-lang/tree/rel/commons-lang-3.20.0
-[58] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.21.0
+[58] Source available at https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.27.0
 [59] Source available at https://github.com/prometheus/client_java/tree/v1.3.10
 [60] Source available at https://github.com/apache/commons-text/tree/rel/commons-text-1.13.1
 [61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0

--- a/pom.xml
+++ b/pom.xml
@@ -227,10 +227,10 @@
     <forkCount.variable>1</forkCount.variable>
     <servlet-api.version>4.0.0</servlet-api.version>
     <rxjava.version>3.0.1</rxjava.version>
-    <otel.version>1.56.0</otel.version>
-    <otel.instrumentation.version>2.21.0</otel.instrumentation.version>
-    <otel.semconv.version>1.37.0</otel.semconv.version>
-    <otel.contrib.version>1.52.0</otel.contrib.version>
+    <otel.version>1.61.0</otel.version>
+    <otel.instrumentation.version>2.27.0</otel.instrumentation.version>
+    <otel.semconv.version>1.41.0</otel.semconv.version>
+    <otel.contrib.version>1.56.0</otel.contrib.version>
     <okhttp3.version>5.3.1</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
     <okio.version>3.16.3</okio.version>

--- a/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <artifactId>opentelemetry-runtime-telemetry</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>

--- a/stats/bookkeeper-stats-providers/otel-metrics-provider/src/main/java/org/apache/bookkeeper/stats/otel/OtelMetricsProvider.java
+++ b/stats/bookkeeper-stats-providers/otel-metrics-provider/src/main/java/org/apache/bookkeeper/stats/otel/OtelMetricsProvider.java
@@ -22,14 +22,13 @@ import io.netty.util.internal.PlatformDependent;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalBufferPools;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetryBuilder;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Experimental;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Internal;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.ExplicitBucketHistogramOptions;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.View;
@@ -83,7 +82,10 @@ public class OtelMetricsProvider implements StatsProvider {
                                                 .setType(InstrumentType.HISTOGRAM)
                                                 .build(),
                                         View.builder()
-                                                .setAggregation(Aggregation.explicitBucketHistogram(histogramBuckets))
+                                                .setAggregation(Aggregation.explicitBucketHistogram(
+                                                        ExplicitBucketHistogramOptions.builder()
+                                                                .setBucketBoundaries(histogramBuckets)
+                                                                .build()))
                                                 .build())
 
                 ).build();
@@ -95,13 +97,12 @@ public class OtelMetricsProvider implements StatsProvider {
     public void start(Configuration conf) {
         boolean exposeDefaultJVMMetrics = conf.getBoolean("exposeDefaultJVMMetrics", true);
         if (exposeDefaultJVMMetrics) {
-            // Include standard JVM stats
-            MemoryPools.registerObservers(openTelemetry);
-            ExperimentalBufferPools.registerObservers(openTelemetry);
-            Classes.registerObservers(openTelemetry);
-            Cpu.registerObservers(openTelemetry);
-            Threads.registerObservers(openTelemetry);
-            GarbageCollector.registerObservers(openTelemetry, true);
+            // Include standard JVM stats (memory pools, classes, CPU, threads, GC)
+            // plus experimental buffer pool metrics, with GC cause attribute capture.
+            RuntimeTelemetryBuilder runtimeTelemetryBuilder = RuntimeTelemetry.builder(openTelemetry);
+            Experimental.setEmitExperimentalMetrics(runtimeTelemetryBuilder, true);
+            Internal.setCaptureGcCause(runtimeTelemetryBuilder, true);
+            runtimeTelemetryBuilder.build();
 
             meter.gaugeBuilder("process.runtime.jvm.memory.direct_bytes_used")
                     .buildWithCallback(odm -> odm.record(getDirectMemoryUsage.get()));


### PR DESCRIPTION
## Summary

- Bump OpenTelemetry dependencies: `opentelemetry-java` 1.56.0 → 1.61.0, `opentelemetry-java-instrumentation` 2.21.0 → 2.27.0, `semantic-conventions-java` 1.37.0 → 1.41.0, `opentelemetry-java-contrib` 1.52.0 → 1.56.0.
- Migrate `OtelMetricsProvider` off the `opentelemetry-runtime-telemetry-java8` per-observer classes (`Classes`, `Cpu`, `GarbageCollector`, `MemoryPools`, `Threads`, `ExperimentalBufferPools`) — they were deprecated in 2.25.0, made internal in 2.26.0, and removed in 2.27.0 — to the unified `opentelemetry-runtime-telemetry` module's `RuntimeTelemetry` builder. Experimental buffer-pool metrics and GC-cause attribute capture are preserved.
- Replace the `Aggregation.explicitBucketHistogram(List<Double>)` overload deprecated in opentelemetry-java SDK 1.60.0 with the new `ExplicitBucketHistogramOptions` form.

## Test plan

- [ ] `mvn -pl stats/bookkeeper-stats-providers/otel-metrics-provider -am compile` succeeds with no deprecation warnings
- [ ] CI passes
- [ ] Smoke-test JVM metrics export with the new `RuntimeTelemetry` to confirm memory pools, classes, CPU, threads, GC (with cause) and buffer pools are still emitted