### PR TITLE
fix: add javadoc support for pom-only shaded modules

### DIFF
--- a/metadata-drivers/jetcd-core-shaded/pom.xml
+++ b/metadata-drivers/jetcd-core-shaded/pom.xml
@@ -147,6 +147,21 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,8 @@
     <okio.version>3.16.3</okio.version>
     <UBUNTU_MIRROR>http://archive.ubuntu.com/ubuntu/</UBUNTU_MIRROR>
     <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
+    <!-- skip javadoc generation by default, use -Pdelombok to activate -->
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <!-- dependency definitions -->
@@ -1027,8 +1029,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
-            <!-- skip javadoc generation by default, use -Pdelombok to activate -->
-            <skip>true</skip>
             <doclint>none</doclint>
           </configuration>
         </plugin>
@@ -1320,6 +1320,7 @@
       <id>delombok</id>
       <properties>
         <src.dir>${project.build.directory}/generated-sources/delombok</src.dir>
+        <maven.javadoc.skip>false</maven.javadoc.skip>
       </properties>
       <build>
         <plugins>
@@ -1350,14 +1351,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <!-- activate javadoc generation -->
-              <skip>false</skip>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/shaded/bookkeeper-server-shaded/pom.xml
+++ b/shaded/bookkeeper-server-shaded/pom.xml
@@ -131,6 +131,21 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -148,6 +148,21 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -232,6 +232,21 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
### Motivation

When publishing the bk to the Maven central repo, you will get the following error:
```
Error:  Deployment failed: 
Error:  pkg:maven/com.***.bookkeeper/bookkeeper-server-shaded@4.16.8.0: Javadocs must be provided but not found in entries
Error:  pkg:maven/com.***.bookkeeper/bookkeeper-server-tests-shaded@4.16.8.0: Javadocs must be provided but not found in entries
Error:  pkg:maven/com.***.distributedlog/distributedlog-core-shaded@4.16.8.0: Javadocs must be provided but not found in entries
Error:  pkg:maven/com.***.bookkeeper.metadata.drivers/jetcd-core-shaded@4.16.8.0: Javadocs must be provided but not found in entries
``` 

### Changes

- add javadoc support for pom-only shaded modules
- control javadoc generation by `maven.javadoc.skip`