### PR TITLE
Upgrade thrift to 0.23.0 to address CVE-2026-43869

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -299,7 +299,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-jdk11-4.0.6.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
-- lib/org.apache.thrift-libthrift-0.14.2.jar [41]
+- lib/org.apache.thrift-libthrift-0.23.0.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
@@ -377,7 +377,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
-[41] Source available at https://github.com/apache/thrift/tree/0.14.2
+[41] Source available at https://github.com/apache/thrift/tree/0.23.0
 [42] Source available at https://source.android.com/
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -266,7 +266,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-jdk11-4.0.6.jar [37]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [38]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [39]
-- lib/org.apache.thrift-libthrift-0.14.2.jar [40]
+- lib/org.apache.thrift-libthrift-0.23.0.jar [40]
 - lib/com.google.android-annotations-4.1.1.4.jar [41]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [44]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [46]
@@ -301,7 +301,7 @@ Apache Software License, Version 2.
 [37] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [38] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [39] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
-[40] Source available at https://github.com/apache/thrift/tree/0.14.2
+[40] Source available at https://github.com/apache/thrift/tree/0.23.0
 [41] Source available at https://source.android.com/
 [44] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [46] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -299,7 +299,7 @@ Apache Software License, Version 2.
 - lib/org.jctools-jctools-core-jdk11-4.0.6.jar [38]
 - lib/org.apache.httpcomponents-httpclient-4.5.13.jar [39]
 - lib/org.apache.httpcomponents-httpcore-4.4.15.jar [40]
-- lib/org.apache.thrift-libthrift-0.14.2.jar [41]
+- lib/org.apache.thrift-libthrift-0.23.0.jar [41]
 - lib/com.google.android-annotations-4.1.1.4.jar [42]
 - lib/com.google.j2objc-j2objc-annotations-2.8.jar [45]
 - lib/io.dropwizard.metrics-metrics-core-4.1.12.1.jar [47]
@@ -374,7 +374,7 @@ Apache Software License, Version 2.
 [38] Source available at https://github.com/JCTools/JCTools/tree/v4.0.5
 [39] Source available at https://github.com/apache/httpcomponents-client/tree/rel/v4.5.13
 [40] Source available at https://github.com/apache/httpcomponents-core/tree/rel/v4.4.15
-[41] Source available at https://github.com/apache/thrift/tree/0.14.2
+[41] Source available at https://github.com/apache/thrift/tree/0.23.0
 [42] Source available at https://source.android.com/
 [45] Source available at https://github.com/google/j2objc/releases/tag/1.3
 [47] Source available at https://github.com/dropwizard/metrics/releases/tag/v4.1.12.1

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <junit5.version>5.10.2</junit5.version>
     <assertj-core.version>3.27.7</assertj-core.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <libthrift.version>0.14.2</libthrift.version>
+    <libthrift.version>0.23.0</libthrift.version>
     <lombok.version>1.18.42</lombok.version>
     <log4j.version>2.23.1</log4j.version>
     <lz4-java.version>1.10.2</lz4-java.version>
@@ -415,6 +415,7 @@
         <artifactId>libthrift</artifactId>
         <version>${libthrift.version}</version>
         <exclusions>
+          <!-- Only TJSON/TMemory APIs are used; exclude HTTP/servlet transports and their transitives -->
           <exclusion>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
@@ -422,6 +423,26 @@
           <exclusion>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### Motivation

thrift contains CVE-2026-43869

### Changes

upgrade thrift to 0.23.0 to address CVE-2026-43869
