### PR TITLE
Add OpenBuilder.withKeepUpdateMetadata and DeleteBuilder.withLoggerContext to the builder API

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerDeleteOp.java
@@ -21,6 +21,8 @@
 
 package org.apache.bookkeeper.client;
 
+import io.github.merlimat.slog.Logger;
+import io.github.merlimat.slog.LoggerBuilder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -36,8 +38,9 @@ import org.apache.bookkeeper.versioning.Version;
  * Encapsulates asynchronous ledger delete operation.
  *
  */
-@CustomLog
 class LedgerDeleteOp {
+
+    private final Logger log;
 
     final BookKeeper bk;
     final long ledgerId;
@@ -60,6 +63,16 @@ class LedgerDeleteOp {
      */
     LedgerDeleteOp(BookKeeper bk, BookKeeperClientStats clientStats,
                    long ledgerId, DeleteCallback cb, Object ctx) {
+        this(bk, clientStats, ledgerId, cb, ctx, null);
+    }
+
+    LedgerDeleteOp(BookKeeper bk, BookKeeperClientStats clientStats,
+                   long ledgerId, DeleteCallback cb, Object ctx, Logger parentLogger) {
+        LoggerBuilder builder = Logger.get(LedgerDeleteOp.class).with();
+        if (parentLogger != null) {
+            builder = builder.ctx(parentLogger);
+        }
+        this.log = builder.attr("ledgerId", ledgerId).build();
         this.bk = bk;
         this.ledgerId = ledgerId;
         this.cb = cb;
@@ -77,6 +90,7 @@ class LedgerDeleteOp {
         bk.getLedgerManager().removeLedgerMetadata(ledgerId, Version.ANY)
             .whenCompleteAsync((ignore, exception) -> {
                     if (exception != null) {
+                        log.debug().exception(exception).log("Failed to delete ledger");
                         deleteOpLogger.registerFailedEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
                     } else {
                         deleteOpLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startTime), TimeUnit.NANOSECONDS);
@@ -90,9 +104,11 @@ class LedgerDeleteOp {
         return String.format("LedgerDeleteOp(%d)", ledgerId);
     }
 
+    @CustomLog
     static class DeleteBuilderImpl  implements DeleteBuilder {
 
         private Long builderLedgerId;
+        private Logger builderParentLogger;
         private final BookKeeper bk;
 
         DeleteBuilderImpl(BookKeeper bk) {
@@ -102,6 +118,12 @@ class LedgerDeleteOp {
         @Override
         public DeleteBuilder withLedgerId(long ledgerId) {
             this.builderLedgerId = ledgerId;
+            return this;
+        }
+
+        @Override
+        public DeleteBuilder withLoggerContext(Logger parentLogger) {
+            this.builderParentLogger = parentLogger;
             return this;
         }
 
@@ -126,7 +148,8 @@ class LedgerDeleteOp {
                 cb.deleteComplete(BKException.Code.IncorrectParameterException, null);
                 return;
             }
-            LedgerDeleteOp op = new LedgerDeleteOp(bk, bk.getClientCtx().getClientStats(), ledgerId, cb, null);
+            LedgerDeleteOp op = new LedgerDeleteOp(bk, bk.getClientCtx().getClientStats(), ledgerId, cb, null,
+                    builderParentLogger);
             ReentrantReadWriteLock closeLock = bk.getCloseLock();
             closeLock.readLock().lock();
             try {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerOpenOp.java
@@ -358,7 +358,11 @@ class LedgerOpenOp {
                     return;
                 }
                 if (recovery) {
-                    op.initiate();
+                    if (keepUpdateMetadata) {
+                        op.initiateWithKeepUpdateMetadata();
+                    } else {
+                        op.initiate();
+                    }
                 } else {
                     op.initiateWithoutRecovery();
                 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/DeleteBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/DeleteBuilder.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.client.api;
 
+import io.github.merlimat.slog.Logger;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
 
@@ -40,5 +41,22 @@ public interface DeleteBuilder extends OpBuilder<Void> {
      * @return the builder itself
      */
     DeleteBuilder withLedgerId(long ledgerId);
+
+    /**
+     * Inherit the context attributes of the given slog {@link Logger} on the logger used by the delete operation.
+     * Every log statement emitted while executing the delete will carry the parent logger's context attributes,
+     * in addition to the {@code ledgerId} attribute that is always added by the client.
+     *
+     * <p>Useful for correlating bookkeeper-client log output with the application's own request / tenant / trace
+     * identifiers — typically the application has built a per-request logger via
+     * {@code Logger.get(...).with().attr(...)...build()} and passes it here.
+     *
+     * @param parentLogger logger whose context attributes to inherit; {@code null} is treated as no extra context
+     *
+     * @return the builder itself
+     */
+    default DeleteBuilder withLoggerContext(Logger parentLogger) {
+        return this;
+    }
 
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/OpenBuilder.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/api/OpenBuilder.java
@@ -74,6 +74,22 @@ public interface OpenBuilder extends OpBuilder<ReadHandle> {
     OpenBuilder withDigestType(DigestType digestType);
 
     /**
+     * Whether to keep updating the metadata of the resulting {@link ReadHandle} if the auto-recovery component
+     * modifies the ledger's ensemble (e.g. when it re-replicates the ledger's data after a bookie becomes
+     * unavailable). It defaults to 'false'.
+     *
+     * <p>This setting only has an effect when the ledger is opened in recovery mode (see
+     * {@link #withRecovery(boolean)}); a ledger opened in readonly mode always keeps its metadata updated.
+     *
+     * @param keepUpdateMetadata whether to keep the ledger metadata updated
+     *
+     * @return the builder itself
+     */
+    default OpenBuilder withKeepUpdateMetadata(boolean keepUpdateMetadata) {
+        return this;
+    }
+
+    /**
      * Inherit the context attributes of the given slog {@link Logger} on the logger bound to
      * the resulting {@link ReadHandle}. Every log statement emitted by the handle (and by the open-time machinery
      * that produces it) will carry the parent logger's context attributes, in addition to the {@code ledgerId}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/OpenBuilderBase.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/OpenBuilderBase.java
@@ -36,6 +36,7 @@ public abstract class OpenBuilderBase implements OpenBuilder {
     protected long ledgerId = LedgerHandle.INVALID_LEDGER_ID;
     protected byte[] password;
     protected DigestType digestType = DigestType.CRC32;
+    protected boolean keepUpdateMetadata = false;
     protected Logger parentLogger;
 
     @Override
@@ -59,6 +60,12 @@ public abstract class OpenBuilderBase implements OpenBuilder {
     @Override
     public OpenBuilder withDigestType(DigestType digestType) {
         this.digestType = digestType;
+        return this;
+    }
+
+    @Override
+    public OpenBuilder withKeepUpdateMetadata(boolean keepUpdateMetadata) {
+        this.keepUpdateMetadata = keepUpdateMetadata;
         return this;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/BookKeeperBuildersTest.java
@@ -26,6 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -368,6 +373,35 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
     }
 
     @Test
+    public void testOpenLedgerWithRecoveryAndKeepUpdateMetadata() throws Exception {
+        registerMockLedgerMetadata(ledgerId, generateClosedLedgerMetadata());
+
+        ReadHandle reader = newOpenLedgerOp()
+            .withPassword(password)
+            .withLedgerId(ledgerId)
+            .withRecovery(true)
+            .withKeepUpdateMetadata(true)
+            .execute()
+            .get();
+        assertEquals(ledgerId, reader.getId());
+        verify(ledgerManager).registerLedgerMetadataListener(eq(ledgerId), any());
+    }
+
+    @Test
+    public void testOpenLedgerWithRecoveryNoKeepUpdateMetadata() throws Exception {
+        registerMockLedgerMetadata(ledgerId, generateClosedLedgerMetadata());
+
+        ReadHandle reader = newOpenLedgerOp()
+            .withPassword(password)
+            .withLedgerId(ledgerId)
+            .withRecovery(true)
+            .execute()
+            .get();
+        assertEquals(ledgerId, reader.getId());
+        verify(ledgerManager, never()).registerLedgerMetadataListener(anyLong(), any());
+    }
+
+    @Test
     public void testDeleteLedgerNoLedgerId() throws Exception {
         assertThrows(BKIncorrectParameterException.class, () -> {
             result(newDeleteLedgerOp()
@@ -418,6 +452,15 @@ public class BookKeeperBuildersTest extends MockBookKeeperTestCase {
             .withCustomMetadata(customMetadata)
             .withCreationTime(System.currentTimeMillis())
             .newEnsembleEntry(0, generateNewEnsemble(ensembleSize)).build();
+    }
+
+    private LedgerMetadata generateClosedLedgerMetadata() throws BKException.BKNotEnoughBookiesException {
+        return LedgerMetadataBuilder.from(generateLedgerMetadata(ensembleSize,
+                writeQuorumSize, ackQuorumSize, password, customMetadata))
+            .withClosedState()
+            .withLastEntryId(-1)
+            .withLength(0)
+            .build();
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/LoggerContextTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/api/LoggerContextTest.java
@@ -29,11 +29,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.client.MockBookKeeperTestCase;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
@@ -41,8 +43,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that the slog {@link Logger} passed to {@link CreateBuilder#withLoggerContext} /
- * {@link OpenBuilder#withLoggerContext} contributes its context attributes to every log event
- * emitted by the resulting handle (and by the create/open machinery that produces it).
+ * {@link OpenBuilder#withLoggerContext} / {@link DeleteBuilder#withLoggerContext} contributes its
+ * context attributes to every log event emitted by the resulting handle (and by the
+ * create/open/delete machinery that produces it).
  */
 public class LoggerContextTest extends MockBookKeeperTestCase {
 
@@ -84,7 +87,7 @@ public class LoggerContextTest extends MockBookKeeperTestCase {
         appender.start();
         config.addAppender(appender);
         LoggerConfig root = config.getRootLogger();
-        root.addAppender(appender, root.getLevel(), null);
+        root.addAppender(appender, Level.ALL, null);
         ctx.updateLoggers();
         return appender;
     }
@@ -140,6 +143,37 @@ public class LoggerContextTest extends MockBookKeeperTestCase {
     }
 
     @Test
+    public void deleteBuilder_withLoggerContext_propagatesIntoLogEvents() throws Exception {
+        // Delete a ledger that does not exist. LedgerDeleteOp logs the failure at debug
+        // level via its contextual logger, which should carry both the parent logger's
+        // attrs and the always-present ledgerId.
+        Logger requestLog = requestLogger("req-del", "acme");
+
+        Configurator.setLevel("org.apache.bookkeeper.client.LedgerDeleteOp", Level.DEBUG);
+        CapturingAppender appender = installAppender("LedgerDeleteOp");
+        try {
+            try {
+                newDeleteLedgerOp()
+                        .withLedgerId(ledgerId)
+                        .withLoggerContext(requestLog)
+                        .execute()
+                        .get();
+            } catch (Exception ignored) {
+                // expected — ledger doesn't exist in the mock
+            }
+        } finally {
+            uninstallAppender(appender);
+            Configurator.setLevel("org.apache.bookkeeper.client.LedgerDeleteOp", Level.INFO);
+        }
+
+        Map<String, String> ctxData = appender.firstMatch().orElseThrow(
+                () -> new AssertionError("expected to capture a LogEvent from LedgerDeleteOp"));
+        assertEquals("req-del", ctxData.get("requestId"));
+        assertEquals("acme", ctxData.get("tenant"));
+        assertEquals(String.valueOf(ledgerId), ctxData.get("ledgerId"));
+    }
+
+    @Test
     public void openBuilder_withLoggerContext_compilesAndChains() throws Exception {
         OpenBuilder ob = newOpenLedgerOp()
                 .withLedgerId(ledgerId)
@@ -153,6 +187,13 @@ public class LoggerContextTest extends MockBookKeeperTestCase {
         CreateBuilder cb = newCreateLedgerOp().withPassword(password);
         CreateBuilder cb2 = cb.withLoggerContext(requestLogger("req-1", "acme"));
         assertTrue(cb2 instanceof CreateBuilder);
+    }
+
+    @Test
+    public void deleteBuilder_withLoggerContext_compilesAndChains() throws Exception {
+        DeleteBuilder db = newDeleteLedgerOp().withLedgerId(ledgerId);
+        DeleteBuilder db2 = db.withLoggerContext(requestLogger("req-1", "acme"));
+        assertTrue(db2 instanceof DeleteBuilder);
     }
 
     @Test
@@ -191,5 +232,22 @@ public class LoggerContextTest extends MockBookKeeperTestCase {
                 .execute()
                 .get();
         assertEquals(ledgerId, writer.getId());
+    }
+
+    @Test
+    public void deleteBuilder_withLoggerContext_nullIsTreatedAsNoExtraContext() throws Exception {
+        setNewGeneratedLedgerId(ledgerId);
+        WriteHandle writer = newCreateLedgerOp()
+                .withEnsembleSize(3).withWriteQuorumSize(2).withAckQuorumSize(1)
+                .withPassword(password)
+                .execute()
+                .get();
+        assertEquals(ledgerId, writer.getId());
+
+        newDeleteLedgerOp()
+                .withLedgerId(ledgerId)
+                .withLoggerContext(null)
+                .execute()
+                .get();
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Follow-up to BP-69 (#4766), which added `CreateBuilder.withLoggerContext` / `OpenBuilder.withLoggerContext` so applications can attach their slog logging context to created/opened ledgers.

### Motivation

Two gaps block applications (specifically Apache Pulsar) from carrying application logging context on all ledger operations through the builder API:

1. Only the classic callback API `BookKeeper.asyncOpenLedger(lId, digestType, passwd, cb, ctx, keepUpdateMetadata)` can set `keepUpdateMetadata`. Pulsar's recovery-open call sites (`ManagedLedgerImpl` initialize, `ManagedCursorImpl` cursor recovery, `BookkeeperSchemaStorage` / `CompactedTopicImpl` / `BookkeeperBucketSnapshotStorage` opens) all pass `keepUpdateMetadata=true`, so they cannot migrate to the builder API and therefore cannot use `withLoggerContext`.
2. `DeleteBuilder` had no `withLoggerContext`, so deletes could not carry application context.

### Changes

**`OpenBuilder.withKeepUpdateMetadata(boolean)`** (first commit)

- New default method returning `this` on the `@Public`/`@Unstable` interface, keeping source compatibility for out-of-tree implementors (same approach as `withLoggerContext`).
- `OpenBuilderBase` stores the flag; `LedgerOpenOp.OpenBuilderImpl` calls `initiateWithKeepUpdateMetadata()` when the flag is set on a recovery open. The flag only has an effect for recovery opens — non-recovery opens always register the metadata listener immediately — matching the classic API, which only exposes the flag on the recovery-open overload.
- Tests in `BookKeeperBuildersTest` verify the ledger metadata listener is registered when opening with recovery and the flag set, and not registered without it.

**`DeleteBuilder.withLoggerContext(Logger)`** (second commit)

- New default no-op method mirroring BP-69's CreateBuilder/OpenBuilder support.
- `DeleteBuilderImpl` passes the parent logger to `LedgerDeleteOp`, whose logger is now a per-op contextual logger (parent context via slog's `LoggerBuilder.ctx(Logger)` plus the always-present `ledgerId` attribute), like `LedgerOpenOp`. The lombok `@CustomLog` static logger moved to `DeleteBuilderImpl`, its only remaining user (builder validation runs before an op exists).
- One behavioral addition: delete failures are now logged at debug level through the contextual logger — the delete path previously had no per-op log statements, so the context would have had nothing to ride on. Failures keep being reported to the caller via the callback, and debug level keeps the log silent at default levels (double deletes are routine for some applications).
- `LoggerContextTest` gains the DeleteBuilder chain and null-is-no-op tests, plus a deterministic check that a failed delete's debug event carries the parent logger's attributes and the `ledgerId`.

Verified with `BookKeeperBuildersTest` (31 tests) and `LoggerContextTest` (8 tests), and `checkstyle:check` — all green.
