### PR TITLE
Fix flaky TableClientTest.testTableAPIServerSideRouting

### DIFF
--- a/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptor.java
+++ b/stream/storage/impl/src/main/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptor.java
@@ -337,8 +337,15 @@ public class RoutingHeaderProxyInterceptor implements ClientInterceptor {
         if (null == descriptor) {
             return message;
         } else {
+            byte[] requestBytes = null;
             try {
-                return interceptTableRequest(method, descriptor, message, sid, rid, rk);
+                if (message.getClass() == descriptor.getClz()) {
+                    return interceptTableRequest(method, descriptor, message, sid, rid, rk);
+                } else {
+                    InputStream is = method.getRequestMarshaller().stream(message);
+                    requestBytes = is.readAllBytes();
+                    return interceptTableRequest(method, descriptor, requestBytes, sid, rid, rk);
+                }
             } catch (Throwable t) {
                 log.error()
                     .attr("streamId", sid)
@@ -346,6 +353,9 @@ public class RoutingHeaderProxyInterceptor implements ClientInterceptor {
                     .attr("routingKey", Hex.encodeHexString(rk))
                     .exception(t)
                     .log("Failed to intercept table request");
+                if (null != requestBytes) {
+                    return method.getRequestMarshaller().parse(new ByteArrayInputStream(requestBytes));
+                }
                 return message;
             }
         }
@@ -363,9 +373,8 @@ public class RoutingHeaderProxyInterceptor implements ClientInterceptor {
         if (message.getClass() == interceptor.getClz()) {
             request = (TableReqT) message;
         } else {
-            InputStream is = method.getRequestMarshaller().stream(message);
-            byte[] bytes = is.readAllBytes();
-            request = interceptor.getParser().parseFrom(bytes);
+            return interceptTableRequest(method, interceptor,
+                method.getRequestMarshaller().stream(message).readAllBytes(), sid, rid, rk);
         }
         TableReqT interceptedMessage = interceptor.getInterceptor().intercept(
             request, sid, rid, rk
@@ -377,5 +386,19 @@ public class RoutingHeaderProxyInterceptor implements ClientInterceptor {
             return method.getRequestMarshaller().parse(new ByteArrayInputStream(reqBytes));
 
         }
+    }
+
+    private <ReqT, TableReqT> ReqT interceptTableRequest(
+        MethodDescriptor<ReqT, ?> method,
+        InterceptorDescriptor<TableReqT> interceptor,
+        byte[] requestBytes,
+        Long sid, Long rid, byte[] rk
+    ) {
+        TableReqT request = interceptor.getParser().parseFrom(requestBytes);
+        TableReqT interceptedMessage = interceptor.getInterceptor().intercept(
+            request, sid, rid, rk
+        );
+        byte[] reqBytes = interceptor.getSerializer().toByteArray(interceptedMessage);
+        return method.getRequestMarshaller().parse(new ByteArrayInputStream(reqBytes));
     }
 }

--- a/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptorTest.java
+++ b/stream/storage/impl/src/test/java/org/apache/bookkeeper/stream/storage/impl/routing/RoutingHeaderProxyInterceptorTest.java
@@ -23,7 +23,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.bookkeeper.stream.protocol.ProtocolConstants.RID_METADATA_KEY;
 import static org.apache.bookkeeper.stream.protocol.ProtocolConstants.RK_METADATA_KEY;
 import static org.apache.bookkeeper.stream.protocol.ProtocolConstants.SID_METADATA_KEY;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -34,11 +36,14 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
 import org.apache.bookkeeper.clients.grpc.GrpcClientTestBase;
 import org.apache.bookkeeper.clients.impl.channel.StorageServerChannel;
+import org.apache.bookkeeper.common.grpc.netty.IdentityInputStreamMarshaller;
 import org.apache.bookkeeper.stream.proto.kv.rpc.DeleteRangeRequest;
 import org.apache.bookkeeper.stream.proto.kv.rpc.DeleteRangeResponse;
 import org.apache.bookkeeper.stream.proto.kv.rpc.IncrementRequest;
@@ -49,6 +54,7 @@ import org.apache.bookkeeper.stream.proto.kv.rpc.RangeRequest;
 import org.apache.bookkeeper.stream.proto.kv.rpc.RangeResponse;
 import org.apache.bookkeeper.stream.proto.kv.rpc.ResponseHeader;
 import org.apache.bookkeeper.stream.proto.kv.rpc.RoutingHeader;
+import org.apache.bookkeeper.stream.proto.kv.rpc.TableServiceGrpc;
 import org.apache.bookkeeper.stream.proto.kv.rpc.TableServiceGrpc.TableServiceImplBase;
 import org.apache.bookkeeper.stream.proto.kv.rpc.TxnRequest;
 import org.apache.bookkeeper.stream.proto.kv.rpc.TxnResponse;
@@ -269,6 +275,87 @@ public class RoutingHeaderProxyInterceptorTest extends GrpcClientTestBase {
 
         assertEquals(expectedRequest, receivedRequest.get());
         assertEquals(expectedRequest.getHeader(), response.getHeader().getRoutingHeader());
+    }
+
+    @Test
+    public void testForwardOriginalInputStreamWhenInterceptionFails() throws Exception {
+        byte[] requestBytes = new byte[] { 4, 1, 2, 3 };
+        CapturingClientCall delegateCall = new CapturingClientCall();
+        RoutingHeaderProxyInterceptor interceptor = new RoutingHeaderProxyInterceptor();
+
+        ClientCall<InputStream, InputStream> interceptedCall = interceptor.interceptCall(
+            proxyTxnMethod(),
+            CallOptions.DEFAULT,
+            new CapturingChannel(delegateCall));
+
+        Metadata headers = new Metadata();
+        headers.put(SID_METADATA_KEY, 1026L);
+        headers.put(RID_METADATA_KEY, 1030L);
+        headers.put(RK_METADATA_KEY, "txn-key".getBytes(UTF_8));
+
+        ByteArrayInputStream originalMessage = new ByteArrayInputStream(requestBytes);
+        interceptedCall.start(new ClientCall.Listener<InputStream>() { }, headers);
+        interceptedCall.sendMessage(originalMessage);
+
+        assertNotSame(originalMessage, delegateCall.message);
+        assertArrayEquals(requestBytes, delegateCall.message.readAllBytes());
+    }
+
+    private static MethodDescriptor<InputStream, InputStream> proxyTxnMethod() {
+        return MethodDescriptor.newBuilder(
+                IdentityInputStreamMarshaller.of(),
+                IdentityInputStreamMarshaller.of())
+            .setFullMethodName(TableServiceGrpc.getTxnMethod().getFullMethodName())
+            .setType(TableServiceGrpc.getTxnMethod().getType())
+            .build();
+    }
+
+    private static class CapturingChannel extends Channel {
+
+        private final CapturingClientCall call;
+
+        CapturingChannel(CapturingClientCall call) {
+            this.call = call;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+                MethodDescriptor<ReqT, RespT> methodDescriptor,
+                CallOptions callOptions) {
+            return (ClientCall<ReqT, RespT>) call;
+        }
+
+        @Override
+        public String authority() {
+            return "test-authority";
+        }
+    }
+
+    private static class CapturingClientCall extends ClientCall<InputStream, InputStream> {
+
+        private InputStream message;
+
+        @Override
+        public void start(Listener<InputStream> responseListener, Metadata headers) {
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+        }
+
+        @Override
+        public void halfClose() {
+        }
+
+        @Override
+        public void sendMessage(InputStream message) {
+            this.message = message;
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation
`TableClientTest.testTableAPIServerSideRouting` can fail intermittently with `txnResult.isSuccess()` returning false.

Observed failure:
- CI job: https://github.com/apache/bookkeeper/actions/runs/26486972755/job/77997366483?pr=4741
- Test failure: `java.lang.AssertionError` at `TableClientTest.java:257`
- Bookie log context: `RoutingHeaderProxyInterceptor` failed while parsing the proxied `TxnRequest` for `streamId=1026`, `rangeId=1030`, and routing key `txn-key`.

```text
Failed to intercept table request {rangeId=1030, routingKey=74786e2d6b6579, streamId=1026}
java.lang.IllegalArgumentException: Invalid unknonwn tag type: 4
    at org.apache.bookkeeper.stream.proto.kv.rpc.LightProtoCodec.skipUnknownField(...)
    at org.apache.bookkeeper.stream.proto.kv.rpc.TxnRequest.parseFrom(...)
    at org.apache.bookkeeper.stream.storage.impl.routing.RoutingHeaderProxyInterceptor.parseTxnRequest(...)
```

The server-side routing proxy forwards table requests as `InputStream`s. When the interceptor tries to rewrite the routing header, it reads the request stream first. If parsing or interception fails, the old fallback returned the same `InputStream` instance. At that point the stream has already been consumed, so the backend receives an empty or partially consumed request instead of the original request body. That can make the proxied txn fail and surfaces as the flaky integration test failure.

### Changes
- Buffer the original request bytes before attempting to parse and rewrite proxied table requests.
- Reuse the buffered bytes when mutating the routing header for proxy-style `InputStream` requests.
- On interception failure, rebuild a fresh request stream from the original bytes so fallback forwarding preserves the request body.
- Add a regression test that sends invalid proxy request bytes through `IdentityInputStreamMarshaller` and verifies the delegate receives a fresh stream with the original payload.

### Testing
- mvn -pl stream/storage/impl -am -P '!mac,!cargo-zigbuild' -DstreamTests -Dtest=RoutingHeaderProxyInterceptorTest -Dsurefire.failIfNoSpecifiedTests=false test
