### PR TITLE
[Fix] Replace Java `record` with nested class in ConcurrentLongHashMap (branch-4.17)

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/collections/ConcurrentLongHashMap.java
@@ -317,7 +317,29 @@ public class ConcurrentLongHashMap<V> {
     // previous design had to paper over with Math.min(keys.length, values.length).
     @SuppressWarnings("serial")
     private static final class Section<V> extends StampedLock {
-        private record Table<V>(long[] keys, V[] values, int capacity) { }
+        private static final class Table<V> {
+            private final long[] keys;
+            private final V[] values;
+            private final int capacity;
+
+            Table(long[] keys, V[] values, int capacity) {
+                this.keys = keys;
+                this.values = values;
+                this.capacity = capacity;
+            }
+
+            long[] keys() {
+                return keys;
+            }
+
+            V[] values() {
+                return values;
+            }
+
+            int capacity() {
+                return capacity;
+            }
+        }
 
         // Section is Serializable only by inheritance from StampedLock; never actually serialized.
         @SuppressFBWarnings("SE_BAD_FIELD")


### PR DESCRIPTION
Fixes #4777

## Summary

`branch-4.17` targets Java 8 but #4771 introduced a Java `record` declaration in `ConcurrentLongHashMap.Section`, which requires Java 16+. This broke the build with:

```
ConcurrentLongHashMap.java:[320,29] ';' expected
ConcurrentLongHashMap.java:[320,32] illegal start of type
```

This change replaces the record with an equivalent `static final` nested class that exposes `keys()`, `values()` and `capacity()` accessors, leaving the existing call sites unchanged.

`master` is not affected because it already targets Java 17.

