### PR TITLE
Write journal entry length prefix and payload in a single BufferedChannel write

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BufferedChannel.java
@@ -115,33 +115,66 @@ public class BufferedChannel extends BufferedReadChannel implements Closeable {
      * @throws IOException if a write operation fails.
      */
     public void write(ByteBuf src) throws IOException {
-        int copied = 0;
         boolean shouldForceWrite = false;
         synchronized (this) {
-            int len = src.readableBytes();
-            while (copied < len) {
-                int bytesToCopy = Math.min(src.readableBytes() - copied, writeBuffer.writableBytes());
-                writeBuffer.writeBytes(src, src.readerIndex() + copied, bytesToCopy);
-                copied += bytesToCopy;
-
-                // if we have run out of buffer space, we should flush to the
-                // file
-                if (!writeBuffer.isWritable()) {
-                    flush();
-                }
-            }
-            position += copied;
-            if (doRegularFlushes) {
-                unpersistedBytes.addAndGet(copied);
-                if (unpersistedBytes.get() >= unpersistedBytesBound) {
-                    flush();
-                    shouldForceWrite = true;
-                }
-            }
+            int copied = copyIntoWriteBuffer(src);
+            shouldForceWrite = updatePositionAndFlushIfNeeded(copied);
         }
         if (shouldForceWrite) {
             forceWrite(false);
         }
+    }
+
+    /**
+     * Write all the data in src1 and src2, in order, to the {@link FileChannel}, taking the
+     * lock only once. This avoids the overhead of two lock acquisitions when writing an
+     * entry preceded by its length prefix.
+     *
+     * @param src1 The first source buffer which contains the data to be written.
+     * @param src2 The second source buffer which contains the data to be written.
+     * @throws IOException if a write operation fails.
+     */
+    public void write(ByteBuf src1, ByteBuf src2) throws IOException {
+        boolean shouldForceWrite = false;
+        synchronized (this) {
+            int copied = copyIntoWriteBuffer(src1);
+            copied += copyIntoWriteBuffer(src2);
+            shouldForceWrite = updatePositionAndFlushIfNeeded(copied);
+        }
+        if (shouldForceWrite) {
+            forceWrite(false);
+        }
+    }
+
+    // must be called while holding the lock on this instance
+    private int copyIntoWriteBuffer(ByteBuf src) throws IOException {
+        int copied = 0;
+        int len = src.readableBytes();
+        while (copied < len) {
+            int bytesToCopy = Math.min(src.readableBytes() - copied, writeBuffer.writableBytes());
+            writeBuffer.writeBytes(src, src.readerIndex() + copied, bytesToCopy);
+            copied += bytesToCopy;
+
+            // if we have run out of buffer space, we should flush to the
+            // file
+            if (!writeBuffer.isWritable()) {
+                flush();
+            }
+        }
+        return copied;
+    }
+
+    // must be called while holding the lock on this instance
+    private boolean updatePositionAndFlushIfNeeded(int copied) throws IOException {
+        position += copied;
+        if (doRegularFlushes) {
+            unpersistedBytes.addAndGet(copied);
+            if (unpersistedBytes.get() >= unpersistedBytesBound) {
+                flush();
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1232,8 +1232,7 @@ public class Journal implements CheckpointSource {
                     // preAlloc based on size
                     logFile.preAllocIfNeeded(4 + entrySize);
 
-                    bc.write(lenBuff);
-                    bc.write(qe.entry);
+                    bc.write(lenBuff, qe.entry);
                     memoryLimitController.releaseMemory(qe.entry.readableBytes());
                     ReferenceCountUtil.release(qe.entry);
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SlowBufferedChannel.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SlowBufferedChannel.java
@@ -64,6 +64,12 @@ public class SlowBufferedChannel extends BufferedChannel {
     }
 
     @Override
+    public synchronized void write(ByteBuf src1, ByteBuf src2) throws IOException {
+        delayMs(addDelay);
+        super.write(src1, src2);
+    }
+
+    @Override
     public void flush() throws IOException {
         delayMs(flushDelay);
         super.flush();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
@@ -24,12 +24,14 @@ package org.apache.bookkeeper.bookie;
 import static org.junit.Assert.assertThrows;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
@@ -125,6 +127,44 @@ public class BufferedChannelTest {
         if (unpersistedBytesBound > 0) {
             Assert.assertEquals("Unpersisted bytes", expectedNumOfUnpersistedBytes, logChannel.getUnpersistedBytes());
         }
+        logChannel.close();
+        fileChannel.close();
+    }
+
+    @Test
+    public void testWriteTwoBuffers() throws Exception {
+        File newLogFile = File.createTempFile("test", "log");
+        newLogFile.deleteOnExit();
+        FileChannel fileChannel = new RandomAccessFile(newLogFile, "rw").getChannel();
+
+        // small write capacity so the pairs below cross the buffer boundary at varied offsets,
+        // including a payload equal to the capacity and one larger than it
+        int writeCapacity = 64;
+        BufferedChannel logChannel = new BufferedChannel(UnpooledByteBufAllocator.DEFAULT, fileChannel,
+                writeCapacity, INTERNAL_BUFFER_READ_CAPACITY, 0);
+
+        int[] payloadSizes = { 25, 31, 60, 3, 64, 128, 1, 41 };
+        ByteBuf expected = Unpooled.buffer();
+        ByteBuf lenBuf = Unpooled.buffer(4);
+
+        for (int payloadSize : payloadSizes) {
+            ByteBuf payload = generateEntry(payloadSize);
+            lenBuf.clear();
+            lenBuf.writeInt(payloadSize);
+
+            expected.writeBytes(lenBuf.slice());
+            expected.writeBytes(payload.slice());
+
+            logChannel.write(lenBuf, payload);
+        }
+
+        Assert.assertEquals(expected.readableBytes(), logChannel.position());
+
+        logChannel.flush();
+
+        byte[] fileBytes = Files.readAllBytes(newLogFile.toPath());
+        Assert.assertArrayEquals(ByteBufUtil.getBytes(expected), fileBytes);
+
         logChannel.close();
         fileChannel.close();
     }


### PR DESCRIPTION
### Motivation

On the journal append path, each entry is written to the `BufferedChannel` as two separate calls — the 4-byte length prefix and then the payload:

```java
bc.write(lenBuff);
bc.write(qe.entry);
```

Each `write()` acquires the channel monitor, so every journal entry pays two lock acquisitions on a monitor that is also contended by the force-write thread (`forceWrite()` takes the same lock to reset `unpersistedBytes`), plus two rounds of position/unpersisted-bytes accounting.

### Changes

- Add a `BufferedChannel.write(ByteBuf src1, ByteBuf src2)` overload that copies both buffers into the write buffer under a single lock acquisition, with a single position/unpersisted-bytes update. The two source buffers are passed as separate arguments — deliberately avoiding a `CompositeByteBuf`, which would add a per-entry allocation and component bookkeeping.
- The existing single-buffer `write()` is refactored onto the same internal helpers, with identical behavior.
- `Journal` now writes the length prefix and entry payload with one call.
- `SlowBufferedChannel` (test injection hook) overrides the new method so the configured add-delay still applies.
- New unit test `testWriteTwoBuffers` covers boundary crossings: payloads that fit, exactly fill, straddle the write-buffer capacity, and exceed it (multiple internal flushes in one call), verifying `position()` and the resulting file contents.

Verified: `BufferedChannelTest` (9/9, including the new test), `BookieJournalTest`, `BookieWriteToJournalTest`, `BookieJournalForceTest`, `BookieJournalPageCacheFlushTest`, `BookieJournalNoSyncTest`, `BookieJournalMaxMemoryTest` (30/30), and module checkstyle.
