### PR TITLE
Use ASF-allowlisted dtolnay/rust-toolchain revision in setup-native-build

### DIFF
--- a/.github/actions/setup-native-build/action.yml
+++ b/.github/actions/setup-native-build/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
       with:
         # Cross-compilation targets: Linux amd64 and arm64 (glibc)
         targets: >-


### PR DESCRIPTION
### Motivation

CI fails on all workflows that use the `setup-native-build` composite action (`bk-ci.yml`, `codeql.yml`, `java21-daily-build.yml`, `windows-daily-build.yml`, `bk-streamstorage-python.yml`, `website-pr-validation.yml`) with:

```
The action dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 is not allowed in apache/bookkeeper because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns...
```

The ASF approved actions allowlist ([apache/infrastructure-actions](https://github.com/apache/infrastructure-actions/blob/main/actions.yml)) only permits `dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30` (tag: `stable`).

The allowlisted revision is also newer (2026-06-30) than the currently pinned one (2026-03-27); both point at the stable toolchain, so this is a plain upgrade.

### Changes

- Pin `dtolnay/rust-toolchain` in `.github/actions/setup-native-build/action.yml` to the ASF-allowlisted revision `4be7066ada62dd38de10e7b70166bc74ed198c30`.
