### PR TITLE
Migrate from Yahoo DataSketches to Apache DataSketches 7.0.1 (KLL)

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -279,8 +279,8 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
 - lib/org.rocksdb-rocksdbjni-9.9.3.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
-- lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
-- lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
+- lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
+- lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
 - lib/at.yawk.lz4-lz4-java-1.10.2.jar [26]
 - lib/com.google.api-api-common-2.53.0.jar [63]
 - lib/com.google.api.grpc-proto-google-common-protos-2.63.2.jar [28]
@@ -387,8 +387,9 @@ Apache Software License, Version 2.
 [22] Source available at https://github.com/jetty/jetty.project/tree/jetty-12.1.7
 [23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
-[25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
+[25] Source available at https://github.com/apache/datasketches-java/tree/7.0.1
 [26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
+[27] Source available at https://github.com/apache/datasketches-memory/tree/4.1.0
 [28] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.63.2/java-common-protos
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.12.1
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -279,8 +279,8 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
 - lib/org.rocksdb-rocksdbjni-9.9.3.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
-- lib/com.yahoo.datasketches-memory-0.8.3.jar [25]
-- lib/com.yahoo.datasketches-sketches-core-0.8.3.jar [25]
+- lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
+- lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
 - lib/at.yawk.lz4-lz4-java-1.10.2.jar [26]
 - lib/com.google.api-api-common-2.53.0.jar [62]
 - lib/com.google.api.grpc-proto-google-common-protos-2.63.2.jar [28]
@@ -383,8 +383,9 @@ Apache Software License, Version 2.
 [22] Source available at https://github.com/jetty/jetty.project/tree/jetty-12.1.7
 [23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
-[25] Source available at https://github.com/DataSketches/sketches-core/tree/sketches-0.8.3
+[25] Source available at https://github.com/apache/datasketches-java/tree/7.0.1
 [26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
+[27] Source available at https://github.com/apache/datasketches-memory/tree/4.1.0
 [28] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.63.2/java-common-protos
 [29] Source available at https://github.com/google/gson/tree/gson-parent-2.12.1
 [30] Source available at https://github.com/census-instrumentation/opencensus-java/tree/v0.31.1

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <mockito.version>4.11.0</mockito.version>
     <netty.version>4.2.12.Final</netty.version>
     <prometheus.version>0.15.0</prometheus.version>
-    <datasketches.version>0.8.3</datasketches.version>
+    <datasketches.version>7.0.1</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
     <protobuf.version>4.34.0</protobuf.version>
@@ -666,8 +666,8 @@
       </dependency>
       <!-- data-sketches -->
       <dependency>
-        <groupId>com.yahoo.datasketches</groupId>
-        <artifactId>sketches-core</artifactId>
+        <groupId>org.apache.datasketches</groupId>
+        <artifactId>datasketches-java</artifactId>
         <version>${datasketches.version}</version>
       </dependency>
       <!-- opentelemetry -->

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -70,8 +70,8 @@
     </dependency>
     
     <dependency>
-      <groupId>com.yahoo.datasketches</groupId>
-      <artifactId>sketches-core</artifactId>
+      <groupId>org.apache.datasketches</groupId>
+      <artifactId>datasketches-java</artifactId>
     </dependency>
 
     <dependency>

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/prometheus/DataSketchesOpStatsLogger.java
@@ -16,10 +16,6 @@
  */
 package org.apache.bookkeeper.stats.prometheus;
 
-import com.yahoo.sketches.quantiles.DoublesSketch;
-import com.yahoo.sketches.quantiles.DoublesSketchBuilder;
-import com.yahoo.sketches.quantiles.DoublesUnion;
-import com.yahoo.sketches.quantiles.DoublesUnionBuilder;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +24,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
 import org.apache.bookkeeper.stats.OpStatsData;
 import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.datasketches.kll.KllDoublesSketch;
 
 /**
  * OpStatsLogger implementation that uses DataSketches library to calculate the approximated latency quantiles.
@@ -43,8 +40,8 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     /*
      * These are the sketches where all the aggregated results are published.
      */
-    private volatile DoublesSketch successResult;
-    private volatile DoublesSketch failResult;
+    private volatile KllDoublesSketch successResult;
+    private volatile KllDoublesSketch failResult;
 
     private final LongAdder successCountAdder = new LongAdder();
     private final LongAdder failCountAdder = new LongAdder();
@@ -145,22 +142,22 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
         current = replacement;
         replacement = local;
 
-        final DoublesUnion aggregateSuccess = new DoublesUnionBuilder().build();
-        final DoublesUnion aggregateFail = new DoublesUnionBuilder().build();
+        final KllDoublesSketch aggregateSuccess = KllDoublesSketch.newHeapInstance();
+        final KllDoublesSketch aggregateFail = KllDoublesSketch.newHeapInstance();
         local.map.forEach((localData, b) -> {
             long stamp = localData.lock.writeLock();
             try {
-                aggregateSuccess.update(localData.successSketch);
-                localData.successSketch.reset();
-                aggregateFail.update(localData.failSketch);
-                localData.failSketch.reset();
+                aggregateSuccess.merge(localData.successSketch);
+                aggregateFail.merge(localData.failSketch);
+                localData.successSketch = KllDoublesSketch.newHeapInstance();
+                localData.failSketch = KllDoublesSketch.newHeapInstance();
             } finally {
                 localData.lock.unlockWrite(stamp);
             }
         });
 
-        successResult = aggregateSuccess.getResultAndReset();
-        failResult = aggregateFail.getResultAndReset();
+        successResult = aggregateSuccess;
+        failResult = aggregateFail;
     }
 
     public long getCount(boolean success) {
@@ -172,8 +169,8 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     }
 
     public double getQuantileValue(boolean success, double quantile) {
-        DoublesSketch s = success ? successResult : failResult;
-        return s != null ? s.getQuantile(quantile) : Double.NaN;
+        KllDoublesSketch s = success ? successResult : failResult;
+        return (s != null && !s.isEmpty()) ? s.getQuantile(quantile) : Double.NaN;
     }
 
     public Map<String, String> getLabels() {
@@ -190,8 +187,8 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
     }
 
     private static class LocalData {
-        private final DoublesSketch successSketch = new DoublesSketchBuilder().build();
-        private final DoublesSketch failSketch = new DoublesSketchBuilder().build();
+        private KllDoublesSketch successSketch = KllDoublesSketch.newHeapInstance();
+        private KllDoublesSketch failSketch = KllDoublesSketch.newHeapInstance();
         private final StampedLock lock = new StampedLock();
     }
 


### PR DESCRIPTION
### Motivation

BookKeeper still depends on `com.yahoo.datasketches:sketches-core:0.8.3`, which has been unmaintained since the project moved to the Apache Software Foundation and was renamed to `org.apache.datasketches:datasketches-java`. A previous attempt to upgrade ([#3264](https://github.com/apache/bookkeeper/pull/3264), May 2022) replaced the dependency 1:1 with the Apache classic-quantiles `DoublesSketch` but never landed.

Since #3264 two things have changed:

1. BookKeeper master now requires Java 17, so we can use the latest `datasketches-java:7.0.1` (which itself requires JDK ≥ 17).
2. The Apache DataSketches maintainers explicitly recommend the **KLL sketch** over the classic quantiles sketch for any new code — see https://github.com/apache/datasketches-java/issues/398#issuecomment-1151490051. KLL is faster, more memory efficient, and has comparable accuracy at the default K. Migrating straight to KLL while we are touching this code avoids the near-term performance regression that #3264 would have introduced.

### Changes

- `pom.xml` and `stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml`: dependency coordinate updated from `com.yahoo.datasketches:sketches-core:0.8.3` → `org.apache.datasketches:datasketches-java:7.0.1`.
- `DataSketchesOpStatsLogger.java`: ported to `org.apache.datasketches.kll.KllDoublesSketch`.
  - On-heap throughout, matching the previous behavior — no off-heap conversion.
  - KLL has no `DoublesUnion`; rotation aggregates with `merge()` directly into a freshly allocated `KllDoublesSketch.newHeapInstance()`.
  - KLL has no `reset()`; per-thread sketches are reassigned to a fresh `newHeapInstance()` under the existing `StampedLock` write lock (the lock provides the happens-before edge that publishes the new reference safely).
  - `KllDoublesSketch.getQuantile()` throws `SketchesArgumentException` on an empty sketch (vs the classic sketch returning `NaN`), so `getQuantileValue()` now guards with `isEmpty()` to preserve the prior `NaN` return.
- `LICENSE-all.bin.txt` / `LICENSE-server.bin.txt`: list `datasketches-java-7.0.1.jar` and the transitively-required `datasketches-memory-4.1.0.jar` separately. The two jars are sourced from distinct Apache repositories (`apache/datasketches-java` and `apache/datasketches-memory`), so each gets its own footnote — `[25]` retargeted to datasketches-java, and the previously-vacant `[27]` slot now references datasketches-memory.

The CVE-2021-40531 OWASP suppression that #3264 added does **not** apply to 7.0.x, so no suppression is needed.

### Verification

- `mvn -pl stats/bookkeeper-stats-providers/prometheus-metrics-provider -am dependency:tree -Dincludes=org.apache.datasketches` confirms the resolved versions: `datasketches-java:jar:7.0.1:compile` → `datasketches-memory:jar:4.1.0:compile` (matches the LICENSE entries).
- `mvn -pl stats/bookkeeper-stats-providers/prometheus-metrics-provider -am clean verify` builds green; all 11 tests in `TestPrometheusFormatter` and `TestPrometheusMetricsProvider` pass.
- `mvn -pl stats/bookkeeper-stats-providers/prometheus-metrics-provider -am spotbugs:check -DskipTests`: no errors/warnings.