### PR TITLE
Upgrade Netty to 4.2.13.Final to address CVEs

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -217,33 +217,33 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [64]
-- lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-compression-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.2.12.Final.jar [11]
-- lib/io.netty-netty-common-4.2.12.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.12.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.2.12.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.12.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.2.12.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-compression-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.2.13.Final.jar [11]
+- lib/io.netty-netty-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -374,7 +374,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.12.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -424,9 +424,9 @@ Apache Software License, Version 2.
 [63] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
 [64] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -435,7 +435,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -443,7 +443,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -451,7 +451,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -459,7 +459,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -469,7 +469,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -477,7 +477,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -486,7 +486,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -494,7 +494,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -502,7 +502,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -510,7 +510,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -518,7 +518,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -526,7 +526,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -534,7 +534,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -542,7 +542,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -551,7 +551,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -559,7 +559,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -567,7 +567,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -575,7 +575,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -583,7 +583,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -591,7 +591,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -599,7 +599,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -607,7 +607,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -615,7 +615,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -623,7 +623,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -632,7 +632,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -640,7 +640,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -217,26 +217,26 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [59]
-- lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
-- lib/io.netty-netty-common-4.2.12.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.12.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.12.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
+- lib/io.netty-netty-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [16]
@@ -320,7 +320,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.12.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.23.1
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -357,9 +357,9 @@ Apache Software License, Version 2.
 [58] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
 [59] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -368,7 +368,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -376,7 +376,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -384,7 +384,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -392,7 +392,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -402,7 +402,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -410,7 +410,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -419,7 +419,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -427,7 +427,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -435,7 +435,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -443,7 +443,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -451,7 +451,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -459,7 +459,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -467,7 +467,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -475,7 +475,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -484,7 +484,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -492,7 +492,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -500,7 +500,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -508,7 +508,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -516,7 +516,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -524,7 +524,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -532,7 +532,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -540,7 +540,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -548,7 +548,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -556,7 +556,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -565,7 +565,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -573,7 +573,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -217,33 +217,33 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [63]
-- lib/io.netty-netty-buffer-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-compression-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.2.12.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.2.12.Final.jar [11]
-- lib/io.netty-netty-common-4.2.12.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.12.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.2.12.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.12.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.2.12.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-compression-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.2.13.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.2.13.Final.jar [11]
+- lib/io.netty-netty-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -370,7 +370,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.12.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -419,9 +419,9 @@ Apache Software License, Version 2.
 [62] Source available at https://github.com/googleapis/sdk-platform-java/tree/v2.53.0/api-common-java
 [63] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.12.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -430,7 +430,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -438,7 +438,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -446,7 +446,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -454,7 +454,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -464,7 +464,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -472,7 +472,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -481,7 +481,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -489,7 +489,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -497,7 +497,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -505,7 +505,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -513,7 +513,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -521,7 +521,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -529,7 +529,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -537,7 +537,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -546,7 +546,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -554,7 +554,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -562,7 +562,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -570,7 +570,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -578,7 +578,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -586,7 +586,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -594,7 +594,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -602,7 +602,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -610,7 +610,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -618,7 +618,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -627,7 +627,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -635,7 +635,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.12.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,33 +23,33 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.12.Final.jar
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar
-- lib/io.netty-netty-codec-compression-4.2.12.Final.jar
-- lib/io.netty-netty-codec-dns-4.2.12.Final.jar
-- lib/io.netty-netty-codec-http-4.2.12.Final.jar
-- lib/io.netty-netty-codec-http2-4.2.12.Final.jar
-- lib/io.netty-netty-codec-socks-4.2.12.Final.jar
-- lib/io.netty-netty-common-4.2.12.Final.jar
-- lib/io.netty-netty-handler-4.2.12.Final.jar
-- lib/io.netty-netty-handler-proxy-4.2.12.Final.jar
-- lib/io.netty-netty-resolver-4.2.12.Final.jar
-- lib/io.netty-netty-resolver-dns-4.2.12.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar
-- lib/io.netty-netty-transport-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar
+- lib/io.netty-netty-buffer-4.2.13.Final.jar
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar
+- lib/io.netty-netty-codec-compression-4.2.13.Final.jar
+- lib/io.netty-netty-codec-dns-4.2.13.Final.jar
+- lib/io.netty-netty-codec-http-4.2.13.Final.jar
+- lib/io.netty-netty-codec-http2-4.2.13.Final.jar
+- lib/io.netty-netty-codec-socks-4.2.13.Final.jar
+- lib/io.netty-netty-common-4.2.13.Final.jar
+- lib/io.netty-netty-handler-4.2.13.Final.jar
+- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar
+- lib/io.netty-netty-resolver-4.2.13.Final.jar
+- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
+- lib/io.netty-netty-transport-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,26 +5,26 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.12.Final.jar
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar
-- lib/io.netty-netty-common-4.2.12.Final.jar
-- lib/io.netty-netty-handler-4.2.12.Final.jar
-- lib/io.netty-netty-resolver-4.2.12.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar
-- lib/io.netty-netty-transport-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar
+- lib/io.netty-netty-buffer-4.2.13.Final.jar
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar
+- lib/io.netty-netty-common-4.2.13.Final.jar
+- lib/io.netty-netty-handler-4.2.13.Final.jar
+- lib/io.netty-netty-resolver-4.2.13.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
+- lib/io.netty-netty-transport-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,33 +5,33 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.12.Final.jar
-- lib/io.netty-netty-codec-base-4.2.12.Final.jar
-- lib/io.netty-netty-codec-compression-4.2.12.Final.jar
-- lib/io.netty-netty-codec-dns-4.2.12.Final.jar
-- lib/io.netty-netty-codec-http-4.2.12.Final.jar
-- lib/io.netty-netty-codec-http2-4.2.12.Final.jar
-- lib/io.netty-netty-codec-socks-4.2.12.Final.jar
-- lib/io.netty-netty-common-4.2.12.Final.jar
-- lib/io.netty-netty-handler-4.2.12.Final.jar
-- lib/io.netty-netty-handler-proxy-4.2.12.Final.jar
-- lib/io.netty-netty-resolver-4.2.12.Final.jar
-- lib/io.netty-netty-resolver-dns-4.2.12.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar [11]
-- lib/io.netty-netty-tcnative-classes-2.0.75.Final.jar
-- lib/io.netty-netty-transport-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.12.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.12.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.12.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.12.Final.jar
+- lib/io.netty-netty-buffer-4.2.13.Final.jar
+- lib/io.netty-netty-codec-base-4.2.13.Final.jar
+- lib/io.netty-netty-codec-compression-4.2.13.Final.jar
+- lib/io.netty-netty-codec-dns-4.2.13.Final.jar
+- lib/io.netty-netty-codec-http-4.2.13.Final.jar
+- lib/io.netty-netty-codec-http2-4.2.13.Final.jar
+- lib/io.netty-netty-codec-socks-4.2.13.Final.jar
+- lib/io.netty-netty-common-4.2.13.Final.jar
+- lib/io.netty-netty-handler-4.2.13.Final.jar
+- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar
+- lib/io.netty-netty-resolver-4.2.13.Final.jar
+- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
+- lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
+- lib/io.netty-netty-transport-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
 
 
                             The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <log4j.version>2.23.1</log4j.version>
     <lz4-java.version>1.10.2</lz4-java.version>
     <mockito.version>4.11.0</mockito.version>
-    <netty.version>4.2.12.Final</netty.version>
+    <netty.version>4.2.13.Final</netty.version>
     <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>0.8.3</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
### Motivation

Upgrade Netty from 4.2.12.Final to 4.2.13.Final to pick up security fixes and bug fixes.

### Netty 4.2.13.Final summary

Release notes: https://netty.io/news/2026/05/04/4-2-13-Final.html

Netty 4.2.13.Final addresses 13 CVEs across multiple modules:

- `netty-codec-http` / `netty-codec-http2` — CVE-2026-42587, CVE-2026-41417, CVE-2026-42581, CVE-2026-42580, CVE-2026-42585, CVE-2026-42584
- `netty-codec` / `netty-codec-compression` — CVE-2026-42583
- `netty-codec-redis` — CVE-2026-42586
- `netty-codec-mqtt` — CVE
- `netty-codec-dns` — CVE-2026-42579
- `netty-codec-http3` — CVE-2026-42582
- `netty-handler-proxy` — CVE-2026-42578
- `netty-transport-native-epoll` — CVE-2026-42577

Other notable fixes in 4.2.13.Final:

- HTTP/2 preface transmission ordering and HTTP chunk parsing with multiple extensions
- `sendfile` `EINTR` offset advancement
- Resource leak fixes in `PemReader` and `CRYPTO_BUFFER_POOL` cleanup
- Guarded malloc failures in the DNS resolver and SSL_CTX_new error handling
- `IndexOutOfBoundsException` in `StompSubframeDecoder`
- Native transport: kqueue `shutdownInput`, `pipe2` fallback, fd-reuse fixes
- API additions: public `LocalIoHandle` and generic `FileRegion` support
- Bumps `netty-tcnative` to 2.0.77.Final

### netty-tcnative 2.0.75.Final → 2.0.77.Final summary

Compare: https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.75.Final...netty-tcnative-parent-2.0.77.Final

Highlights from the tcnative changelog:

- **OpenSSL 3.6 for `openssl-dynamic`** — version 1.1 is no longer shipped on many modern OSes; this also enables post-quantum / hybrid key exchange algorithms when running against OpenSSL ≥ 3.5.
- **Use-after-free / dangling pointer fix** for session tickets on OpenSSL 3.x (`OSSL_PARAM_construct_octet_string` stores a raw pointer; key bytes are now copied into a stable buffer owned by the ticket-keys allocation).
- **Memory-leak fixes**: `setSessionTicketKeys0` when `GetByteArrayElements` fails, `CRYPTO_BUFFER` leaks during decompression and on push failures, dangling global ref in the verifier setter.
- **Robustness against allocation/JNI failures**: NULL checks for `OPENSSL_malloc` in ALPN/NPN setup, `GetIntArrayElements`, `GetStringUTFChars`, and `apr_thread_rwlock_create` return values.
- **Undefined-behavior fixes**: uninitialized `proto_len`, wrong `%s` format specifier for a `jint`, missing semicolon in an old-OpenSSL `#ifdef` branch.
- **ALPN/NPN fallback correctness** — fall back to the last *local* supported protocol instead of the last peer-offered one.
- **SSL info callback** moved to per-context creation (`SSLContext.make(...)`) instead of per `SSL` instance.
- **Async verifier**: correctly tracks chain length / cert count so the `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` substitution fires on truncated chains.
- **JNI hygiene**: clear pending exceptions thrown from the keylog callback; delete local refs created in loops to avoid local-ref-table overflow.
- **Better diagnostics**: more meaningful exceptions when `SSLContext.make(...)` fails.
- **Cross-compilation**: aarch64 boringssl-static build restored; force `HAVE_PTHREAD_RWLOCKS=1` so locks are available when cross-compiling.
- New API: `SSL.getVersionInt()` to avoid string allocation on every handshake.

### Changes

- Bump `netty.version` from `4.2.12.Final` to `4.2.13.Final` in `pom.xml`.
- Regenerate `LICENSE-*.bin.txt` and `NOTICE-*.bin.txt` for the bundled Netty jars.