### PR TITLE
Avoid PTR lookup for loopback DNS resolution

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/net/DNS.java
@@ -70,19 +70,16 @@ public class DNS {
             //Not proper address. May be IPv6
             throw new NamingException("IPV6");
         }
+
+        // Loopback addresses are local-only; avoid querying external DNS for PTR records.
+        if (hostIp.isLoopbackAddress()) {
+            return cachedHostname;
+        }
+
         String reverseIP = parts[3] + "." + parts[2] + "." + parts[1] + "."
                 + parts[0] + ".in-addr.arpa";
 
-        DirContext ictx = new InitialDirContext();
-        Attributes attribute;
-        try {
-            attribute = ictx.getAttributes("dns://"               // Use "dns:///" if the default
-                    + ((ns == null) ? "" : ns)
-                    // nameserver is to be used
-                    + "/" + reverseIP, new String[]{"PTR"});
-        } finally {
-            ictx.close();
-        }
+        Attributes attribute = getPtrAttributes(reverseIP, ns);
 
         if (null == attribute) {
             throw new NamingException("No attribute is found");
@@ -98,6 +95,18 @@ public class DNS {
         }
 
         return ptrAttr.get().toString();
+    }
+
+    static Attributes getPtrAttributes(String reverseIP, String ns) throws NamingException {
+        DirContext ictx = new InitialDirContext();
+        try {
+            return ictx.getAttributes("dns://"               // Use "dns:///" if the default
+                    + ((ns == null) ? "" : ns)
+                    // nameserver is to be used
+                    + "/" + reverseIP, new String[]{"PTR"});
+        } finally {
+            ictx.close();
+        }
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/DNSTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/net/DNSTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.net;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+import java.net.InetAddress;
+import javax.naming.NamingException;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class DNSTest {
+
+    @Test
+    public void testReverseDnsForLoopbackAddressDoesNotQueryPtr() throws Exception {
+        String expectedHostname = DNS.getDefaultHost("default");
+        try (MockedStatic<DNS> mockedDns = mockStatic(DNS.class, invocation -> {
+            if ("getPtrAttributes".equals(invocation.getMethod().getName())) {
+                throw new NamingException("simulated DNS timeout");
+            }
+            return invocation.callRealMethod();
+        })) {
+            String hostname = DNS.reverseDns(InetAddress.getByName("127.0.0.1"), null);
+
+            assertEquals(expectedHostname, hostname);
+            mockedDns.verify(() -> DNS.getPtrAttributes(anyString(), nullable(String.class)), never());
+        }
+    }
+
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

BookKeeper's `DNS.reverseDns` currently performs a DNS PTR lookup for IPv4 loopback addresses such as `127.0.0.1`. A loopback address is local-only, so asking an external DNS server for `1.0.0.127.in-addr.arpa` is unnecessary and can add avoidable network cost.

This also makes local tests depend on router-specific DNS behavior. Some DNS servers return `NXDOMAIN` quickly for this PTR query, for example:

```bash
dig -x 127.0.0.1 @8.8.8.8
```

However, some home routers do not return a standard DNS response for the same query:

```bash
dig -x 127.0.0.1 @192.168.1.1
# connection timed out; no servers could be reached

dig +tcp -x 127.0.0.1 @192.168.1.1
# communications error: end of file
```

In that environment, ordinary DNS resolution still works, for example `dig @192.168.1.1 google.com` succeeds. The issue is specific to reverse lookup of the loopback PTR record.

I encountered this while running Pulsar's broker `AuditorLedgerCheckerTest`, which starts multiple local BookKeeper bookies. The local bookie startup path tried to resolve the loopback interface address, the router DNS timed out on the PTR query for `127.0.0.1`, and the test could not start. Switching DNS to `8.8.8.8` made the test start again because that resolver returns quickly.

Since loopback addresses are not externally meaningful, BookKeeper should not query external DNS for their PTR records. It can return the already cached local hostname, matching the existing fallback used by `DNS.getHosts` when no hostname can be determined.

### Changes

- Skip PTR lookup in `DNS.reverseDns` when the IPv4 address is loopback.
- Return the cached local hostname for IPv4 loopback addresses.
- Extract the PTR lookup call into `getPtrAttributes` so the DNS query layer can be mocked in tests.
- Add `DNSTest` coverage that simulates a DNS timeout and verifies `127.0.0.1` does not call the PTR lookup path.

### Tests

```bash
mvn -pl bookkeeper-server -Dtest=org.apache.bookkeeper.net.DNSTest -DfailIfNoTests=false test
```
