### PR TITLE
Issue 4800: Reuse metadata driver for over-replicated ledger GC

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -363,6 +363,7 @@ public class BookieImpl implements Bookie {
 
         if (null == ledgerStorage) {
             ledgerStorage = BookieResources.createLedgerStorage(conf, null,
+                                                                null,
                                                                 ledgerDirsManager,
                                                                 indexDirsManager,
                                                                 statsLogger,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieResources.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieResources.java
@@ -28,6 +28,7 @@ import org.apache.bookkeeper.common.allocator.ByteBufAllocatorBuilder;
 import org.apache.bookkeeper.common.allocator.ByteBufAllocatorWithOomHandler;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.MetadataBookieDriver;
 import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.exceptions.MetadataException;
@@ -95,6 +96,7 @@ public class BookieResources {
 
     public static LedgerStorage createLedgerStorage(ServerConfiguration conf,
                                                     LedgerManager ledgerManager,
+                                                    LedgerManagerFactory ledgerManagerFactory,
                                                     LedgerDirsManager ledgerDirsManager,
                                                     LedgerDirsManager indexDirsManager,
                                                     StatsLogger statsLogger,
@@ -104,6 +106,7 @@ public class BookieResources {
         log.info().attr("ledgerStorageClass", ledgerStorageClass).log("Using ledger storage");
         LedgerStorage storage = LedgerStorageFactory.createLedgerStorage(ledgerStorageClass);
 
+        storage.setLedgerManagerFactory(ledgerManagerFactory);
         storage.initialize(conf, ledgerManager, ledgerDirsManager, indexDirsManager, statsLogger, allocator);
         storage.setCheckpointSource(CheckpointSource.DEFAULT);
         return storage;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -49,6 +49,7 @@ import org.apache.bookkeeper.bookie.storage.ldb.PersistentEntryLogMetadataMap;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableLong;
@@ -147,7 +148,17 @@ public class GarbageCollectorThread implements Runnable {
                                   final CompactableLedgerStorage ledgerStorage,
                                   EntryLogger entryLogger,
                                   StatsLogger statsLogger) throws IOException {
-        this(conf, ledgerManager, ledgerDirsManager, ledgerStorage, entryLogger, statsLogger, newExecutor());
+        this(conf, ledgerManager, null, ledgerDirsManager, ledgerStorage, entryLogger, statsLogger, newExecutor());
+    }
+
+    public GarbageCollectorThread(ServerConfiguration conf, LedgerManager ledgerManager,
+                                  LedgerManagerFactory ledgerManagerFactory,
+                                  final LedgerDirsManager ledgerDirsManager,
+                                  final CompactableLedgerStorage ledgerStorage,
+                                  EntryLogger entryLogger,
+                                  StatsLogger statsLogger) throws IOException {
+        this(conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, ledgerStorage, entryLogger, statsLogger,
+                newExecutor());
     }
 
     @VisibleForTesting
@@ -170,6 +181,18 @@ public class GarbageCollectorThread implements Runnable {
                                   StatsLogger statsLogger,
                                   ScheduledExecutorService gcExecutor)
         throws IOException {
+        this(conf, ledgerManager, null, ledgerDirsManager, ledgerStorage, entryLogger, statsLogger, gcExecutor);
+    }
+
+    public GarbageCollectorThread(ServerConfiguration conf,
+                                  LedgerManager ledgerManager,
+                                  LedgerManagerFactory ledgerManagerFactory,
+                                  final LedgerDirsManager ledgerDirsManager,
+                                  final CompactableLedgerStorage ledgerStorage,
+                                  EntryLogger entryLogger,
+                                  StatsLogger statsLogger,
+                                  ScheduledExecutorService gcExecutor)
+        throws IOException {
         this.gcExecutor = gcExecutor;
         this.conf = conf;
 
@@ -184,7 +207,8 @@ public class GarbageCollectorThread implements Runnable {
         this.totalEntryLogSize = 0L;
         this.entryLogCompactRatio = 0.0;
         this.currentEntryLogUsageBuckets = new int[ENTRY_LOG_USAGE_SEGMENT_COUNT];
-        this.garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, ledgerStorage, conf, statsLogger);
+        this.garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, ledgerStorage,
+                ledgerManagerFactory, conf, statsLogger);
         this.gcStats = new GarbageCollectorStats(
             statsLogger,
             () -> numActiveEntryLogs,
@@ -818,11 +842,6 @@ public class GarbageCollectorThread implements Runnable {
             entryLogMetaMap.close();
         } catch (Exception e) {
             log.warn().exception(e).log("Failed to close entryLog metadata-map");
-        }
-        try {
-            garbageCollector.closeMetadataDriver();
-        } catch (Exception e) {
-            log.warn().exception(e).log("Failed to close garbage collector metadata resources");
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -819,6 +819,11 @@ public class GarbageCollectorThread implements Runnable {
         } catch (Exception e) {
             log.warn().exception(e).log("Failed to close entryLog metadata-map");
         }
+        try {
+            garbageCollector.close();
+        } catch (Exception e) {
+            log.warn().exception(e).log("Failed to close garbage collector metadata resources");
+        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -820,7 +820,7 @@ public class GarbageCollectorThread implements Runnable {
             log.warn().exception(e).log("Failed to close entryLog metadata-map");
         }
         try {
-            garbageCollector.close();
+            garbageCollector.closeMetadataDriver();
         } catch (Exception e) {
             log.warn().exception(e).log("Failed to close garbage collector metadata resources");
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -62,6 +62,7 @@ import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
@@ -100,6 +101,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     // contain any active ledgers in them; and compacts the entry logs that
     // has lower remaining percentage to reclaim disk space.
     GarbageCollectorThread gcThread;
+    private LedgerManagerFactory ledgerManagerFactory;
 
     // this indicates that a write has happened since the last flush
     private final AtomicBoolean somethingWritten = new AtomicBoolean(false);
@@ -164,6 +166,11 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     public void setStateManager(StateManager stateManager) {}
 
     @Override
+    public void setLedgerManagerFactory(LedgerManagerFactory ledgerManagerFactory) {
+        this.ledgerManagerFactory = ledgerManagerFactory;
+    }
+
+    @Override
     public void setCheckpointSource(CheckpointSource checkpointSource) {
         this.checkpointSource = checkpointSource;
     }
@@ -185,7 +192,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         this.entryLogger.addListener(this);
         ledgerCache = new LedgerCacheImpl(conf, activeLedgers,
                 null == indexDirsManager ? ledgerDirsManager : indexDirsManager, statsLogger);
-        gcThread = new GarbageCollectorThread(conf, ledgerManager, ledgerDirsManager,
+        gcThread = new GarbageCollectorThread(conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager,
                                               this, entryLogger, statsLogger.scope("gc"));
         ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
         // Expose Stats

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -36,6 +36,7 @@ import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.stats.StatsLogger;
 
 /**
@@ -59,6 +60,7 @@ public interface LedgerStorage {
             throws IOException;
 
     void setStateManager(StateManager stateManager);
+    default void setLedgerManagerFactory(LedgerManagerFactory ledgerManagerFactory) {}
     void setCheckpointSource(CheckpointSource checkpointSource);
     void setCheckpointer(Checkpointer checkpointer);
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -70,7 +70,7 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
  * </p>
  */
 @CustomLog
-public class ScanAndCompareGarbageCollector implements GarbageCollector {
+public class ScanAndCompareGarbageCollector implements GarbageCollector, AutoCloseable {
 
     private final LedgerManager ledgerManager;
     private final CompactableLedgerStorage ledgerStorage;
@@ -84,6 +84,8 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private StatsLogger statsLogger;
     private final int maxConcurrentRequests;
     private final RateLimiter gcMetadataOpRateLimiter;
+    private MetadataBookieDriver metadataDriver;
+    private LedgerManagerFactory metadataLedgerManagerFactory;
 
     public ScanAndCompareGarbageCollector(LedgerManager ledgerManager, CompactableLedgerStorage ledgerStorage,
             ServerConfiguration conf, StatsLogger statsLogger) throws IOException {
@@ -235,13 +237,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         final Set<Long> overReplicatedLedgers = Sets.newHashSet();
         final Semaphore semaphore = new Semaphore(this.maxConcurrentRequests);
         final CountDownLatch latch = new CountDownLatch(bkActiveledgers.size());
-        // instantiate zookeeper client to initialize ledger manager
-
-        @Cleanup
-        MetadataBookieDriver metadataDriver = instantiateMetadataDriver(conf, statsLogger);
-
-        @Cleanup
-        LedgerManagerFactory lmf = metadataDriver.getLedgerManagerFactory();
+        LedgerManagerFactory lmf = getOrCreateMetadataLedgerManagerFactory();
 
         @Cleanup
         LedgerUnderreplicationManager lum = lmf.newLedgerUnderreplicationManager();
@@ -324,6 +320,22 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         return overReplicatedLedgers;
     }
 
+    private synchronized LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory() throws BookieException {
+        if (metadataLedgerManagerFactory != null) {
+            return metadataLedgerManagerFactory;
+        }
+
+        metadataDriver = instantiateMetadataDriver(conf, statsLogger);
+        try {
+            metadataLedgerManagerFactory = metadataDriver.getLedgerManagerFactory();
+        } catch (MetadataException me) {
+            closeMetadataDriver();
+            throw new BookieException.MetadataStoreException(
+                    "Failed to initialize ledger manager factory for over-replicated ledger GC", me);
+        }
+        return metadataLedgerManagerFactory;
+    }
+
     private static MetadataBookieDriver instantiateMetadataDriver(ServerConfiguration conf, StatsLogger statsLogger)
             throws BookieException {
         try {
@@ -337,6 +349,24 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             throw new BookieException.MetadataStoreException("Failed to initialize metadata bookie driver", me);
         } catch (ConfigurationException e) {
             throw new BookieException.BookieIllegalOpException(e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        closeMetadataDriver();
+    }
+
+    private void closeMetadataDriver() {
+        metadataLedgerManagerFactory = null;
+        if (metadataDriver != null) {
+            try {
+                metadataDriver.close();
+            } catch (Exception e) {
+                log.warn().exception(e).log("Failed to close metadata driver used for over-replicated ledger GC");
+            } finally {
+                metadataDriver = null;
+            }
         }
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -26,7 +26,6 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.RateLimiter;
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.Set;
@@ -47,13 +46,9 @@ import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
-import org.apache.bookkeeper.meta.MetadataBookieDriver;
-import org.apache.bookkeeper.meta.MetadataDrivers;
-import org.apache.bookkeeper.meta.exceptions.MetadataException;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.versioning.Versioned;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 
 /**
  * Garbage collector implementation using scan and compare.
@@ -81,18 +76,22 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
     private long lastOverReplicatedLedgerGcTimeMillis;
     private final boolean verifyMetadataOnGc;
     private int activeLedgerCounter;
-    private StatsLogger statsLogger;
     private final int maxConcurrentRequests;
     private final RateLimiter gcMetadataOpRateLimiter;
-    private MetadataBookieDriver metadataDriver;
-    private LedgerManagerFactory metadataLedgerManagerFactory;
+    private final LedgerManagerFactory ledgerManagerFactory;
 
     public ScanAndCompareGarbageCollector(LedgerManager ledgerManager, CompactableLedgerStorage ledgerStorage,
             ServerConfiguration conf, StatsLogger statsLogger) throws IOException {
+        this(ledgerManager, ledgerStorage, null, conf, statsLogger);
+    }
+
+    public ScanAndCompareGarbageCollector(LedgerManager ledgerManager, CompactableLedgerStorage ledgerStorage,
+            LedgerManagerFactory ledgerManagerFactory, ServerConfiguration conf, StatsLogger statsLogger)
+            throws IOException {
         this.ledgerManager = ledgerManager;
         this.ledgerStorage = ledgerStorage;
+        this.ledgerManagerFactory = ledgerManagerFactory;
         this.conf = conf;
-        this.statsLogger = statsLogger;
         this.selfBookieAddress = BookieImpl.getBookieId(conf);
 
         this.gcOverReplicatedLedgerIntervalMillis = conf.getGcOverreplicatedLedgerWaitTimeMillis();
@@ -237,10 +236,13 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         final Set<Long> overReplicatedLedgers = Sets.newHashSet();
         final Semaphore semaphore = new Semaphore(this.maxConcurrentRequests);
         final CountDownLatch latch = new CountDownLatch(bkActiveledgers.size());
-        LedgerManagerFactory lmf = getOrCreateMetadataLedgerManagerFactory();
+        if (ledgerManagerFactory == null) {
+            log.warn("Skipping over-replicated ledger GC because LedgerManagerFactory is not available.");
+            return overReplicatedLedgers;
+        }
 
         @Cleanup
-        LedgerUnderreplicationManager lum = lmf.newLedgerUnderreplicationManager();
+        LedgerUnderreplicationManager lum = ledgerManagerFactory.newLedgerUnderreplicationManager();
 
         for (final Long ledgerId : bkActiveledgers) {
             try {
@@ -318,46 +320,6 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
         latch.await();
         bkActiveledgers.removeAll(overReplicatedLedgers);
         return overReplicatedLedgers;
-    }
-
-    private synchronized LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory() throws Exception {
-        if (metadataLedgerManagerFactory != null) {
-            return metadataLedgerManagerFactory;
-        }
-
-        metadataDriver = instantiateMetadataDriver(conf, statsLogger);
-        metadataLedgerManagerFactory = metadataDriver.getLedgerManagerFactory();
-        return metadataLedgerManagerFactory;
-    }
-
-    private static MetadataBookieDriver instantiateMetadataDriver(ServerConfiguration conf, StatsLogger statsLogger)
-            throws BookieException {
-        try {
-            String metadataServiceUriStr = conf.getMetadataServiceUri();
-            MetadataBookieDriver driver = MetadataDrivers.getBookieDriver(URI.create(metadataServiceUriStr));
-            driver.initialize(
-                    conf,
-                    statsLogger);
-            return driver;
-        } catch (MetadataException me) {
-            throw new BookieException.MetadataStoreException("Failed to initialize metadata bookie driver", me);
-        } catch (ConfigurationException e) {
-            throw new BookieException.BookieIllegalOpException(e);
-        }
-    }
-
-    public void closeMetadataDriver() {
-        if (metadataDriver != null) {
-            try {
-                metadataLedgerManagerFactory.close();
-                metadataDriver.close();
-            } catch (Exception e) {
-                log.warn().exception(e).log("Failed to close metadata driver used for over-replicated ledger GC");
-            } finally {
-                metadataLedgerManagerFactory = null;
-                metadataDriver = null;
-            }
-        }
     }
 
     private boolean isNotBookieIncludedInLedgerEnsembles(Versioned<LedgerMetadata> metadata) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -70,7 +70,7 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
  * </p>
  */
 @CustomLog
-public class ScanAndCompareGarbageCollector implements GarbageCollector, AutoCloseable {
+public class ScanAndCompareGarbageCollector implements GarbageCollector {
 
     private final LedgerManager ledgerManager;
     private final CompactableLedgerStorage ledgerStorage;
@@ -346,19 +346,15 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector, AutoClo
         }
     }
 
-    @Override
-    public synchronized void close() {
-        closeMetadataDriver();
-    }
-
-    private void closeMetadataDriver() {
-        metadataLedgerManagerFactory = null;
+    public void closeMetadataDriver() {
         if (metadataDriver != null) {
             try {
+                metadataLedgerManagerFactory.close();
                 metadataDriver.close();
             } catch (Exception e) {
                 log.warn().exception(e).log("Failed to close metadata driver used for over-replicated ledger GC");
             } finally {
+                metadataLedgerManagerFactory = null;
                 metadataDriver = null;
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -320,19 +320,13 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector, AutoClo
         return overReplicatedLedgers;
     }
 
-    private synchronized LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory() throws BookieException {
+    private synchronized LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory() throws Exception {
         if (metadataLedgerManagerFactory != null) {
             return metadataLedgerManagerFactory;
         }
 
         metadataDriver = instantiateMetadataDriver(conf, statsLogger);
-        try {
-            metadataLedgerManagerFactory = metadataDriver.getLedgerManagerFactory();
-        } catch (MetadataException me) {
-            closeMetadataDriver();
-            throw new BookieException.MetadataStoreException(
-                    "Failed to initialize ledger manager factory for over-replicated ledger GC", me);
-        }
+        metadataLedgerManagerFactory = metadataDriver.getLedgerManagerFactory();
         return metadataLedgerManagerFactory;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.IteratorUtility;
@@ -67,6 +68,11 @@ public class SortedLedgerStorage
     @VisibleForTesting
     protected SortedLedgerStorage(InterleavedLedgerStorage ils) {
         interleavedLedgerStorage = ils;
+    }
+
+    @Override
+    public void setLedgerManagerFactory(LedgerManagerFactory ledgerManagerFactory) {
+        interleavedLedgerStorage.setLedgerManagerFactory(ledgerManagerFactory);
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -65,6 +65,7 @@ import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.common.util.nativeio.NativeIOImpl;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -123,6 +124,7 @@ public class DbLedgerStorage implements LedgerStorage {
     private static final long STORAGE_FLAGS_KEY = 0L;
     private int numberOfDirs;
     private List<SingleDirectoryDbLedgerStorage> ledgerStorageList;
+    private LedgerManagerFactory ledgerManagerFactory;
 
     private ExecutorService entryLoggerWriteExecutor = null;
     private ExecutorService entryLoggerFlushExecutor = null;
@@ -238,7 +240,7 @@ public class DbLedgerStorage implements LedgerStorage {
             } else {
                 entrylogger = new DefaultEntryLogger(conf, ldm, null, statsLogger, allocator);
             }
-            ledgerStorageList.add(newSingleDirectoryDbLedgerStorage(conf, ledgerManager, ldm,
+            ledgerStorageList.add(newSingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerManagerFactory, ldm,
                 idm, entrylogger,
                 statsLogger, perDirectoryWriteCacheSize,
                 perDirectoryReadCacheSize,
@@ -279,13 +281,19 @@ public class DbLedgerStorage implements LedgerStorage {
 
     @VisibleForTesting
     protected SingleDirectoryDbLedgerStorage newSingleDirectoryDbLedgerStorage(ServerConfiguration conf,
-            LedgerManager ledgerManager, LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
-            EntryLogger entryLogger, StatsLogger statsLogger, long writeCacheSize, long readCacheSize,
-            int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
+            LedgerManager ledgerManager, LedgerManagerFactory ledgerManagerFactory, LedgerDirsManager ledgerDirsManager,
+            LedgerDirsManager indexDirsManager, EntryLogger entryLogger, StatsLogger statsLogger, long writeCacheSize,
+            long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
             throws IOException {
-        return new SingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerDirsManager, indexDirsManager, entryLogger,
-                                                  statsLogger, allocator, writeCacheSize, readCacheSize,
+        return new SingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager,
+                                                  indexDirsManager, entryLogger, statsLogger, allocator, writeCacheSize,
+                                                  readCacheSize,
                                                   readAheadCacheBatchSize, readAheadCacheBatchBytesSize);
+    }
+
+    @Override
+    public void setLedgerManagerFactory(LedgerManagerFactory ledgerManagerFactory) {
+        this.ledgerManagerFactory = ledgerManagerFactory;
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -72,6 +72,7 @@ import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
@@ -152,6 +153,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     private final String indexBaseDir;
 
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
+                                          LedgerManagerFactory ledgerManagerFactory,
                                           LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                                           EntryLogger entryLogger, StatsLogger statsLogger, ByteBufAllocator allocator,
                                           long writeCacheSize, long readCacheSize, int readAheadCacheBatchSize,
@@ -210,8 +212,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 TransientLedgerInfo.LEDGER_INFO_CACHING_TIME_MINUTES, TimeUnit.MINUTES);
 
         this.entryLogger = entryLogger;
-        gcThread = new GarbageCollectorThread(conf,
-                ledgerManager, ledgerDirsManager, this, entryLogger, ledgerIndexDirStatsLogger);
+        gcThread = new GarbageCollectorThread(conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, this,
+                entryLogger, ledgerIndexDirStatsLogger);
 
         dbLedgerStorageStats = new DbLedgerStorageStats(
             ledgerIndexDirStatsLogger,

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/EmbeddedServer.java
@@ -387,7 +387,7 @@ public class EmbeddedServer {
                         new RxSchedulerLifecycleComponent("rx-scheduler", conf, bookieStats,
                                 rxScheduler, rxExecutor));
 
-                storage = BookieResources.createLedgerStorage(conf.getServerConf(), ledgerManager,
+                storage = BookieResources.createLedgerStorage(conf.getServerConf(), ledgerManager, ledgerManagerFactory,
                         ledgerDirsManager, indexDirsManager, bookieStats, allocator);
 
                 EntryCopier copier = new EntryCopierImpl(bookieId,
@@ -413,7 +413,7 @@ public class EmbeddedServer {
                         registrationManager);
                 cookieValidation.checkCookies(storageDirectoriesFromConf(conf.getServerConf()));
                 // storage should be created after legacy validation or it will fail (it would find ledger dirs)
-                storage = BookieResources.createLedgerStorage(conf.getServerConf(), ledgerManager,
+                storage = BookieResources.createLedgerStorage(conf.getServerConf(), ledgerManager, ledgerManagerFactory,
                         ledgerDirsManager, indexDirsManager, bookieStats, allocator);
             }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/LocalBookKeeper.java
@@ -531,7 +531,7 @@ public class LocalBookKeeper implements AutoCloseable {
             LedgerDirsManager indexDirsManager = BookieResources.createIndexDirsManager(
                     conf, diskChecker, NullStatsLogger.INSTANCE, ledgerDirsManager);
             LedgerStorage storage = BookieResources.createLedgerStorage(
-                    conf, ledgerManager, ledgerDirsManager, indexDirsManager,
+                    conf, ledgerManager, lmFactory, ledgerDirsManager, indexDirsManager,
                     NullStatsLogger.INSTANCE, allocator);
 
             CookieValidation cookieValidation = new LegacyCookieValidation(conf, registrationManager);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -35,19 +35,28 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import io.github.merlimat.slog.Event;
 import io.github.merlimat.slog.Logger;
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.MetadataBookieDriver;
+import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.MockLedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -58,6 +67,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
 
 /**
@@ -143,6 +153,46 @@ public class GarbageCollectorThreadTest {
             sum += usageBuckets[i];
         }
         Assert.assertEquals("Incorrect number of items", items + 1, sum);
+    }
+
+    @Test
+    public void testOverreplicatedLedgerGcReusesMetadataDriverUntilClosed() throws Exception {
+        ServerConfiguration bkConf = TestBKConfiguration.newServerConfiguration()
+                .setAllowLoopback(true)
+                .setMetadataServiceUri("zk://127.0.0.1/ledgers");
+        MetadataBookieDriver metadataDriver = mock(MetadataBookieDriver.class);
+        LedgerManagerFactory lmf = mock(LedgerManagerFactory.class);
+        when(metadataDriver.getLedgerManagerFactory()).thenReturn(lmf);
+
+        try (MockedStatic<MetadataDrivers> metadataDrivers = mockStatic(MetadataDrivers.class)) {
+            metadataDrivers.when(() -> MetadataDrivers.getBookieDriver(any(URI.class))).thenReturn(metadataDriver);
+            ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
+                    ledgerManager, ledgerStorage, bkConf, NullStatsLogger.INSTANCE);
+
+            Assert.assertSame(lmf, getOrCreateMetadataLedgerManagerFactory(garbageCollector));
+            Assert.assertSame(lmf, getOrCreateMetadataLedgerManagerFactory(garbageCollector));
+            metadataDrivers.verify(() -> MetadataDrivers.getBookieDriver(any(URI.class)), times(1));
+
+            garbageCollector.close();
+
+            verify(metadataDriver).close();
+            Assert.assertNull(getMetadataDriver(garbageCollector));
+        }
+    }
+
+    private static LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory(
+            ScanAndCompareGarbageCollector garbageCollector) throws Exception {
+        Method method = ScanAndCompareGarbageCollector.class.getDeclaredMethod(
+                "getOrCreateMetadataLedgerManagerFactory");
+        method.setAccessible(true);
+        return (LedgerManagerFactory) method.invoke(garbageCollector);
+    }
+
+    private static MetadataBookieDriver getMetadataDriver(ScanAndCompareGarbageCollector garbageCollector)
+            throws Exception {
+        Field field = ScanAndCompareGarbageCollector.class.getDeclaredField("metadataDriver");
+        field.setAccessible(true);
+        return (MetadataBookieDriver) field.get(garbageCollector);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -35,9 +35,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -45,9 +44,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import io.github.merlimat.slog.Event;
 import io.github.merlimat.slog.Logger;
 import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.net.URI;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.bookie.storage.EntryLogger;
@@ -55,8 +51,6 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
-import org.apache.bookkeeper.meta.MetadataBookieDriver;
-import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.MockLedgerManager;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -67,7 +61,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Spy;
 
 /**
@@ -156,43 +149,16 @@ public class GarbageCollectorThreadTest {
     }
 
     @Test
-    public void testOverreplicatedLedgerGcReusesMetadataDriverUntilClosed() throws Exception {
-        ServerConfiguration bkConf = TestBKConfiguration.newServerConfiguration()
-                .setAllowLoopback(true)
-                .setMetadataServiceUri("zk://127.0.0.1/ledgers");
-        MetadataBookieDriver metadataDriver = mock(MetadataBookieDriver.class);
+    public void testGarbageCollectorThreadDoesNotCloseServerOwnedLedgerManagerFactory() throws Exception {
         LedgerManagerFactory lmf = mock(LedgerManagerFactory.class);
-        when(metadataDriver.getLedgerManagerFactory()).thenReturn(lmf);
+        File ledgerDir = tmpDirs.createNew("testGcFactoryOwnership", "ledgers");
+        GarbageCollectorThread gcThread = new GarbageCollectorThread(
+                TestBKConfiguration.newServerConfiguration(), new MockLedgerManager(), lmf, newDirsManager(ledgerDir),
+                new MockLedgerStorage(), newLegacyEntryLogger(20000, ledgerDir), NullStatsLogger.INSTANCE);
 
-        try (MockedStatic<MetadataDrivers> metadataDrivers = mockStatic(MetadataDrivers.class)) {
-            metadataDrivers.when(() -> MetadataDrivers.getBookieDriver(any(URI.class))).thenReturn(metadataDriver);
-            ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
-                    ledgerManager, ledgerStorage, bkConf, NullStatsLogger.INSTANCE);
+        gcThread.shutdown();
 
-            Assert.assertSame(lmf, getOrCreateMetadataLedgerManagerFactory(garbageCollector));
-            Assert.assertSame(lmf, getOrCreateMetadataLedgerManagerFactory(garbageCollector));
-            metadataDrivers.verify(() -> MetadataDrivers.getBookieDriver(any(URI.class)), times(1));
-
-            garbageCollector.closeMetadataDriver();
-
-            verify(metadataDriver).close();
-            Assert.assertNull(getMetadataDriver(garbageCollector));
-        }
-    }
-
-    private static LedgerManagerFactory getOrCreateMetadataLedgerManagerFactory(
-            ScanAndCompareGarbageCollector garbageCollector) throws Exception {
-        Method method = ScanAndCompareGarbageCollector.class.getDeclaredMethod(
-                "getOrCreateMetadataLedgerManagerFactory");
-        method.setAccessible(true);
-        return (LedgerManagerFactory) method.invoke(garbageCollector);
-    }
-
-    private static MetadataBookieDriver getMetadataDriver(ScanAndCompareGarbageCollector garbageCollector)
-            throws Exception {
-        Field field = ScanAndCompareGarbageCollector.class.getDeclaredField("metadataDriver");
-        field.setAccessible(true);
-        return (MetadataBookieDriver) field.get(garbageCollector);
+        verify(lmf, never()).close();
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GarbageCollectorThreadTest.java
@@ -173,7 +173,7 @@ public class GarbageCollectorThreadTest {
             Assert.assertSame(lmf, getOrCreateMetadataLedgerManagerFactory(garbageCollector));
             metadataDrivers.verify(() -> MetadataDrivers.getBookieDriver(any(URI.class)), times(1));
 
-            garbageCollector.close();
+            garbageCollector.closeMetadataDriver();
 
             verify(metadataDriver).close();
             Assert.assertNull(getMetadataDriver(garbageCollector));

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GcOverreplicatedLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/GcOverreplicatedLedgerTest.java
@@ -23,7 +23,6 @@ package org.apache.bookkeeper.bookie;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -39,15 +38,11 @@ import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.meta.LedgerManagerTestCase;
 import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
-import org.apache.bookkeeper.meta.MetadataBookieDriver;
-import org.apache.bookkeeper.meta.MetadataDrivers;
 import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
-import org.apache.bookkeeper.meta.exceptions.MetadataException;
 import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.SnapshotMap;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.zookeeper.ZooDefs;
 import org.junit.Assert;
 import org.junit.Before;
@@ -90,11 +85,7 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
         ServerConfiguration bkConf = getBkConf(bookieNotInEnsemble);
 
         @Cleanup
-        final MetadataBookieDriver metadataDriver = instantiateMetadataDriver(bkConf);
-        @Cleanup
-        final LedgerManagerFactory lmf = metadataDriver.getLedgerManagerFactory();
-        @Cleanup
-        final LedgerUnderreplicationManager lum = lmf.newLedgerUnderreplicationManager();
+        final LedgerUnderreplicationManager lum = ledgerManagerFactory.newLedgerUnderreplicationManager();
 
         Assert.assertFalse(lum.isLedgerBeingReplicated(lh.getId()));
 
@@ -104,7 +95,7 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
 
         final CompactableLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, mockLedgerStorage,
-                bkConf, NullStatsLogger.INSTANCE);
+                ledgerManagerFactory, bkConf, NullStatsLogger.INSTANCE);
         Thread.sleep(bkConf.getGcOverreplicatedLedgerWaitTimeMillis() + 1);
         garbageCollector.gc(new GarbageCleaner() {
 
@@ -121,20 +112,6 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
 
         Assert.assertFalse(lum.isLedgerBeingReplicated(lh.getId()));
         Assert.assertFalse(activeLedgers.containsKey(lh.getId()));
-    }
-
-    private static MetadataBookieDriver instantiateMetadataDriver(ServerConfiguration conf)
-            throws BookieException {
-        try {
-            final String metadataServiceUriStr = conf.getMetadataServiceUri();
-            final MetadataBookieDriver driver = MetadataDrivers.getBookieDriver(URI.create(metadataServiceUriStr));
-            driver.initialize(conf, NullStatsLogger.INSTANCE);
-            return driver;
-        } catch (MetadataException me) {
-            throw new BookieException.MetadataStoreException("Failed to initialize metadata bookie driver", me);
-        } catch (ConfigurationException e) {
-            throw new BookieException.BookieIllegalOpException(e);
-        }
     }
 
     @Test
@@ -155,7 +132,7 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
 
         final CompactableLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, mockLedgerStorage,
-                bkConf, NullStatsLogger.INSTANCE);
+                ledgerManagerFactory, bkConf, NullStatsLogger.INSTANCE);
         Thread.sleep(bkConf.getGcOverreplicatedLedgerWaitTimeMillis() + 1);
         garbageCollector.gc(new GarbageCleaner() {
 
@@ -193,7 +170,7 @@ public class GcOverreplicatedLedgerTest extends LedgerManagerTestCase {
 
         final CompactableLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, mockLedgerStorage,
-                bkConf, NullStatsLogger.INSTANCE);
+                ledgerManagerFactory, bkConf, NullStatsLogger.INSTANCE);
         Thread.sleep(bkConf.getGcOverreplicatedLedgerWaitTimeMillis() + 1);
         garbageCollector.gc(new GarbageCleaner() {
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestBookieImpl.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestBookieImpl.java
@@ -196,7 +196,7 @@ public class TestBookieImpl extends BookieImpl {
                     conf, diskChecker, statsLogger, ledgerDirsManager);
 
             LedgerStorage storage = BookieResources.createLedgerStorage(
-                    conf, ledgerManager, ledgerDirsManager, indexDirsManager,
+                    conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, indexDirsManager,
                     statsLogger, UnpooledByteBufAllocator.DEFAULT);
 
             return new Resources(conf,

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageWriteCacheTest.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.junit.After;
 import org.junit.Before;
@@ -54,23 +55,23 @@ public class DbLedgerStorageWriteCacheTest {
 
         @Override
         protected SingleDirectoryDbLedgerStorage newSingleDirectoryDbLedgerStorage(ServerConfiguration conf,
-            LedgerManager ledgerManager, LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
-            EntryLogger entryLogger, StatsLogger statsLogger,
-            long writeCacheSize, long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
+            LedgerManager ledgerManager, LedgerManagerFactory ledgerManagerFactory, LedgerDirsManager ledgerDirsManager,
+            LedgerDirsManager indexDirsManager, EntryLogger entryLogger, StatsLogger statsLogger, long writeCacheSize,
+            long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
                 throws IOException {
-            return new MockedSingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerDirsManager, indexDirsManager,
-                entryLogger, statsLogger, allocator, writeCacheSize,
+            return new MockedSingleDirectoryDbLedgerStorage(conf, ledgerManager, ledgerManagerFactory,
+                ledgerDirsManager, indexDirsManager, entryLogger, statsLogger, allocator, writeCacheSize,
                 readCacheSize, readAheadCacheBatchSize, readAheadCacheBatchBytesSize);
         }
 
         private static class MockedSingleDirectoryDbLedgerStorage extends SingleDirectoryDbLedgerStorage {
             public MockedSingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
-                    LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager, EntryLogger entryLogger,
-                    StatsLogger statsLogger,
+                    LedgerManagerFactory ledgerManagerFactory, LedgerDirsManager ledgerDirsManager,
+                    LedgerDirsManager indexDirsManager, EntryLogger entryLogger, StatsLogger statsLogger,
                     ByteBufAllocator allocator, long writeCacheSize,
                     long readCacheSize, int readAheadCacheBatchSize, long readAheadCacheBatchBytesSize)
                     throws IOException {
-                super(conf, ledgerManager, ledgerDirsManager, indexDirsManager, entryLogger,
+                super(conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, indexDirsManager, entryLogger,
                       statsLogger, allocator, writeCacheSize, readCacheSize, readAheadCacheBatchSize,
                       readAheadCacheBatchBytesSize);
             }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -886,7 +886,7 @@ public abstract class BookKeeperClusterTestCase {
             UncleanShutdownDetection uncleanShutdownDetection = new UncleanShutdownDetectionImpl(ledgerDirsManager);
 
             storage = BookieResources.createLedgerStorage(
-                    conf, ledgerManager, ledgerDirsManager, indexDirsManager,
+                    conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, indexDirsManager,
                     bookieStats, allocator);
 
             if (conf.isForceReadOnlyBookie()) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -886,7 +886,7 @@ public abstract class BookKeeperClusterTestCase {
             UncleanShutdownDetection uncleanShutdownDetection = new UncleanShutdownDetectionImpl(ledgerDirsManager);
 
             storage = BookieResources.createLedgerStorage(
-                    conf, ledgerManager, ledgerManagerFactory, ledgerDirsManager, indexDirsManager,
+                    conf, ledgerManager, lmFactory, ledgerDirsManager, indexDirsManager,
                     bookieStats, allocator);
 
             if (conf.isForceReadOnlyBookie()) {

--- a/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
+++ b/stream/server/src/main/java/org/apache/bookkeeper/stream/server/service/BookieService.java
@@ -100,7 +100,7 @@ public class BookieService extends AbstractLifecycleComponent<BookieConfiguratio
         LedgerDirsManager indexDirsManager = BookieResources.createIndexDirsManager(
                 serverConf, diskChecker, bookieStats.scope(LD_INDEX_SCOPE), ledgerDirsManager);
         LedgerStorage storage = BookieResources.createLedgerStorage(
-                serverConf, ledgerManager, ledgerDirsManager, indexDirsManager, bookieStats, allocator);
+                serverConf, ledgerManager, lmFactory, ledgerDirsManager, indexDirsManager, bookieStats, allocator);
         UncleanShutdownDetection uncleanShutdownDetection = new UncleanShutdownDetectionImpl(ledgerDirsManager);
 
         LegacyCookieValidation cookieValidation = new LegacyCookieValidation(serverConf, rm);


### PR DESCRIPTION
Descriptions of the changes in this PR:

Main Issue: #xyz

### Motivation

Over-replicated ledger cleanup currently instantiates a metadata bookie driver each time the scan-and-compare garbage collector checks for over-replicated ledgers. This repeatedly creates metadata client resources during GC cycles, which is unnecessary and can add overhead to the cleanup path.

### Changes

- Reuse a metadata bookie driver and ledger manager factory inside `ScanAndCompareGarbageCollector` for over-replicated ledger cleanup.
- Make `ScanAndCompareGarbageCollector` closeable and release the cached metadata driver when `GarbageCollectorThread` shuts down.
- Keep the existing GC metadata operation rate limiter behavior while reusing the metadata driver.
- Add a focused unit test to verify the metadata driver is reused across calls and closed correctly.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all the following to help us incorporate your contribution
> quickly and easily:
>
> Otherwise:
>
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
>
> ---