### PR TITLE
Add spin-wait hint to BlockingMpscQueue producer-side busy loops

### DIFF
--- a/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/BlockingMpscQueue.java
+++ b/bookkeeper-common/src/main/java/org/apache/bookkeeper/common/collections/BlockingMpscQueue.java
@@ -34,11 +34,14 @@ public class BlockingMpscQueue<T> extends MpscArrayQueue<T> implements BlockingQ
 
     @Override
     public void put(T e) throws InterruptedException {
+        int idleCounter = 0;
         while (!this.relaxedOffer(e)) {
             // Do busy-spin loop
             if (Thread.interrupted()) {
                 throw new InterruptedException();
             }
+
+            idleCounter = WAIT_STRATEGY.idle(idleCounter);
         }
     }
 
@@ -46,6 +49,7 @@ public class BlockingMpscQueue<T> extends MpscArrayQueue<T> implements BlockingQ
     public boolean offer(T e, long timeout, TimeUnit unit) throws InterruptedException {
         long absoluteEndTime = System.nanoTime() + unit.toNanos(timeout);
 
+        int idleCounter = 0;
         while (!this.relaxedOffer(e)) {
             // Do busy-spin loop
 
@@ -56,6 +60,8 @@ public class BlockingMpscQueue<T> extends MpscArrayQueue<T> implements BlockingQ
             if (Thread.interrupted()) {
                 throw new InterruptedException();
             }
+
+            idleCounter = WAIT_STRATEGY.idle(idleCounter);
         }
 
         return true;


### PR DESCRIPTION
### Motivation

`BlockingMpscQueue.put()` and the timed `offer()` busy-spin on `relaxedOffer()` in a bare loop, with no pause hint. When the queue fills up under back-pressure (e.g. the journal queue with `enableBusyWait=true`), every blocked producer thread pins a core spinning at full speed — competing for CPU with the very consumer thread that needs to run to drain the queue.

The consumer side (`take()` / `poll()`) already idles through `WAIT_STRATEGY.idle()`, which uses the `Thread.onSpinWait()` intrinsic (via `BusyWait.onSpinWait()`). The producer side was missing the same treatment.

### Changes

Apply the same wait strategy in the `put()` and `offer(timeout)` spin loops. The producers still busy-spin (by design for this queue), but with the spin-wait hint that reduces power/pipeline contention and lets the sibling hyperthread — often the consumer — make progress.

Verified with `BlockingMpscQueueTest` (4/4 pass) and module checkstyle.
