### PR TITLE
Include lombok.config in source release assembly

### DIFF
--- a/bookkeeper-dist/src/assemble/src.xml
+++ b/bookkeeper-dist/src/assemble/src.xml
@@ -31,6 +31,7 @@
         <include>**/LICENSE</include>
         <include>**/NOTICE</include>
         <include>**/pom.xml</include>
+        <include>lombok.config</include>
         <include>**/*gradle*</include>
         <include>**/src/**</include>
         <include>**/conf/**</include>


### PR DESCRIPTION
### Motivation
The source release archive should include the top-level `lombok.config`.

Without it, compiling from the source archive fails with:

```text
The @CustomLog is not configured; please set lombok.log.custom.declaration in lombok.config.
```

### Changes
Include `lombok.config` in the source assembly descriptor.

### Verification
- Confirmed the generated source tarball contains `bookkeeper-4.18.0/lombok.config`.
- Built from the regenerated source tarball with `mvn -DskipTests -Dexec.skip=true -Dmaven.antrun.skip=true clean install`.
