### PR TITLE
Fix masked WriteSet shuffle bounds that can reuse stale bookie indexes

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RoundRobinDistributionSchedule.java
@@ -247,7 +247,7 @@ public class RoundRobinDistributionSchedule implements DistributionSchedule {
         }
 
         private void checkBounds(int i) {
-            if (i < 0 || i > size) {
+            if (i < 0 || i >= size) {
                 throw new IndexOutOfBoundsException(
                         "Index " + i + " out of bounds, array size = " + size);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/TopologyAwareEnsemblePlacementPolicy.java
@@ -628,8 +628,8 @@ abstract class TopologyAwareEnsemblePlacementPolicy implements
             }
         }
         if (first != -1) {
-            for (int i = last + 1; i > first; i--) {
-                int swapWith = ThreadLocalRandom.current().nextInt(i);
+            for (int i = last; i > first; i--) {
+                int swapWith = ThreadLocalRandom.current().nextInt(first, i + 1);
                 writeSet.set(swapWith, writeSet.set(i, writeSet.get(swapWith)));
             }
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/RoundRobinDistributionScheduleTest.java
@@ -25,6 +25,7 @@ import static org.apache.bookkeeper.client.RoundRobinDistributionSchedule.writeS
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.Sets;
 import java.util.BitSet;
@@ -155,6 +156,31 @@ public class RoundRobinDistributionScheduleTest {
         w = writeSetFromValues(1, 2, 3, 4, 5);
         w.moveAndShift(4, 4);
         assertEquals(w, writeSetFromValues(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void testWriteSetRejectsIndexEqualToSize() {
+        DistributionSchedule.WriteSet w = writeSetFromValues(1, 2, 3);
+        try {
+            w.get(w.size());
+            fail("Expected get(size) to fail");
+        } catch (IndexOutOfBoundsException expected) {
+            // expected
+        }
+
+        try {
+            w.set(w.size(), 4);
+            fail("Expected set(size, value) to fail");
+        } catch (IndexOutOfBoundsException expected) {
+            // expected
+        }
+
+        try {
+            w.moveAndShift(0, w.size());
+            fail("Expected moveAndShift(..., size) to fail");
+        } catch (IndexOutOfBoundsException expected) {
+            // expected
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`shuffleWithMask` is used by topology-aware read reordering to shuffle contiguous `WriteSet` entries with the same mask. When the matched range is at the end of the logical `WriteSet`, the current loop starts from `last + 1`, which is outside the active range.

Since `WriteSet` instances are recycled and may retain a larger backing array than their current logical size, accessing `size` can reuse stale bookie indexes from a previous use.

### Changes

- Shuffle only within the matched range `[first, last]`.
- Treat `index == size` as out of bounds in `WriteSetImpl`.
- Add coverage for `get(size)`, `set(size, ...)`, and `moveAndShift(..., size)`.

### Verifying this change

```
mvn -pl bookkeeper-server -Dtest=TestRackawareEnsemblePlacementPolicy#testShuffleWithMask,RoundRobinDistributionScheduleTest test -DskipShade -Dspotbugs.skip -Dlicense.skip
```
