### PR TITLE
fix: startup exception being silently swallowed when journal replay fails

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieImpl.java
@@ -899,15 +899,15 @@ public class BookieImpl implements Bookie {
     int shutdown(int exitCode) {
         lock.lock();
         try {
+            // the exitCode only set when first shutdown usually due to exception found
+            if (this.exitCode == ExitCode.OK) {
+                this.exitCode = exitCode;
+            }
             if (isRunning()) {
-                // the exitCode only set when first shutdown usually due to exception found
                 log.info()
                         .attr("bookiePort", conf.getBookiePort())
                         .attr("exitCode", exitCode)
                         .log("Shutting down Bookie");
-                if (this.exitCode == ExitCode.OK) {
-                    this.exitCode = exitCode;
-                }
 
                 stateManager.forceToShuttingDown();
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -134,7 +134,7 @@ public class BookieServer {
         if (!this.bookie.isRunning()) {
             exitCode = bookie.getExitCode();
             this.requestProcessor.close();
-            throw new IOException("Bookie failed to start, exit code: " + exitCode);
+            throw new IllegalStateException("Bookie failed to start, exit code: " + exitCode);
         }
 
         this.uncleanShutdownDetection.registerStartUp();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieServer.java
@@ -134,7 +134,7 @@ public class BookieServer {
         if (!this.bookie.isRunning()) {
             exitCode = bookie.getExitCode();
             this.requestProcessor.close();
-            return;
+            throw new IOException("Bookie failed to start, exit code: " + exitCode);
         }
 
         this.uncleanShutdownDetection.registerStartUp();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -26,6 +26,7 @@ import static org.apache.bookkeeper.meta.MetadataDrivers.runFunctionWithRegistra
 import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.bookkeeper.util.BookKeeperConstants.BOOKIE_STATUS_FILENAME;
 import static org.apache.bookkeeper.util.TestUtils.countNumOfFiles;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
@@ -246,7 +247,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             int logBefore = countNumOfFiles(conf.getLedgerDirs(), "log");
             int idxBefore = countNumOfFiles(conf.getLedgerDirs(), "idx");
 
-            server.start();
+            assertThatThrownBy(server::start)
+                .isInstanceOf(IllegalStateException.class);
 
             for (int j = 0; j < journalDirs.length; j++) {
                 Journal journal = ((BookieImpl) server.getBookie()).journals.get(j);
@@ -309,8 +311,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
                                                  NullStatsLogger.INSTANCE, UnpooledByteBufAllocator.DEFAULT,
                                                  new MockUncleanShutdownDetection());
 
-        bkServer.start();
-        bkServer.join();
+        assertThatThrownBy(bkServer::start)
+            .isInstanceOf(IllegalStateException.class);
         assertEquals("Failed to return ExitCode.ZK_REG_FAIL",
                      ExitCode.ZK_REG_FAIL, bkServer.getExitCode());
     }
@@ -1159,7 +1161,8 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
         // for the ledger (whose entries are not flushed). but since we set
         // minUsableSizeForIndexFileCreation to very high value, it wouldn't. be
         // able to find any index dir when all discs are full
-        server.start();
+        assertThatThrownBy(server::start)
+            .isInstanceOf(IllegalStateException.class);
         assertFalse("Bookie should be Shutdown", server.getBookie().isRunning());
         server.shutdown();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieInitializationTest.java
@@ -247,8 +247,7 @@ public class BookieInitializationTest extends BookKeeperClusterTestCase {
             int logBefore = countNumOfFiles(conf.getLedgerDirs(), "log");
             int idxBefore = countNumOfFiles(conf.getLedgerDirs(), "idx");
 
-            assertThatThrownBy(server::start)
-                .isInstanceOf(IllegalStateException.class);
+            server.start();
 
             for (int j = 0; j < journalDirs.length; j++) {
                 Journal journal = ((BookieImpl) server.getBookie()).journals.get(j);


### PR DESCRIPTION
### Summary

When `BookieImpl.start()` fails during journal replay (e.g. missing recovery log), the exception is silently swallowed and the bookie appears to be running despite being in a broken, partially-initialized state.

**Root cause:** Two issues conspire to hide the failure:

1. **`BookieServer.start()`** detects `!bookie.isRunning()` but silently `return`s instead of throwing an exception. The method declares `throws IOException` but never uses it on the failure path.

2. **`BookieImpl.shutdown()`** skips setting `this.exitCode` when `isRunning()` is `false` (which is always the case before `initState()` is called at line 756). So `getExitCode()` returns `ExitCode.OK` (0) even on failure.

**Effect:** The exception is caught by `AbstractLifecycleComponent.start()` and dispatched to the `uncaughtExceptionHandler` (set by `ComponentStarter`), which triggers `ComponentShutdownHook` for cleanup. However, without the IOException being thrown from `BookieServer.start()`, the exception path relies entirely on the handler — and the exit code was incorrectly `OK(0)`.

### Changes

- **`BookieServer.start()`**: `return` → `throw new IOException("Bookie failed to start, exit code: " + exitCode)` — ensures the exception properly propagates to the lifecycle framework's exception handler.
- **`BookieImpl.shutdown()`**: Move `this.exitCode = exitCode` outside the `if (isRunning())` guard — ensures the exit code is always set, even during early startup before `initState()`.

Complementary to #4740 which fixed the root cause of journal file deletion (lastMark regression). This PR fixes the consequence: if a journal file is missing for any reason, the bookie should fail fast with a proper error.