### PR TITLE
Upgrade Netty to 4.2.14

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -217,18 +217,18 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [64]
-- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-compression-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.2.13.Final.jar [11]
-- lib/io.netty-netty-common-4.2.13.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-compression-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.2.14.Final.jar [11]
+- lib/io.netty-netty-common-4.2.14.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.14.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.2.14.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.14.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.2.14.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -236,14 +236,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -353,7 +353,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.14.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -397,9 +397,9 @@ Apache Software License, Version 2.
 [62] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [64] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.14.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -408,7 +408,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -416,7 +416,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -424,7 +424,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -432,7 +432,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -442,7 +442,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -450,7 +450,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -459,7 +459,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -467,7 +467,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -475,7 +475,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -483,7 +483,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -491,7 +491,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -499,7 +499,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -507,7 +507,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -515,7 +515,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -524,7 +524,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -532,7 +532,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -540,7 +540,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -548,7 +548,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -556,7 +556,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -564,7 +564,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -572,7 +572,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -580,7 +580,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -588,7 +588,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -596,7 +596,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -605,7 +605,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -613,7 +613,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-bkctl.bin.txt
@@ -217,11 +217,11 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [59]
-- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
-- lib/io.netty-netty-common-4.2.13.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar [11]
+- lib/io.netty-netty-common-4.2.14.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.14.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.14.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -229,14 +229,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar [11]
 - lib/org.apache.logging.log4j-log4j-api-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-core-2.23.1.jar [16]
 - lib/org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar [16]
@@ -286,7 +286,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.14.Final
 [16] Source available at https://github.com/apache/logging-log4j2/tree/rel/2.23.1
 [18] Source available at https://github.com/apache/commons-collections/tree/collections-4.1
 [19] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
@@ -315,9 +315,9 @@ Apache Software License, Version 2.
 [57] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [59] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.14.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -326,7 +326,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -334,7 +334,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -342,7 +342,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -350,7 +350,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -360,7 +360,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -368,7 +368,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -377,7 +377,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -385,7 +385,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -393,7 +393,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -401,7 +401,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -409,7 +409,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -417,7 +417,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -425,7 +425,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -433,7 +433,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -442,7 +442,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -450,7 +450,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -458,7 +458,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -466,7 +466,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -474,7 +474,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -482,7 +482,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -490,7 +490,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -498,7 +498,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -506,7 +506,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -514,7 +514,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -523,7 +523,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -531,7 +531,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -217,18 +217,18 @@ Apache Software License, Version 2.
 - lib/commons-io-commons-io-2.19.0.jar [8]
 - lib/commons-logging-commons-logging-1.3.5.jar [10]
 - lib/io.github.merlimat.slog-slog-0.9.9.jar [63]
-- lib/io.netty-netty-buffer-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-compression-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-dns-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-http-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-http2-4.2.13.Final.jar [11]
-- lib/io.netty-netty-codec-socks-4.2.13.Final.jar [11]
-- lib/io.netty-netty-common-4.2.13.Final.jar [11]
-- lib/io.netty-netty-handler-4.2.13.Final.jar [11]
-- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar [11]
-- lib/io.netty-netty-resolver-4.2.13.Final.jar [11]
-- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar [11]
+- lib/io.netty-netty-buffer-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-compression-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-dns-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-http-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-http2-4.2.14.Final.jar [11]
+- lib/io.netty-netty-codec-socks-4.2.14.Final.jar [11]
+- lib/io.netty-netty-common-4.2.14.Final.jar [11]
+- lib/io.netty-netty-handler-4.2.14.Final.jar [11]
+- lib/io.netty-netty-handler-proxy-4.2.14.Final.jar [11]
+- lib/io.netty-netty-resolver-4.2.14.Final.jar [11]
+- lib/io.netty-netty-resolver-dns-4.2.14.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -236,14 +236,14 @@ Apache Software License, Version 2.
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar [11]
-- lib/io.netty-netty-transport-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar [11]
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar [11]
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar [11]
+- lib/io.netty-netty-transport-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar [11]
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar [11]
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar [11]
 - lib/io.prometheus-simpleclient-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_common-0.15.0.jar [12]
 - lib/io.prometheus-simpleclient_hotspot-0.15.0.jar [12]
@@ -349,7 +349,7 @@ Apache Software License, Version 2.
 [8] Source available at https://github.com/apache/commons-io/tree/rel/commons-io-2.19.0
 [9] Source available at https://github.com/apache/commons-lang/tree/LANG_2_6
 [10] Source available at https://github.com/apache/commons-logging/tree/commons-logging-1.3.5
-[11] Source available at https://github.com/netty/netty/tree/netty-4.2.13.Final
+[11] Source available at https://github.com/netty/netty/tree/netty-4.2.14.Final
 [12] Source available at https://github.com/prometheus/client_java/tree/parent-0.15.0
 [13] Source available at https://github.com/vert-x3/vertx-auth/tree/4.3.2
 [14] Source available at https://github.com/vert-x3/vertx-bridge-common/tree/4.3.2
@@ -393,9 +393,9 @@ Apache Software License, Version 2.
 [61] Source available at https://github.com/apache/commons-beanutils/tree/rel/commons-beanutils-1.11.0
 [63] Source available at https://github.com/merlimat/slog/tree/v0.9.9
 ------------------------------------------------------------------------------------
-lib/io.netty-netty-codec-base-4.2.13.Final.jar bundles some 3rd party dependencies
+lib/io.netty-netty-codec-base-4.2.14.Final.jar bundles some 3rd party dependencies
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the extensions to Java Collections Framework which has
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
@@ -404,7 +404,7 @@ been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of Robert Harder's Public Domain
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
@@ -412,7 +412,7 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Webbit', an event based
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
@@ -420,7 +420,7 @@ WebSocket and HTTP server, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'SLF4J', a simple logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
@@ -428,7 +428,7 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Harmony', an open source
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
@@ -438,7 +438,7 @@ Java SE, which can be obtained at:
   * HOMEPAGE:
     * http://archive.apache.org/dist/harmony/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
@@ -446,7 +446,7 @@ and decompression library written by Matthew J. Francis. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'libdivsufsort', a C API library to construct
 the suffix array and the Burrows-Wheeler transformed string for any input string of
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
@@ -455,7 +455,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of Nitsan Wakart's 'JCTools',
 Java Concurrency Tools for the JVM, which can be obtained at:
 
   * LICENSE:
@@ -463,7 +463,7 @@ Java Concurrency Tools for the JVM, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
@@ -471,7 +471,7 @@ pure Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Compress-LZF', a Java library for encoding and
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
@@ -479,7 +479,7 @@ decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/ning/compress
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lz4-java', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
@@ -487,7 +487,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/yawkat/lz4-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
@@ -495,7 +495,7 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
@@ -503,7 +503,7 @@ and decompression library written by William Kinney. It can be obtained at:
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of and optionally depends on 'Protocol Buffers',
 Google's data interchange format, which can be obtained at:
 
   * LICENSE:
@@ -511,7 +511,7 @@ Google's data interchange format, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
@@ -520,7 +520,7 @@ equivalent functionality.  It can be obtained at:
   * HOMEPAGE:
     * http://www.bouncycastle.org/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Snappy', a compression library produced
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
@@ -528,7 +528,7 @@ by Google Inc, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/snappy
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
@@ -536,7 +536,7 @@ serialization API, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Caliper', Google's micro-
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
@@ -544,7 +544,7 @@ benchmarking framework, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/google/caliper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Commons Logging', a logging
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
@@ -552,7 +552,7 @@ framework, which can be obtained at:
   * HOMEPAGE:
     * http://commons.apache.org/logging/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
@@ -560,7 +560,7 @@ can be obtained at:
   * HOMEPAGE:
     * http://logging.apache.org/log4j/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
+lib/io.netty-netty-codec-base-4.2.14.Final.jar optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
@@ -568,7 +568,7 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
@@ -576,7 +576,7 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
@@ -584,7 +584,7 @@ the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified version of 'HPACK', a Java implementation of
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
@@ -592,7 +592,7 @@ the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
@@ -601,7 +601,7 @@ provides utilities for the java.lang API, which can be obtained at:
     * https://commons.apache.org/proper/commons-lang/
 
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the Maven wrapper scripts from 'Maven Wrapper',
 that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
@@ -609,7 +609,7 @@ that provides an easy way to ensure a user has everything necessary to run the M
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-lib/io.netty-netty-codec-base-4.2.13.Final.jar contains the dnsinfo.h header file,
+lib/io.netty-netty-codec-base-4.2.14.Final.jar contains the dnsinfo.h header file,
 that provides a way to retrieve the system DNS configuration on MacOS.
 This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).

--- a/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-all.bin.txt
@@ -23,18 +23,18 @@ LongAdder), which was released with the following comments:
     http://creativecommons.org/publicdomain/zero/1.0/
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.13.Final.jar
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar
-- lib/io.netty-netty-codec-compression-4.2.13.Final.jar
-- lib/io.netty-netty-codec-dns-4.2.13.Final.jar
-- lib/io.netty-netty-codec-http-4.2.13.Final.jar
-- lib/io.netty-netty-codec-http2-4.2.13.Final.jar
-- lib/io.netty-netty-codec-socks-4.2.13.Final.jar
-- lib/io.netty-netty-common-4.2.13.Final.jar
-- lib/io.netty-netty-handler-4.2.13.Final.jar
-- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar
-- lib/io.netty-netty-resolver-4.2.13.Final.jar
-- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar
+- lib/io.netty-netty-buffer-4.2.14.Final.jar
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar
+- lib/io.netty-netty-codec-compression-4.2.14.Final.jar
+- lib/io.netty-netty-codec-dns-4.2.14.Final.jar
+- lib/io.netty-netty-codec-http-4.2.14.Final.jar
+- lib/io.netty-netty-codec-http2-4.2.14.Final.jar
+- lib/io.netty-netty-codec-socks-4.2.14.Final.jar
+- lib/io.netty-netty-common-4.2.14.Final.jar
+- lib/io.netty-netty-handler-4.2.14.Final.jar
+- lib/io.netty-netty-handler-proxy-4.2.14.Final.jar
+- lib/io.netty-netty-resolver-4.2.14.Final.jar
+- lib/io.netty-netty-resolver-dns-4.2.14.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -42,14 +42,14 @@ LongAdder), which was released with the following comments:
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
-- lib/io.netty-netty-transport-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
+- lib/io.netty-netty-transport-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-bkctl.bin.txt
@@ -5,11 +5,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.13.Final.jar
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar
-- lib/io.netty-netty-common-4.2.13.Final.jar
-- lib/io.netty-netty-handler-4.2.13.Final.jar
-- lib/io.netty-netty-resolver-4.2.13.Final.jar
+- lib/io.netty-netty-buffer-4.2.14.Final.jar
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar
+- lib/io.netty-netty-common-4.2.14.Final.jar
+- lib/io.netty-netty-handler-4.2.14.Final.jar
+- lib/io.netty-netty-resolver-4.2.14.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -17,14 +17,14 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
-- lib/io.netty-netty-transport-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
+- lib/io.netty-netty-transport-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar
 
 
                             The Netty Project

--- a/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/NOTICE-server.bin.txt
@@ -5,18 +5,18 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------------
-- lib/io.netty-netty-buffer-4.2.13.Final.jar
-- lib/io.netty-netty-codec-base-4.2.13.Final.jar
-- lib/io.netty-netty-codec-compression-4.2.13.Final.jar
-- lib/io.netty-netty-codec-dns-4.2.13.Final.jar
-- lib/io.netty-netty-codec-http-4.2.13.Final.jar
-- lib/io.netty-netty-codec-http2-4.2.13.Final.jar
-- lib/io.netty-netty-codec-socks-4.2.13.Final.jar
-- lib/io.netty-netty-common-4.2.13.Final.jar
-- lib/io.netty-netty-handler-4.2.13.Final.jar
-- lib/io.netty-netty-handler-proxy-4.2.13.Final.jar
-- lib/io.netty-netty-resolver-4.2.13.Final.jar
-- lib/io.netty-netty-resolver-dns-4.2.13.Final.jar
+- lib/io.netty-netty-buffer-4.2.14.Final.jar
+- lib/io.netty-netty-codec-base-4.2.14.Final.jar
+- lib/io.netty-netty-codec-compression-4.2.14.Final.jar
+- lib/io.netty-netty-codec-dns-4.2.14.Final.jar
+- lib/io.netty-netty-codec-http-4.2.14.Final.jar
+- lib/io.netty-netty-codec-http2-4.2.14.Final.jar
+- lib/io.netty-netty-codec-socks-4.2.14.Final.jar
+- lib/io.netty-netty-common-4.2.14.Final.jar
+- lib/io.netty-netty-handler-4.2.14.Final.jar
+- lib/io.netty-netty-handler-proxy-4.2.14.Final.jar
+- lib/io.netty-netty-resolver-4.2.14.Final.jar
+- lib/io.netty-netty-resolver-dns-4.2.14.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar [11]
@@ -24,14 +24,14 @@ The Apache Software Foundation (http://www.apache.org/).
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar [11]
 - lib/io.netty-netty-tcnative-classes-2.0.77.Final.jar
-- lib/io.netty-netty-transport-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-epoll-4.2.13.Final.jar
-- lib/io.netty-netty-transport-classes-io_uring-4.2.13.Final.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-epoll-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-x86_64.jar
-- lib/io.netty-netty-transport-native-io_uring-4.2.13.Final-linux-aarch_64.jar
-- lib/io.netty-netty-transport-native-unix-common-4.2.13.Final.jar
+- lib/io.netty-netty-transport-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-epoll-4.2.14.Final.jar
+- lib/io.netty-netty-transport-classes-io_uring-4.2.14.Final.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-epoll-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar
+- lib/io.netty-netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar
+- lib/io.netty-netty-transport-native-unix-common-4.2.14.Final.jar
 
 
                             The Netty Project

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <log4j.version>2.23.1</log4j.version>
     <lz4-java.version>1.10.2</lz4-java.version>
     <mockito.version>4.11.0</mockito.version>
-    <netty.version>4.2.13.Final</netty.version>
+    <netty.version>4.2.14.Final</netty.version>
     <prometheus.version>0.15.0</prometheus.version>
     <datasketches.version>7.0.1</datasketches.version>
     <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
### Motivation

Netty 4.2.14 contains some bug fixes and improvements.
* [Netty 4.2.14 release notes](https://netty.io/news/2026/05/20/4-2-14-Final.html)

### Changes

- upgrade Netty to 4.2.14