### PR TITLE
Issue 4795: docs: fix missing HTTP API endpoints in versioned admin REST API docs

### DIFF
--- a/site3/website/versioned_docs/version-4.14.8/admin/http.md
+++ b/site3/website/versioned_docs/version-4.14.8/admin/http.md
@@ -22,9 +22,9 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 * Description: Get heartbeat status for a specific bookie
 * Response: 
 
-| Code   | Description |
-|:-------|:------------|
-|200 | Successful operation |
+    | Code   | Description |
+    |:-------|:------------|
+    |200 | Successful operation |
 
 ## Config
 
@@ -234,6 +234,37 @@ Currently all the HTTP endpoints could be divided into these 5 components:
         }
         ```    
 
+### Endpoint: /api/v1/bookie/cluster_info
+1. Method: GET
+    * Description:  Get top-level info of this cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "auditorElected" : false,
+          "auditorId" : "",
+          "clusterUnderReplicated" : false,
+          "ledgerReplicationEnabled" : true,
+          "totalBookiesCount" : 1,
+          "writableBookiesCount" : 1,
+          "readonlyBookiesCount" : 0,
+          "unavailableBookiesCount" : 0
+        }
+        ```    
+   `clusterUnderReplicated` is true if there is any underreplicated ledger known currently. 
+    Trigger audit to increase precision. Audit might not be possible if `auditorElected` is false or
+    `ledgerReplicationEnabled` is false.
+
+   `totalBookiesCount` = `writableBookiesCount` + `readonlyBookiesCount` + `unavailableBookiesCount`.
+
+
 ### Endpoint: /api/v1/bookie/last_log_mark
 1. Method: GET
     * Description:  Get the last log marker.
@@ -373,8 +404,91 @@ Currently all the HTTP endpoints could be divided into these 5 components:
         |503 | Bookie is not ready |
    * Body: &lt;empty&gt;
 
+### Endpoint: /api/v1/bookie/state/readonly
+1. Method: GET
+    * Description: Get bookie readOnly state.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+       ```json
+       {
+          "readOnly" : false
+        }
+       ```
+
+2. Method: PUT
+    * Description: Set bookie readOnly state.
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+    * Parameters:
+
+      | Name | Type | Required | Description |
+      |:-----|:-----|:---------|:------------|
+      | readOnly | Boolean | Yes |  Whether bookie readOnly state. |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+
 
 ## Auto recovery
+
+### Endpoint: /api/v1/autorecovery/status?enabled=&lt;boolean&gt;
+1. Method: GET
+    * Description:  Get autorecovery enable status with cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+2. Method: PUT
+    * Description:  Set autorecovery enable status with cluster.
+    * Parameters:
+
+      | Name | Type | Required | Description                        |
+      |:-----|:---------|:-----------------------------------|:------------|
+      |enabled    | Boolean | Yes      | Whether autorecovery enable status |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "enabled": true
+        }
+        ```
 
 ### Endpoint: /api/v1/autorecovery/bookie/
 1. Method: PUT

--- a/site3/website/versioned_docs/version-4.15.5/admin/http.md
+++ b/site3/website/versioned_docs/version-4.15.5/admin/http.md
@@ -22,9 +22,9 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 * Description: Get heartbeat status for a specific bookie
 * Response: 
 
-| Code   | Description |
-|:-------|:------------|
-|200 | Successful operation |
+    | Code   | Description |
+    |:-------|:------------|
+    |200 | Successful operation |
 
 ## Config
 
@@ -234,6 +234,37 @@ Currently all the HTTP endpoints could be divided into these 5 components:
         }
         ```    
 
+### Endpoint: /api/v1/bookie/cluster_info
+1. Method: GET
+    * Description:  Get top-level info of this cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "auditorElected" : false,
+          "auditorId" : "",
+          "clusterUnderReplicated" : false,
+          "ledgerReplicationEnabled" : true,
+          "totalBookiesCount" : 1,
+          "writableBookiesCount" : 1,
+          "readonlyBookiesCount" : 0,
+          "unavailableBookiesCount" : 0
+        }
+        ```    
+   `clusterUnderReplicated` is true if there is any underreplicated ledger known currently. 
+    Trigger audit to increase precision. Audit might not be possible if `auditorElected` is false or
+    `ledgerReplicationEnabled` is false.
+
+   `totalBookiesCount` = `writableBookiesCount` + `readonlyBookiesCount` + `unavailableBookiesCount`.
+
+
 ### Endpoint: /api/v1/bookie/last_log_mark
 1. Method: GET
     * Description:  Get the last log marker.
@@ -373,8 +404,91 @@ Currently all the HTTP endpoints could be divided into these 5 components:
         |503 | Bookie is not ready |
    * Body: &lt;empty&gt;
 
+### Endpoint: /api/v1/bookie/state/readonly
+1. Method: GET
+    * Description: Get bookie readOnly state.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+       ```json
+       {
+          "readOnly" : false
+        }
+       ```
+
+2. Method: PUT
+    * Description: Set bookie readOnly state.
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+    * Parameters:
+
+      | Name | Type | Required | Description |
+      |:-----|:-----|:---------|:------------|
+      | readOnly | Boolean | Yes |  Whether bookie readOnly state. |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+
 
 ## Auto recovery
+
+### Endpoint: /api/v1/autorecovery/status?enabled=&lt;boolean&gt;
+1. Method: GET
+    * Description:  Get autorecovery enable status with cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+2. Method: PUT
+    * Description:  Set autorecovery enable status with cluster.
+    * Parameters:
+
+      | Name | Type | Required | Description                        |
+      |:-----|:---------|:-----------------------------------|:------------|
+      |enabled    | Boolean | Yes      | Whether autorecovery enable status |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "enabled": true
+        }
+        ```
 
 ### Endpoint: /api/v1/autorecovery/bookie/
 1. Method: PUT

--- a/site3/website/versioned_docs/version-4.16.7/admin/http.md
+++ b/site3/website/versioned_docs/version-4.16.7/admin/http.md
@@ -22,9 +22,9 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 * Description: Get heartbeat status for a specific bookie
 * Response: 
 
-| Code   | Description |
-|:-------|:------------|
-|200 | Successful operation |
+    | Code   | Description |
+    |:-------|:------------|
+    |200 | Successful operation |
 
 ## Config
 
@@ -240,7 +240,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -324,6 +324,11 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 ### Endpoint: /api/v1/bookie/gc
 1. Method: PUT
     * Description:  trigger gc for this bookie.
+    * Parameters:
+        | Name | Type | Required | Description |
+        |:-----|:-----|:---------|:------------|
+        |forceMajor  | Boolean | No | only trigger the forceMajor gc for this bookie. |
+        |forceMinor  | Boolean | No | only trigger the forceMinor gc for this bookie. |
     * Response:  
 
         | Code   | Description |
@@ -383,7 +388,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -393,7 +398,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -419,7 +424,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-                    |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -482,7 +487,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Parameters: 
 
       | Name | Type | Required | Description |
-              |:-----|:-----|:---------|:------------|
+      |:-----|:-----|:---------|:------------|
       |entryLocationRocksDBCompact  | String | Yes | Configuration name(key) |
       |entryLocations | String | no | entry location rocksDB path |
     * Body:
@@ -517,8 +522,91 @@ Currently all the HTTP endpoints could be divided into these 5 components:
        }
        ```
 
+### Endpoint: /api/v1/bookie/state/readonly
+1. Method: GET
+    * Description: Get bookie readOnly state.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+       ```json
+       {
+          "readOnly" : false
+        }
+       ```
+
+2. Method: PUT
+    * Description: Set bookie readOnly state.
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+    * Parameters:
+
+      | Name | Type | Required | Description |
+      |:-----|:-----|:---------|:------------|
+      | readOnly | Boolean | Yes |  Whether bookie readOnly state. |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+
 
 ## Auto recovery
+
+### Endpoint: /api/v1/autorecovery/status?enabled=&lt;boolean&gt;
+1. Method: GET
+    * Description:  Get autorecovery enable status with cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+2. Method: PUT
+    * Description:  Set autorecovery enable status with cluster.
+    * Parameters:
+
+      | Name | Type | Required | Description                        |
+      |:-----|:---------|:-----------------------------------|:------------|
+      |enabled    | Boolean | Yes      | Whether autorecovery enable status |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "enabled": true
+        }
+        ```
 
 ### Endpoint: /api/v1/autorecovery/bookie/
 1. Method: PUT

--- a/site3/website/versioned_docs/version-4.17.3/admin/http.md
+++ b/site3/website/versioned_docs/version-4.17.3/admin/http.md
@@ -22,9 +22,9 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 * Description: Get heartbeat status for a specific bookie
 * Response: 
 
-| Code   | Description |
-|:-------|:------------|
-|200 | Successful operation |
+    | Code   | Description |
+    |:-------|:------------|
+    |200 | Successful operation |
 
 ## Config
 
@@ -240,7 +240,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -324,6 +324,11 @@ Currently all the HTTP endpoints could be divided into these 5 components:
 ### Endpoint: /api/v1/bookie/gc
 1. Method: PUT
     * Description:  trigger gc for this bookie.
+    * Parameters:
+        | Name | Type | Required | Description |
+        |:-----|:-----|:---------|:------------|
+        |forceMajor  | Boolean | No | only trigger the forceMajor gc for this bookie. |
+        |forceMinor  | Boolean | No | only trigger the forceMinor gc for this bookie. |
     * Response:  
 
         | Code   | Description |
@@ -383,7 +388,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -393,7 +398,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-              |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -419,7 +424,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Response:
 
       | Code   | Description |
-                    |:-------|:------------|
+      |:-------|:------------|
       |200 | Successful operation |
       |403 | Permission denied |
       |404 | Not found |
@@ -482,7 +487,7 @@ Currently all the HTTP endpoints could be divided into these 5 components:
     * Parameters: 
 
       | Name | Type | Required | Description |
-              |:-----|:-----|:---------|:------------|
+      |:-----|:-----|:---------|:------------|
       |entryLocationRocksDBCompact  | String | Yes | Configuration name(key) |
       |entryLocations | String | no | entry location rocksDB path |
     * Body:
@@ -517,8 +522,91 @@ Currently all the HTTP endpoints could be divided into these 5 components:
        }
        ```
 
+### Endpoint: /api/v1/bookie/state/readonly
+1. Method: GET
+    * Description: Get bookie readOnly state.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+       ```json
+       {
+          "readOnly" : false
+        }
+       ```
+
+2. Method: PUT
+    * Description: Set bookie readOnly state.
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+    * Parameters:
+
+      | Name | Type | Required | Description |
+      |:-----|:-----|:---------|:------------|
+      | readOnly | Boolean | Yes |  Whether bookie readOnly state. |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "readOnly": true
+        }
+        ```
+
 
 ## Auto recovery
+
+### Endpoint: /api/v1/autorecovery/status?enabled=&lt;boolean&gt;
+1. Method: GET
+    * Description:  Get autorecovery enable status with cluster.
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Response Body format:
+
+        ```json
+        {
+          "enabled": true
+        }
+        ```
+
+2. Method: PUT
+    * Description:  Set autorecovery enable status with cluster.
+    * Parameters:
+
+      | Name | Type | Required | Description                        |
+      |:-----|:---------|:-----------------------------------|:------------|
+      |enabled    | Boolean | Yes      | Whether autorecovery enable status |
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |404 | Not found |
+    * Body:
+        ```json
+        {
+          "enabled": true
+        }
+        ```
 
 ### Endpoint: /api/v1/autorecovery/bookie/
 1. Method: PUT


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fix #4795

### Motivation

Several HTTP API endpoints implemented in `HttpRouter.java` were absent from the versioned admin REST API documentation pages (`site3/website/versioned_docs/version-*/admin/http.md`). Each version's doc was audited against its corresponding git tag to ensure only endpoints actually present in that release are documented.

### Changes

**version-4.14.8 and version-4.15.5** — added missing endpoints (verified against `release-4.14.8` / `release-4.15.5` tags):
- `/api/v1/bookie/cluster_info`
- `/api/v1/bookie/state/readonly` (GET + PUT)
- `/api/v1/autorecovery/status` (GET + PUT)

**version-4.16.7 and version-4.17.3** — added missing endpoints (verified against `release-4.16.7` / `release-4.17.3` tags):
- `/api/v1/bookie/state/readonly` (GET + PUT)
- `/api/v1/autorecovery/status` (GET + PUT)
- `forceMajor` / `forceMinor` optional parameters on `PUT /api/v1/bookie/gc`
- Fixed misaligned Markdown table separators

Note: `suspend_compaction`, `resume_compaction`, `sanity`, and `entry_location_compact` were intentionally **not** added to 4.14.8 / 4.15.5 — those endpoints did not exist in `HttpRouter.java` at those release tags.