### PR TITLE
Fix LedgerHandle batchReadUnconfirmedAsync: use slog log instead of LOG

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java
@@ -982,7 +982,10 @@ public class LedgerHandle implements WriteHandle {
     public CompletableFuture<LedgerEntries> batchReadUnconfirmedAsync(long startEntry, int maxCount, long maxSize) {
         // Little sanity check
         if (startEntry < 0 || maxCount < 0 || maxSize < 0) {
-            LOG.error("IncorrectParameterException on ledgerId:{} firstEntry:{} when batch read", ledgerId, startEntry);
+            log.error()
+                    .attr("ledgerId", ledgerId)
+                    .attr("startEntry", startEntry)
+                    .log("IncorrectParameterException when batch read");
             return FutureUtils.exception(new BKIncorrectParameterException());
         }
 


### PR DESCRIPTION
## Summary

The new \`batchReadUnconfirmedAsync\` method added in #4739 calls \`LOG.error(...)\`, but \`LedgerHandle\` was already migrated to slog and only has a lowercase \`log\` field. As a result, master fails to compile (\`cannot find symbol: variable LOG\`), which also blocks every open PR.

This change converts the call to the slog builder style used elsewhere in the same file.

## Test plan

- [x] \`mvn compile -pl bookkeeper-server\` succeeds locally