### PR TITLE
Issue 4797:Prevent thread leak when BookKeeper client constructor fails

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -426,7 +426,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         boolean initialized = false;
         try {
             // initialize resources
-            this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
+            this.scheduler = OrderedScheduler.newSchedulerBuilder()
+                    .numThreads(1)
+                    .name("BookKeeperClientScheduler")
+                    .build();
             this.highPriorityTaskExecutor =
                     OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
             this.mainWorkerPool = OrderedExecutor.newBuilder()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -423,144 +423,140 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         this.internalConf = ClientInternalConf.fromConfigAndFeatureProvider(conf, this.featureProvider);
 
-        boolean initialized = false;
+        // initialize resources
+        this.scheduler = OrderedScheduler.newSchedulerBuilder()
+                .numThreads(1)
+                .name("BookKeeperClientScheduler")
+                .build();
+        this.highPriorityTaskExecutor =
+                OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
+        this.mainWorkerPool = OrderedExecutor.newBuilder()
+                .name("BookKeeperClientWorker")
+                .numThreads(conf.getNumWorkerThreads())
+                .statsLogger(rootStatsLogger)
+                .traceTaskExecution(conf.getEnableTaskExecutionStats())
+                .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
+                .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
+                .enableBusyWait(conf.isBusyWaitEnabled())
+                .build();
+
+        // initialize stats logger
+        this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
+        this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
+
+        // initialize metadata driver
         try {
-            // initialize resources
-            this.scheduler = OrderedScheduler.newSchedulerBuilder()
-                    .numThreads(1)
-                    .name("BookKeeperClientScheduler")
+            String metadataServiceUriStr = conf.getMetadataServiceUri();
+            if (null != metadataServiceUriStr) {
+                this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
+            } else {
+                checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
+                this.metadataDriver = MetadataDrivers.getClientDriver("zk");
+            }
+            this.metadataDriver.initialize(
+                conf,
+                highPriorityTaskExecutor,
+                rootStatsLogger,
+                Optional.ofNullable(zkc));
+        } catch (ConfigurationException ce) {
+            log.error()
+                    .exception(ce)
+                    .log("Failed to initialize metadata client driver using invalid metadata service uri");
+            closeQuietlyOnConstructorFailure();
+            throw new IOException("Failed to initialize metadata client driver", ce);
+        } catch (MetadataException me) {
+            log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
+            closeQuietlyOnConstructorFailure();
+            throw new IOException("Failed to initialize metadata client driver", me);
+        }
+
+        // initialize event loop group
+        if (null == eventLoopGroup) {
+            this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
+                    new DefaultThreadFactory("bookkeeper-io"));
+            this.ownEventLoopGroup = true;
+        } else {
+            this.eventLoopGroup = eventLoopGroup;
+            this.ownEventLoopGroup = false;
+        }
+
+        if (byteBufAllocator != null) {
+            this.allocator = byteBufAllocator;
+        } else {
+            this.allocator = ByteBufAllocatorBuilder.create()
+                    .poolingPolicy(conf.getAllocatorPoolingPolicy())
+                    .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
+                    .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
+                    .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
+                    .exitOnOutOfMemory(conf.exitOnOutOfMemory())
                     .build();
-            this.highPriorityTaskExecutor =
-                    OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
-            this.mainWorkerPool = OrderedExecutor.newBuilder()
-                    .name("BookKeeperClientWorker")
-                    .numThreads(conf.getNumWorkerThreads())
-                    .statsLogger(rootStatsLogger)
-                    .traceTaskExecution(conf.getEnableTaskExecutionStats())
-                    .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
-                    .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
-                    .enableBusyWait(conf.isBusyWaitEnabled())
-                    .build();
+        }
 
-            // initialize stats logger
-            this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
-            this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
+        if (null == requestTimer) {
+            this.requestTimer = new HashedWheelTimer(
+                    new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
+                    conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
+                    conf.getTimeoutTimerNumTicks());
+            this.ownTimer = true;
+        } else {
+            this.requestTimer = requestTimer;
+            this.ownTimer = false;
+        }
 
-            // initialize metadata driver
-            try {
-                String metadataServiceUriStr = conf.getMetadataServiceUri();
-                if (null != metadataServiceUriStr) {
-                    this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
-                } else {
-                    checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
-                    this.metadataDriver = MetadataDrivers.getClientDriver("zk");
-                }
-                this.metadataDriver.initialize(
-                    conf,
-                    highPriorityTaskExecutor,
-                    rootStatsLogger,
-                    Optional.ofNullable(zkc));
-            } catch (ConfigurationException ce) {
-                log.error()
-                        .exception(ce)
-                        .log("Failed to initialize metadata client driver using invalid metadata service uri");
-                throw new IOException("Failed to initialize metadata client driver", ce);
-            } catch (MetadataException me) {
-                log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
-                throw new IOException("Failed to initialize metadata client driver", me);
-            }
+        BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
+                ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
+                : new BookieAddressResolverDisabled();
+        if (dnsResolver != null) {
+            dnsResolver.setBookieAddressResolver(bookieAddressResolver);
+        }
+        // initialize the ensemble placement
+        this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
+                dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
 
-            // initialize event loop group
-            if (null == eventLoopGroup) {
-                this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
-                        new DefaultThreadFactory("bookkeeper-io"));
-                this.ownEventLoopGroup = true;
-            } else {
-                this.eventLoopGroup = eventLoopGroup;
-                this.ownEventLoopGroup = false;
-            }
+        this.bookieWatcher = new BookieWatcherImpl(
+                conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
+                this.statsLogger.scope(WATCHER_SCOPE));
 
-            if (byteBufAllocator != null) {
-                this.allocator = byteBufAllocator;
-            } else {
-                this.allocator = ByteBufAllocatorBuilder.create()
-                        .poolingPolicy(conf.getAllocatorPoolingPolicy())
-                        .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
-                        .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
-                        .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
-                        .exitOnOutOfMemory(conf.exitOnOutOfMemory())
-                        .build();
-            }
+        // initialize bookie client
+        this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
+                scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
 
-            if (null == requestTimer) {
-                this.requestTimer = new HashedWheelTimer(
-                        new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
-                        conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
-                        conf.getTimeoutTimerNumTicks());
-                this.ownTimer = true;
-            } else {
-                this.requestTimer = requestTimer;
-                this.ownTimer = false;
-            }
+        if (conf.getDiskWeightBasedPlacementEnabled()) {
+            log.info("Weighted ledger placement enabled");
+            ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
+                    .setNameFormat("BKClientMetaDataPollScheduler-%d");
+            this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
+            this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
+            this.bookieWatcher.initialBlockingBookieRead();
+            this.bookieInfoReader.start();
+        } else {
+            log.info("Weighted ledger placement is not enabled");
+            this.bookieInfoScheduler = null;
+            this.bookieInfoReader = new BookieInfoReader(this, conf, null);
+            this.bookieWatcher.initialBlockingBookieRead();
+        }
 
-            BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
-                    ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
-                    : new BookieAddressResolverDisabled();
-            if (dnsResolver != null) {
-                dnsResolver.setBookieAddressResolver(bookieAddressResolver);
-            }
-            // initialize the ensemble placement
-            this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
-                    dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
+        // initialize ledger manager
+        try {
+            this.ledgerManagerFactory =
+                this.metadataDriver.getLedgerManagerFactory();
+        } catch (MetadataException e) {
+            closeQuietlyOnConstructorFailure();
+            throw new IOException("Failed to initialize ledger manager factory", e);
+        }
+        this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
+        this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
 
-            this.bookieWatcher = new BookieWatcherImpl(
-                    conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
-                    this.statsLogger.scope(WATCHER_SCOPE));
+        this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
+        scheduleBookieHealthCheckIfEnabled(conf);
+    }
 
-            // initialize bookie client
-            this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
-                    scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
-
-            if (conf.getDiskWeightBasedPlacementEnabled()) {
-                log.info("Weighted ledger placement enabled");
-                ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
-                        .setNameFormat("BKClientMetaDataPollScheduler-%d");
-                this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
-                this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
-                this.bookieWatcher.initialBlockingBookieRead();
-                this.bookieInfoReader.start();
-            } else {
-                log.info("Weighted ledger placement is not enabled");
-                this.bookieInfoScheduler = null;
-                this.bookieInfoReader = new BookieInfoReader(this, conf, null);
-                this.bookieWatcher.initialBlockingBookieRead();
-            }
-
-            // initialize ledger manager
-            try {
-                this.ledgerManagerFactory =
-                    this.metadataDriver.getLedgerManagerFactory();
-            } catch (MetadataException e) {
-                throw new IOException("Failed to initialize ledger manager factory", e);
-            }
-            this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
-            this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
-
-            this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
-            scheduleBookieHealthCheckIfEnabled(conf);
-            initialized = true;
-        } finally {
-            if (!initialized) {
-                // Release everything we have allocated so far. Any exception raised by
-                // close() itself must NOT mask the original construction failure, so we
-                // log it and let the original throwable propagate.
-                try {
-                    close();
-                } catch (Throwable closeError) {
-                    log.error().exception(closeError)
-                            .log("Failed to release resources after BookKeeper construction error");
-                }
-            }
+    private void closeQuietlyOnConstructorFailure() {
+        try {
+            close();
+        } catch (Throwable closeError) {
+            log.error().exception(closeError)
+                    .log("Failed to release resources after BookKeeper construction error");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -423,127 +423,142 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         this.internalConf = ClientInternalConf.fromConfigAndFeatureProvider(conf, this.featureProvider);
 
-        // initialize resources
-        this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
-        this.highPriorityTaskExecutor =
-                OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
-        this.mainWorkerPool = OrderedExecutor.newBuilder()
-                .name("BookKeeperClientWorker")
-                .numThreads(conf.getNumWorkerThreads())
-                .statsLogger(rootStatsLogger)
-                .traceTaskExecution(conf.getEnableTaskExecutionStats())
-                .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
-                .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
-                .enableBusyWait(conf.isBusyWaitEnabled())
-                .build();
-
-        // initialize stats logger
-        this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
-        this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
-
-        // initialize metadata driver
+        boolean initialized = false;
         try {
-            String metadataServiceUriStr = conf.getMetadataServiceUri();
-            if (null != metadataServiceUriStr) {
-                this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
-            } else {
-                checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
-                this.metadataDriver = MetadataDrivers.getClientDriver("zk");
-            }
-            this.metadataDriver.initialize(
-                conf,
-                highPriorityTaskExecutor,
-                rootStatsLogger,
-                Optional.ofNullable(zkc));
-        } catch (ConfigurationException ce) {
-            log.error()
-                    .exception(ce)
-                    .log("Failed to initialize metadata client driver using invalid metadata service uri");
-            throw new IOException("Failed to initialize metadata client driver", ce);
-        } catch (MetadataException me) {
-            log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
-            throw new IOException("Failed to initialize metadata client driver", me);
-        }
-
-        // initialize event loop group
-        if (null == eventLoopGroup) {
-            this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
-                    new DefaultThreadFactory("bookkeeper-io"));
-            this.ownEventLoopGroup = true;
-        } else {
-            this.eventLoopGroup = eventLoopGroup;
-            this.ownEventLoopGroup = false;
-        }
-
-        if (byteBufAllocator != null) {
-            this.allocator = byteBufAllocator;
-        } else {
-            this.allocator = ByteBufAllocatorBuilder.create()
-                    .poolingPolicy(conf.getAllocatorPoolingPolicy())
-                    .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
-                    .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
-                    .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
-                    .exitOnOutOfMemory(conf.exitOnOutOfMemory())
+            // initialize resources
+            this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
+            this.highPriorityTaskExecutor =
+                    OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
+            this.mainWorkerPool = OrderedExecutor.newBuilder()
+                    .name("BookKeeperClientWorker")
+                    .numThreads(conf.getNumWorkerThreads())
+                    .statsLogger(rootStatsLogger)
+                    .traceTaskExecution(conf.getEnableTaskExecutionStats())
+                    .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
+                    .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
+                    .enableBusyWait(conf.isBusyWaitEnabled())
                     .build();
+
+            // initialize stats logger
+            this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
+            this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
+
+            // initialize metadata driver
+            try {
+                String metadataServiceUriStr = conf.getMetadataServiceUri();
+                if (null != metadataServiceUriStr) {
+                    this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
+                } else {
+                    checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
+                    this.metadataDriver = MetadataDrivers.getClientDriver("zk");
+                }
+                this.metadataDriver.initialize(
+                    conf,
+                    highPriorityTaskExecutor,
+                    rootStatsLogger,
+                    Optional.ofNullable(zkc));
+            } catch (ConfigurationException ce) {
+                log.error()
+                        .exception(ce)
+                        .log("Failed to initialize metadata client driver using invalid metadata service uri");
+                throw new IOException("Failed to initialize metadata client driver", ce);
+            } catch (MetadataException me) {
+                log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
+                throw new IOException("Failed to initialize metadata client driver", me);
+            }
+
+            // initialize event loop group
+            if (null == eventLoopGroup) {
+                this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
+                        new DefaultThreadFactory("bookkeeper-io"));
+                this.ownEventLoopGroup = true;
+            } else {
+                this.eventLoopGroup = eventLoopGroup;
+                this.ownEventLoopGroup = false;
+            }
+
+            if (byteBufAllocator != null) {
+                this.allocator = byteBufAllocator;
+            } else {
+                this.allocator = ByteBufAllocatorBuilder.create()
+                        .poolingPolicy(conf.getAllocatorPoolingPolicy())
+                        .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
+                        .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
+                        .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
+                        .exitOnOutOfMemory(conf.exitOnOutOfMemory())
+                        .build();
+            }
+
+            if (null == requestTimer) {
+                this.requestTimer = new HashedWheelTimer(
+                        new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
+                        conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
+                        conf.getTimeoutTimerNumTicks());
+                this.ownTimer = true;
+            } else {
+                this.requestTimer = requestTimer;
+                this.ownTimer = false;
+            }
+
+            BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
+                    ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
+                    : new BookieAddressResolverDisabled();
+            if (dnsResolver != null) {
+                dnsResolver.setBookieAddressResolver(bookieAddressResolver);
+            }
+            // initialize the ensemble placement
+            this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
+                    dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
+
+            this.bookieWatcher = new BookieWatcherImpl(
+                    conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
+                    this.statsLogger.scope(WATCHER_SCOPE));
+
+            // initialize bookie client
+            this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
+                    scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
+
+            if (conf.getDiskWeightBasedPlacementEnabled()) {
+                log.info("Weighted ledger placement enabled");
+                ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
+                        .setNameFormat("BKClientMetaDataPollScheduler-%d");
+                this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
+                this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
+                this.bookieWatcher.initialBlockingBookieRead();
+                this.bookieInfoReader.start();
+            } else {
+                log.info("Weighted ledger placement is not enabled");
+                this.bookieInfoScheduler = null;
+                this.bookieInfoReader = new BookieInfoReader(this, conf, null);
+                this.bookieWatcher.initialBlockingBookieRead();
+            }
+
+            // initialize ledger manager
+            try {
+                this.ledgerManagerFactory =
+                    this.metadataDriver.getLedgerManagerFactory();
+            } catch (MetadataException e) {
+                throw new IOException("Failed to initialize ledger manager factory", e);
+            }
+            this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
+            this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
+
+            this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
+            scheduleBookieHealthCheckIfEnabled(conf);
+            initialized = true;
+        } finally {
+            if (!initialized) {
+                // Release everything we have allocated so far. Any exception raised by
+                // close() itself must NOT mask the original construction failure, so we
+                // log it and let the original throwable propagate.
+                try {
+                    close();
+                } catch (Throwable closeError) {
+                    log.error().exception(closeError)
+                            .log("Failed to release resources after BookKeeper construction error");
+                }
+            }
         }
-
-
-        if (null == requestTimer) {
-            this.requestTimer = new HashedWheelTimer(
-                    new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
-                    conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
-                    conf.getTimeoutTimerNumTicks());
-            this.ownTimer = true;
-        } else {
-            this.requestTimer = requestTimer;
-            this.ownTimer = false;
-        }
-
-        BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
-                ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
-                : new BookieAddressResolverDisabled();
-        if (dnsResolver != null) {
-            dnsResolver.setBookieAddressResolver(bookieAddressResolver);
-        }
-        // initialize the ensemble placement
-        this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
-                dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
-
-        this.bookieWatcher = new BookieWatcherImpl(
-                conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
-                this.statsLogger.scope(WATCHER_SCOPE));
-
-        // initialize bookie client
-        this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
-                scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
-
-        if (conf.getDiskWeightBasedPlacementEnabled()) {
-            log.info("Weighted ledger placement enabled");
-            ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
-                    .setNameFormat("BKClientMetaDataPollScheduler-%d");
-            this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
-            this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
-            this.bookieWatcher.initialBlockingBookieRead();
-            this.bookieInfoReader.start();
-        } else {
-            log.info("Weighted ledger placement is not enabled");
-            this.bookieInfoScheduler = null;
-            this.bookieInfoReader = new BookieInfoReader(this, conf, null);
-            this.bookieWatcher.initialBlockingBookieRead();
-        }
-
-        // initialize ledger manager
-        try {
-            this.ledgerManagerFactory =
-                this.metadataDriver.getLedgerManagerFactory();
-        } catch (MetadataException e) {
-            throw new IOException("Failed to initialize ledger manager factory", e);
-        }
-        this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
-        this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
-
-        this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
-        scheduleBookieHealthCheckIfEnabled(conf);
     }
 
     /**
@@ -1520,32 +1535,44 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         // Close bookie client so all pending bookie requests would be failed
         // which will reject any incoming bookie requests.
-        bookieClient.close();
+        if (bookieClient != null) {
+            bookieClient.close();
+        }
         try {
             // Close ledger manage so all pending metadata requests would be failed
             // which will reject any incoming metadata requests.
-            ledgerManager.close();
-            ledgerIdGenerator.close();
+            if (ledgerManager != null) {
+                ledgerManager.close();
+            }
+            if (ledgerIdGenerator != null) {
+                ledgerIdGenerator.close();
+            }
         } catch (IOException ie) {
             log.error().exception(ie).log("Failed to close ledger manager");
         }
 
         // Close the scheduler
-        scheduler.shutdown();
-        if (!scheduler.awaitTermination(10, TimeUnit.SECONDS)) {
-            log.warn("The scheduler did not shutdown cleanly");
+        if (scheduler != null) {
+            scheduler.shutdown();
+            if (!scheduler.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("The scheduler did not shutdown cleanly");
+            }
         }
 
         // Close the watchTask scheduler
-        highPriorityTaskExecutor.shutdown();
-        if (!highPriorityTaskExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
-            log.warn("The highPriorityTaskExecutor for WatchTask did not shutdown cleanly, interrupting");
-            highPriorityTaskExecutor.shutdownNow();
+        if (highPriorityTaskExecutor != null) {
+            highPriorityTaskExecutor.shutdown();
+            if (!highPriorityTaskExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("The highPriorityTaskExecutor for WatchTask did not shutdown cleanly, interrupting");
+                highPriorityTaskExecutor.shutdownNow();
+            }
         }
 
-        mainWorkerPool.shutdown();
-        if (!mainWorkerPool.awaitTermination(10, TimeUnit.SECONDS)) {
-            log.warn("The mainWorkerPool did not shutdown cleanly");
+        if (mainWorkerPool != null) {
+            mainWorkerPool.shutdown();
+            if (!mainWorkerPool.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("The mainWorkerPool did not shutdown cleanly");
+            }
         }
         if (this.bookieInfoScheduler != null) {
             this.bookieInfoScheduler.shutdown();
@@ -1554,13 +1581,15 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             }
         }
 
-        if (ownTimer) {
+        if (ownTimer && requestTimer != null) {
             requestTimer.stop();
         }
-        if (ownEventLoopGroup) {
+        if (ownEventLoopGroup && eventLoopGroup != null) {
             eventLoopGroup.shutdownGracefully();
         }
-        this.metadataDriver.close();
+        if (metadataDriver != null) {
+            this.metadataDriver.close();
+        }
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -424,10 +424,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         this.internalConf = ClientInternalConf.fromConfigAndFeatureProvider(conf, this.featureProvider);
 
         // initialize resources
-        this.scheduler = OrderedScheduler.newSchedulerBuilder()
-                .numThreads(1)
-                .name("BookKeeperClientScheduler")
-                .build();
+        this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
         this.highPriorityTaskExecutor =
                 OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
         this.mainWorkerPool = OrderedExecutor.newBuilder()
@@ -462,11 +459,11 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             log.error()
                     .exception(ce)
                     .log("Failed to initialize metadata client driver using invalid metadata service uri");
-            closeQuietlyOnConstructorFailure();
+            close();
             throw new IOException("Failed to initialize metadata client driver", ce);
         } catch (MetadataException me) {
             log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
-            closeQuietlyOnConstructorFailure();
+            close();
             throw new IOException("Failed to initialize metadata client driver", me);
         }
 
@@ -541,7 +538,7 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
             this.ledgerManagerFactory =
                 this.metadataDriver.getLedgerManagerFactory();
         } catch (MetadataException e) {
-            closeQuietlyOnConstructorFailure();
+            close();
             throw new IOException("Failed to initialize ledger manager factory", e);
         }
         this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
@@ -549,15 +546,6 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
         scheduleBookieHealthCheckIfEnabled(conf);
-    }
-
-    private void closeQuietlyOnConstructorFailure() {
-        try {
-            close();
-        } catch (Throwable closeError) {
-            log.error().exception(closeError)
-                    .log("Failed to release resources after BookKeeper construction error");
-        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -423,129 +423,144 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
 
         this.internalConf = ClientInternalConf.fromConfigAndFeatureProvider(conf, this.featureProvider);
 
-        // initialize resources
-        this.scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
-        this.highPriorityTaskExecutor =
-                OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
-        this.mainWorkerPool = OrderedExecutor.newBuilder()
-                .name("BookKeeperClientWorker")
-                .numThreads(conf.getNumWorkerThreads())
-                .statsLogger(rootStatsLogger)
-                .traceTaskExecution(conf.getEnableTaskExecutionStats())
-                .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
-                .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
-                .enableBusyWait(conf.isBusyWaitEnabled())
-                .build();
-
-        // initialize stats logger
-        this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
-        this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
-
-        // initialize metadata driver
+        boolean initialized = false;
         try {
-            String metadataServiceUriStr = conf.getMetadataServiceUri();
-            if (null != metadataServiceUriStr) {
-                this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
-            } else {
-                checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
-                this.metadataDriver = MetadataDrivers.getClientDriver("zk");
-            }
-            this.metadataDriver.initialize(
-                conf,
-                highPriorityTaskExecutor,
-                rootStatsLogger,
-                Optional.ofNullable(zkc));
-        } catch (ConfigurationException ce) {
-            log.error()
-                    .exception(ce)
-                    .log("Failed to initialize metadata client driver using invalid metadata service uri");
-            close();
-            throw new IOException("Failed to initialize metadata client driver", ce);
-        } catch (MetadataException me) {
-            log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
-            close();
-            throw new IOException("Failed to initialize metadata client driver", me);
-        }
-
-        // initialize event loop group
-        if (null == eventLoopGroup) {
-            this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
-                    new DefaultThreadFactory("bookkeeper-io"));
-            this.ownEventLoopGroup = true;
-        } else {
-            this.eventLoopGroup = eventLoopGroup;
-            this.ownEventLoopGroup = false;
-        }
-
-        if (byteBufAllocator != null) {
-            this.allocator = byteBufAllocator;
-        } else {
-            this.allocator = ByteBufAllocatorBuilder.create()
-                    .poolingPolicy(conf.getAllocatorPoolingPolicy())
-                    .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
-                    .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
-                    .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
-                    .exitOnOutOfMemory(conf.exitOnOutOfMemory())
+            // initialize resources
+            this.scheduler =
+                    OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperClientScheduler").build();
+            this.highPriorityTaskExecutor =
+                    OrderedScheduler.newSchedulerBuilder().numThreads(1).name("BookKeeperHighPriorityThread").build();
+            this.mainWorkerPool = OrderedExecutor.newBuilder()
+                    .name("BookKeeperClientWorker")
+                    .numThreads(conf.getNumWorkerThreads())
+                    .statsLogger(rootStatsLogger)
+                    .traceTaskExecution(conf.getEnableTaskExecutionStats())
+                    .preserveMdcForTaskExecution(conf.getPreserveMdcForTaskExecution())
+                    .traceTaskWarnTimeMicroSec(conf.getTaskExecutionWarnTimeMicros())
+                    .enableBusyWait(conf.isBusyWaitEnabled())
                     .build();
+
+            // initialize stats logger
+            this.statsLogger = rootStatsLogger.scope(BookKeeperClientStats.CLIENT_SCOPE);
+            this.clientStats = BookKeeperClientStats.newInstance(this.statsLogger);
+
+            // initialize metadata driver
+            try {
+                String metadataServiceUriStr = conf.getMetadataServiceUri();
+                if (null != metadataServiceUriStr) {
+                    this.metadataDriver = MetadataDrivers.getClientDriver(URI.create(metadataServiceUriStr));
+                } else {
+                    checkNotNull(zkc, "No external zookeeper provided when no metadata service uri is found");
+                    this.metadataDriver = MetadataDrivers.getClientDriver("zk");
+                }
+                this.metadataDriver.initialize(
+                    conf,
+                    highPriorityTaskExecutor,
+                    rootStatsLogger,
+                    Optional.ofNullable(zkc));
+            } catch (ConfigurationException ce) {
+                log.error()
+                        .exception(ce)
+                        .log("Failed to initialize metadata client driver using invalid metadata service uri");
+                throw new IOException("Failed to initialize metadata client driver", ce);
+            } catch (MetadataException me) {
+                log.error().exception(me).log("Encountered metadata exceptions on initializing metadata client driver");
+                throw new IOException("Failed to initialize metadata client driver", me);
+            }
+
+            // initialize event loop group
+            if (null == eventLoopGroup) {
+                this.eventLoopGroup = EventLoopUtil.getClientEventLoopGroup(conf,
+                        new DefaultThreadFactory("bookkeeper-io"));
+                this.ownEventLoopGroup = true;
+            } else {
+                this.eventLoopGroup = eventLoopGroup;
+                this.ownEventLoopGroup = false;
+            }
+
+            if (byteBufAllocator != null) {
+                this.allocator = byteBufAllocator;
+            } else {
+                this.allocator = ByteBufAllocatorBuilder.create()
+                        .poolingPolicy(conf.getAllocatorPoolingPolicy())
+                        .poolingConcurrency(conf.getAllocatorPoolingConcurrency())
+                        .outOfMemoryPolicy(conf.getAllocatorOutOfMemoryPolicy())
+                        .leakDetectionPolicy(conf.getAllocatorLeakDetectionPolicy())
+                        .exitOnOutOfMemory(conf.exitOnOutOfMemory())
+                        .build();
+            }
+
+            if (null == requestTimer) {
+                this.requestTimer = new HashedWheelTimer(
+                        new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
+                        conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
+                        conf.getTimeoutTimerNumTicks());
+                this.ownTimer = true;
+            } else {
+                this.requestTimer = requestTimer;
+                this.ownTimer = false;
+            }
+
+            BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
+                    ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
+                    : new BookieAddressResolverDisabled();
+            if (dnsResolver != null) {
+                dnsResolver.setBookieAddressResolver(bookieAddressResolver);
+            }
+            // initialize the ensemble placement
+            this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
+                    dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
+
+            this.bookieWatcher = new BookieWatcherImpl(
+                    conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
+                    this.statsLogger.scope(WATCHER_SCOPE));
+
+            // initialize bookie client
+            this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
+                    scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
+
+            if (conf.getDiskWeightBasedPlacementEnabled()) {
+                log.info("Weighted ledger placement enabled");
+                ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
+                        .setNameFormat("BKClientMetaDataPollScheduler-%d");
+                this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
+                this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
+                this.bookieWatcher.initialBlockingBookieRead();
+                this.bookieInfoReader.start();
+            } else {
+                log.info("Weighted ledger placement is not enabled");
+                this.bookieInfoScheduler = null;
+                this.bookieInfoReader = new BookieInfoReader(this, conf, null);
+                this.bookieWatcher.initialBlockingBookieRead();
+            }
+
+            // initialize ledger manager
+            try {
+                this.ledgerManagerFactory =
+                    this.metadataDriver.getLedgerManagerFactory();
+            } catch (MetadataException e) {
+                throw new IOException("Failed to initialize ledger manager factory", e);
+            }
+            this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
+            this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
+
+            this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
+            scheduleBookieHealthCheckIfEnabled(conf);
+            initialized = true;
+        } finally {
+            if (!initialized) {
+                try {
+                    close();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.warn().exception(ie)
+                            .log("Interrupted while closing partially-initialized BookKeeper client");
+                } catch (Throwable t) {
+                    log.warn().exception(t)
+                            .log("Failed to close partially-initialized BookKeeper client");
+                }
+            }
         }
-
-        if (null == requestTimer) {
-            this.requestTimer = new HashedWheelTimer(
-                    new ThreadFactoryBuilder().setNameFormat("BookieClientTimer-%d").build(),
-                    conf.getTimeoutTimerTickDurationMs(), TimeUnit.MILLISECONDS,
-                    conf.getTimeoutTimerNumTicks());
-            this.ownTimer = true;
-        } else {
-            this.requestTimer = requestTimer;
-            this.ownTimer = false;
-        }
-
-        BookieAddressResolver bookieAddressResolver = conf.getBookieAddressResolverEnabled()
-                ? new DefaultBookieAddressResolver(metadataDriver.getRegistrationClient())
-                : new BookieAddressResolverDisabled();
-        if (dnsResolver != null) {
-            dnsResolver.setBookieAddressResolver(bookieAddressResolver);
-        }
-        // initialize the ensemble placement
-        this.placementPolicy = initializeEnsemblePlacementPolicy(conf,
-                dnsResolver, this.requestTimer, this.featureProvider, this.statsLogger, bookieAddressResolver);
-
-        this.bookieWatcher = new BookieWatcherImpl(
-                conf, this.placementPolicy, metadataDriver.getRegistrationClient(), bookieAddressResolver,
-                this.statsLogger.scope(WATCHER_SCOPE));
-
-        // initialize bookie client
-        this.bookieClient = new BookieClientImpl(conf, this.eventLoopGroup, this.allocator, this.mainWorkerPool,
-                scheduler, rootStatsLogger, this.bookieWatcher.getBookieAddressResolver());
-
-        if (conf.getDiskWeightBasedPlacementEnabled()) {
-            log.info("Weighted ledger placement enabled");
-            ThreadFactoryBuilder tFBuilder = new ThreadFactoryBuilder()
-                    .setNameFormat("BKClientMetaDataPollScheduler-%d");
-            this.bookieInfoScheduler = Executors.newSingleThreadScheduledExecutor(tFBuilder.build());
-            this.bookieInfoReader = new BookieInfoReader(this, conf, this.bookieInfoScheduler);
-            this.bookieWatcher.initialBlockingBookieRead();
-            this.bookieInfoReader.start();
-        } else {
-            log.info("Weighted ledger placement is not enabled");
-            this.bookieInfoScheduler = null;
-            this.bookieInfoReader = new BookieInfoReader(this, conf, null);
-            this.bookieWatcher.initialBlockingBookieRead();
-        }
-
-        // initialize ledger manager
-        try {
-            this.ledgerManagerFactory =
-                this.metadataDriver.getLedgerManagerFactory();
-        } catch (MetadataException e) {
-            close();
-            throw new IOException("Failed to initialize ledger manager factory", e);
-        }
-        this.ledgerManager = new CleanupLedgerManager(ledgerManagerFactory.newLedgerManager());
-        this.ledgerIdGenerator = ledgerManagerFactory.newLedgerIdGenerator();
-
-        this.bookieQuarantineRatio = conf.getBookieQuarantineRatio();
-        scheduleBookieHealthCheckIfEnabled(conf);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
@@ -143,7 +143,7 @@ public class BookKeeperConstructorFailureTest {
         }
         return counts;
     }
-    
+
     private static String matchPrefix(String name) {
         if (name == null) {
             return null;
@@ -153,7 +153,7 @@ public class BookKeeperConstructorFailureTest {
                 .findFirst()
                 .orElse(null);
     }
-    
+
     private static boolean hasLeak(Map<String, Integer> counts) {
         for (Integer v : counts.values()) {
             if (v != null && v > 0) {
@@ -162,7 +162,7 @@ public class BookKeeperConstructorFailureTest {
         }
         return false;
     }
-    
+
     private static void waitForThreadShutdown(ThreadGroup group, long timeoutMs)
             throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
@@ -20,14 +20,9 @@
  */
 package org.apache.bookkeeper.client;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -36,113 +31,81 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Verifies that the {@link BookKeeper} client constructor releases every
- * resource it has already allocated when initialization fails part-way
- * through (e.g. the metadata service URI is invalid or unreachable).
+ * Verifies that when {@link BookKeeper} construction fails at metadata-driver
+ * initialization, the {@link org.apache.bookkeeper.common.util.OrderedExecutor}
+ * pools allocated before that point are released and do not accumulate across
+ * repeated failing {@code build()} calls.
  *
- * <p>Before the fix, a failing {@code BookKeeper.forConfig(conf).build()}
- * leaked the worker pools it had just created
- * ({@code BookKeeperClientScheduler}, {@code BookKeeperClientWorker-*},
- * {@code BookKeeperHighPriorityThread}, and
- * {@code BKClientMetaDataPollScheduler-*} when disk-weight is enabled),
- * along with the underlying bookie / metadata sockets. Repeatedly catching
- * the construction exception in user code therefore leaked threads
- * monotonically and eventually exhausted the JVM.
+ * <p>This test targets the <em>early-failure</em> path (an unreachable
+ * ZooKeeper URI), which is the most common production misconfiguration and the
+ * historical source of thread leaks. It does not cover resources allocated after
+ * the metadata driver (e.g. {@code eventLoopGroup}, {@code requestTimer},
+ * {@code bookieInfoScheduler}); those code paths require a reachable ZK and are
+ * exercised by {@link BookKeeperCloseTest} together with the construction
+ * cleanup logic in {@link BookKeeper}.
  *
- * <p>The test does not need a real bookie cluster: it deliberately points the
- * client at an invalid metadata service URI so initialization fails <i>after</i>
- * the worker pools have been allocated but <i>before</i> the metadata driver
- * is up. That is the exact failure path which used to leak resources.
- *
- * <p><b>Why this test counts threads by prefix instead of diffing name sets:</b>
- * {@link org.apache.bookkeeper.common.util.OrderedExecutor} names its threads
- * {@code <baseName>-OrderedScheduler-<i>-<n>}, and the {@code <n>} counter
- * resets every time a new pool is built. Two separate failed {@code build()}
- * calls therefore produce threads with <i>identical</i> names. A
- * {@code Set<String>} would silently dedupe them and miss the leak; a
- * per-prefix count does not.
+ * <p>Every {@code build()} attempt runs inside a dedicated {@link ThreadGroup}
+ * and only threads living in that group are counted, so concurrently executing
+ * tests in the same JVM cannot pollute the result.
  */
 public class BookKeeperConstructorFailureTest {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(BookKeeperConstructorFailureTest.class);
 
-    /**
-     * An invalid metadata service URI scheme. {@code MetadataDrivers#getClientDriver(URI)}
-     * fails to resolve any driver for it and throws, exercising the failure path
-     * <i>after</i> the worker pools / bookie client have been created but
-     * <i>before</i> the metadata client driver is initialized — the original
-     * leak path.
-     */
-    private static final String INVALID_METADATA_URI = "zk+null://127.0.0.1:1/ledgers";
+    private static final String UNREACHABLE_METADATA_URI = "zk://127.0.0.1:1/ledgers";
 
     /**
-     * Thread-name prefixes the BookKeeper client constructor creates. If
-     * {@code close()} runs correctly on the failure path, none of these may
-     * outlive the failed construction.
+     * Thread-name prefixes of the three OrderedExecutor pools that BookKeeper allocates
+     * <em>before</em> {@code metadataDriver.initialize(...)}. With an unreachable ZK URI,
+     * construction fails inside that call, so only these three pools can possibly leak
+     * on this code path.
      */
     private static final String[] CLIENT_THREAD_PREFIXES = new String[] {
         "BookKeeperClientScheduler",
         "BookKeeperClientWorker",
         "BookKeeperHighPriorityThread",
-        "BKClientMetaDataPollScheduler",
     };
 
-    /**
-     * A single failing {@code build()} must not leak any client-owned thread.
-     */
-    @Test
-    public void testNoThreadLeakWhenMetadataServiceUnavailable() throws Exception {
-        Map<String, Integer> baseline = snapshotClientThreadCounts();
-        LOG.info("baseline thread counts: {}", baseline);
+    private static final int FAILED_BUILD_ITERATIONS = 5;
 
-        ClientConfiguration conf = newFailingClientConf();
-        try {
-            BookKeeper.forConfig(conf).build();
-            fail("BookKeeper construction should have failed");
-        } catch (Exception expected) {
-            LOG.info("expected failure during BookKeeper construction: {}", expected.toString());
-        }
+    private static final long THREAD_SHUTDOWN_TIMEOUT_MS = 5_000L;
 
-        waitForThreadShutdown(baseline, 10_000L);
-
-        Map<String, Integer> leak = computeLeak(baseline, snapshotClientThreadCounts());
-        assertTrue("BookKeeper constructor leaked threads after failure: " + leak,
-                leak.isEmpty());
-    }
-
-    /**
-     * Repeated failing {@code build()} calls must not accumulate threads.
-     * Without the fix, each iteration leaked ~3 threads, so even a small
-     * loop is enough to make the leak unambiguous.
-     */
+    /** Repeated failing {@code build()} calls must not accumulate worker-pool threads. */
     @Test
     public void testRepeatedFailedBuildsDoNotAccumulateThreads() throws Exception {
-        Map<String, Integer> baseline = snapshotClientThreadCounts();
-        LOG.info("baseline thread counts: {}", baseline);
+        ThreadGroup group = new ThreadGroup("bk-ctor-failure-test");
+        runFailingBuildsIn(group);
+        waitForThreadShutdown(group, THREAD_SHUTDOWN_TIMEOUT_MS);
 
-        ClientConfiguration conf = newFailingClientConf();
-        final int iterations = 20;
-        for (int i = 0; i < iterations; i++) {
-            try {
-                BookKeeper.forConfig(conf).build();
-                fail("BookKeeper construction should have failed at iteration " + i);
-            } catch (Exception expected) {
-                LOG.debug("iteration {} failed as expected: {}", i, expected.toString());
-            }
+        Map<String, Integer> leak = snapshotClientThreadCounts(group);
+        if (hasLeak(leak)) {
+            LOG.error("Thread leak detected after {} failed build()s in group {}: {}",
+                    FAILED_BUILD_ITERATIONS, group.getName(), leak);
+            fail("BookKeeper constructor leaked threads after " + FAILED_BUILD_ITERATIONS
+                    + " failed build()s in group " + group.getName() + ": " + leak);
         }
+    }
 
-        waitForThreadShutdown(baseline, 30_000L);
-
-        Map<String, Integer> current = snapshotClientThreadCounts();
-        Map<String, Integer> leak = computeLeak(baseline, current);
-        if (!leak.isEmpty()) {
-            LOG.error("Thread leak detected after {} failed build()s. baseline={}, current={}, leak={}",
-                    iterations, baseline, current, leak);
-            fail("BookKeeper constructor leaked threads after " + iterations
-                    + " failed build()s. baseline=" + baseline
-                    + ", current=" + current
-                    + ", leak=" + leak);
+    private static void runFailingBuildsIn(ThreadGroup group) throws InterruptedException {
+        ClientConfiguration conf = newFailingClientConf();
+        Throwable[] driverError = new Throwable[1];
+        Thread driver = new Thread(group, () -> {
+            for (int i = 0; i < FAILED_BUILD_ITERATIONS; i++) {
+                try {
+                    BookKeeper.forConfig(conf).build();
+                    driverError[0] = new AssertionError(
+                            "BookKeeper construction should have failed at iteration " + i);
+                    return;
+                } catch (Exception expected) {
+                    LOG.debug("iteration {} failed as expected: {}", i, expected.toString());
+                }
+            }
+        }, "bk-ctor-failure-driver");
+        driver.start();
+        driver.join();
+        if (driverError[0] instanceof AssertionError) {
+            throw (AssertionError) driverError[0];
         }
     }
 
@@ -150,43 +113,37 @@ public class BookKeeperConstructorFailureTest {
 
     private static ClientConfiguration newFailingClientConf() {
         ClientConfiguration conf = new ClientConfiguration();
-        conf.setMetadataServiceUri(INVALID_METADATA_URI);
+        conf.setMetadataServiceUri(UNREACHABLE_METADATA_URI);
         conf.setZkTimeout(1000);
-        conf.setClientConnectTimeoutMillis(1000);
+        conf.setZkRetryBackoffMaxRetries(0);
         return conf;
     }
 
-    /**
-     * Returns a count of currently-live threads, grouped by the
-     * {@link #CLIENT_THREAD_PREFIXES} entry they originated from.
-     *
-     * <p>Counting (not name-set diffing) is required because OrderedExecutor
-     * resets its per-pool name counter every {@code build()}, so two separate
-     * leaked schedulers can share an identical thread name.
-     */
-    private static Map<String, Integer> snapshotClientThreadCounts() {
-        ThreadMXBean mx = ManagementFactory.getThreadMXBean();
-        ThreadInfo[] infos = mx.getThreadInfo(mx.getAllThreadIds(), 0);
+    /** Returns the live-thread counts inside {@code group} grouped by {@link #CLIENT_THREAD_PREFIXES}. */
+    private static Map<String, Integer> snapshotClientThreadCounts(ThreadGroup group) {
+        Thread[] threads = new Thread[Math.max(16, group.activeCount() * 2)];
+        int n;
+        // Loop to handle the race where a thread starts between activeCount() and enumerate().
+        while ((n = group.enumerate(threads, true)) == threads.length) {
+            threads = new Thread[threads.length * 2];
+        }
         Map<String, Integer> counts = new TreeMap<>();
         for (String prefix : CLIENT_THREAD_PREFIXES) {
             counts.put(prefix, 0);
         }
-        for (ThreadInfo info : infos) {
-            if (info == null) {
+        for (int i = 0; i < n; i++) {
+            Thread t = threads[i];
+            if (t == null || !t.isAlive()) {
                 continue;
             }
-            String prefix = matchPrefix(info.getThreadName());
+            String prefix = matchPrefix(t.getName());
             if (prefix != null) {
                 counts.merge(prefix, 1, Integer::sum);
             }
         }
         return counts;
     }
-
-    /**
-     * Returns the {@link #CLIENT_THREAD_PREFIXES} entry the given thread name
-     * starts with, or {@code null} if it is not a BookKeeper-client thread.
-     */
+    
     private static String matchPrefix(String name) {
         if (name == null) {
             return null;
@@ -196,35 +153,24 @@ public class BookKeeperConstructorFailureTest {
                 .findFirst()
                 .orElse(null);
     }
-
-    /**
-     * Computes per-prefix leakage: {@code current[prefix] - baseline[prefix]}
-     * for any prefix where the result is positive. An empty map means no leak.
-     */
-    private static Map<String, Integer> computeLeak(Map<String, Integer> baseline,
-                                                    Map<String, Integer> current) {
-        Map<String, Integer> leak = new LinkedHashMap<>();
-        for (String prefix : CLIENT_THREAD_PREFIXES) {
-            int delta = current.getOrDefault(prefix, 0) - baseline.getOrDefault(prefix, 0);
-            if (delta > 0) {
-                leak.put(prefix, delta);
+    
+    private static boolean hasLeak(Map<String, Integer> counts) {
+        for (Integer v : counts.values()) {
+            if (v != null && v > 0) {
+                return true;
             }
         }
-        return leak;
+        return false;
     }
-
-    /**
-     * Polls per-prefix live thread counts, waiting until none exceeds the
-     * baseline, or until {@code timeoutMs} elapses.
-     */
-    private static void waitForThreadShutdown(Map<String, Integer> baseline, long timeoutMs)
+    
+    private static void waitForThreadShutdown(ThreadGroup group, long timeoutMs)
             throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline) {
-            if (computeLeak(baseline, snapshotClientThreadCounts()).isEmpty()) {
+            if (!hasLeak(snapshotClientThreadCounts(group))) {
                 return;
             }
-            Thread.sleep(100);
+            Thread.sleep(50);
         }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookKeeperConstructorFailureTest.java
@@ -1,0 +1,230 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies that the {@link BookKeeper} client constructor releases every
+ * resource it has already allocated when initialization fails part-way
+ * through (e.g. the metadata service URI is invalid or unreachable).
+ *
+ * <p>Before the fix, a failing {@code BookKeeper.forConfig(conf).build()}
+ * leaked the worker pools it had just created
+ * ({@code BookKeeperClientScheduler}, {@code BookKeeperClientWorker-*},
+ * {@code BookKeeperHighPriorityThread}, and
+ * {@code BKClientMetaDataPollScheduler-*} when disk-weight is enabled),
+ * along with the underlying bookie / metadata sockets. Repeatedly catching
+ * the construction exception in user code therefore leaked threads
+ * monotonically and eventually exhausted the JVM.
+ *
+ * <p>The test does not need a real bookie cluster: it deliberately points the
+ * client at an invalid metadata service URI so initialization fails <i>after</i>
+ * the worker pools have been allocated but <i>before</i> the metadata driver
+ * is up. That is the exact failure path which used to leak resources.
+ *
+ * <p><b>Why this test counts threads by prefix instead of diffing name sets:</b>
+ * {@link org.apache.bookkeeper.common.util.OrderedExecutor} names its threads
+ * {@code <baseName>-OrderedScheduler-<i>-<n>}, and the {@code <n>} counter
+ * resets every time a new pool is built. Two separate failed {@code build()}
+ * calls therefore produce threads with <i>identical</i> names. A
+ * {@code Set<String>} would silently dedupe them and miss the leak; a
+ * per-prefix count does not.
+ */
+public class BookKeeperConstructorFailureTest {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(BookKeeperConstructorFailureTest.class);
+
+    /**
+     * An invalid metadata service URI scheme. {@code MetadataDrivers#getClientDriver(URI)}
+     * fails to resolve any driver for it and throws, exercising the failure path
+     * <i>after</i> the worker pools / bookie client have been created but
+     * <i>before</i> the metadata client driver is initialized — the original
+     * leak path.
+     */
+    private static final String INVALID_METADATA_URI = "zk+null://127.0.0.1:1/ledgers";
+
+    /**
+     * Thread-name prefixes the BookKeeper client constructor creates. If
+     * {@code close()} runs correctly on the failure path, none of these may
+     * outlive the failed construction.
+     */
+    private static final String[] CLIENT_THREAD_PREFIXES = new String[] {
+        "BookKeeperClientScheduler",
+        "BookKeeperClientWorker",
+        "BookKeeperHighPriorityThread",
+        "BKClientMetaDataPollScheduler",
+    };
+
+    /**
+     * A single failing {@code build()} must not leak any client-owned thread.
+     */
+    @Test
+    public void testNoThreadLeakWhenMetadataServiceUnavailable() throws Exception {
+        Map<String, Integer> baseline = snapshotClientThreadCounts();
+        LOG.info("baseline thread counts: {}", baseline);
+
+        ClientConfiguration conf = newFailingClientConf();
+        try {
+            BookKeeper.forConfig(conf).build();
+            fail("BookKeeper construction should have failed");
+        } catch (Exception expected) {
+            LOG.info("expected failure during BookKeeper construction: {}", expected.toString());
+        }
+
+        waitForThreadShutdown(baseline, 10_000L);
+
+        Map<String, Integer> leak = computeLeak(baseline, snapshotClientThreadCounts());
+        assertTrue("BookKeeper constructor leaked threads after failure: " + leak,
+                leak.isEmpty());
+    }
+
+    /**
+     * Repeated failing {@code build()} calls must not accumulate threads.
+     * Without the fix, each iteration leaked ~3 threads, so even a small
+     * loop is enough to make the leak unambiguous.
+     */
+    @Test
+    public void testRepeatedFailedBuildsDoNotAccumulateThreads() throws Exception {
+        Map<String, Integer> baseline = snapshotClientThreadCounts();
+        LOG.info("baseline thread counts: {}", baseline);
+
+        ClientConfiguration conf = newFailingClientConf();
+        final int iterations = 20;
+        for (int i = 0; i < iterations; i++) {
+            try {
+                BookKeeper.forConfig(conf).build();
+                fail("BookKeeper construction should have failed at iteration " + i);
+            } catch (Exception expected) {
+                LOG.debug("iteration {} failed as expected: {}", i, expected.toString());
+            }
+        }
+
+        waitForThreadShutdown(baseline, 30_000L);
+
+        Map<String, Integer> current = snapshotClientThreadCounts();
+        Map<String, Integer> leak = computeLeak(baseline, current);
+        if (!leak.isEmpty()) {
+            LOG.error("Thread leak detected after {} failed build()s. baseline={}, current={}, leak={}",
+                    iterations, baseline, current, leak);
+            fail("BookKeeper constructor leaked threads after " + iterations
+                    + " failed build()s. baseline=" + baseline
+                    + ", current=" + current
+                    + ", leak=" + leak);
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static ClientConfiguration newFailingClientConf() {
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setMetadataServiceUri(INVALID_METADATA_URI);
+        conf.setZkTimeout(1000);
+        conf.setClientConnectTimeoutMillis(1000);
+        return conf;
+    }
+
+    /**
+     * Returns a count of currently-live threads, grouped by the
+     * {@link #CLIENT_THREAD_PREFIXES} entry they originated from.
+     *
+     * <p>Counting (not name-set diffing) is required because OrderedExecutor
+     * resets its per-pool name counter every {@code build()}, so two separate
+     * leaked schedulers can share an identical thread name.
+     */
+    private static Map<String, Integer> snapshotClientThreadCounts() {
+        ThreadMXBean mx = ManagementFactory.getThreadMXBean();
+        ThreadInfo[] infos = mx.getThreadInfo(mx.getAllThreadIds(), 0);
+        Map<String, Integer> counts = new TreeMap<>();
+        for (String prefix : CLIENT_THREAD_PREFIXES) {
+            counts.put(prefix, 0);
+        }
+        for (ThreadInfo info : infos) {
+            if (info == null) {
+                continue;
+            }
+            String prefix = matchPrefix(info.getThreadName());
+            if (prefix != null) {
+                counts.merge(prefix, 1, Integer::sum);
+            }
+        }
+        return counts;
+    }
+
+    /**
+     * Returns the {@link #CLIENT_THREAD_PREFIXES} entry the given thread name
+     * starts with, or {@code null} if it is not a BookKeeper-client thread.
+     */
+    private static String matchPrefix(String name) {
+        if (name == null) {
+            return null;
+        }
+        return Arrays.stream(CLIENT_THREAD_PREFIXES)
+                .filter(name::startsWith)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Computes per-prefix leakage: {@code current[prefix] - baseline[prefix]}
+     * for any prefix where the result is positive. An empty map means no leak.
+     */
+    private static Map<String, Integer> computeLeak(Map<String, Integer> baseline,
+                                                    Map<String, Integer> current) {
+        Map<String, Integer> leak = new LinkedHashMap<>();
+        for (String prefix : CLIENT_THREAD_PREFIXES) {
+            int delta = current.getOrDefault(prefix, 0) - baseline.getOrDefault(prefix, 0);
+            if (delta > 0) {
+                leak.put(prefix, delta);
+            }
+        }
+        return leak;
+    }
+
+    /**
+     * Polls per-prefix live thread counts, waiting until none exceeds the
+     * baseline, or until {@code timeoutMs} elapses.
+     */
+    private static void waitForThreadShutdown(Map<String, Integer> baseline, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (computeLeak(baseline, snapshotClientThreadCounts()).isEmpty()) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+    }
+}


### PR DESCRIPTION

Descriptions of the changes in this PR:

Fix #4797

### Motivation

When `BookKeeper.forConfig(conf).build()` fails part-way through construction
(for example because `metadataServiceUri` points to an unreachable or invalid
ZooKeeper ensemble, or `MetadataDrivers#getClientDriver(URI)` cannot resolve
a driver for the configured scheme), the constructor leaks every resource it
has already allocated up to the point of failure.

### Changes

- In the `BookKeeper` constructor, when initialization fails *after* the
  worker pools have been created but *before* the object is
  fully constructed, invoke `close()` on the partially-initialized instance
  so that all already-allocated resources are
  shut down before the exception is propagated to the caller.

- Add `BookKeeperConstructorFailureTest` under
  `bookkeeper-server/src/test/java/org/apache/bookkeeper/client/` covering
  the regression:
  - `testRepeatedFailedBuildsDoNotAccumulateThreads` — 5 consecutive
    failing `build()` calls must not accumulate threads.