### PR TITLE
Skip journal flush-trace loop when debug logging is disabled

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -1151,14 +1151,17 @@ public class Journal implements CheckpointSource {
                                 journalFlushWatcher.stop().elapsed(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS);
 
                         // Trace the lifetime of entries through persistence
-                        for (QueueEntry e : toFlush) {
-                            if (e != null) {
-                                log.debug()
-                                        .attr("ledgerId", e.ledgerId)
-                                        .attr("entryId", e.entryId)
-                                        .log("Written and queuing for flush");
+                        RecyclableArrayList<QueueEntry> flushedEntries = toFlush;
+                        log.debug(e -> {
+                            for (QueueEntry entry : flushedEntries) {
+                                if (entry != null) {
+                                    log.debug()
+                                            .attr("ledgerId", entry.ledgerId)
+                                            .attr("entryId", entry.entryId)
+                                            .log("Written and queuing for flush");
+                                }
                             }
-                        }
+                        });
 
                         journalStats.getForceWriteBatchEntriesStats()
                             .registerSuccessfulValue(numEntriesToFlush);


### PR DESCRIPTION
### Motivation

After every journal flush, a second pass iterates the whole `toFlush` list purely to emit per-entry DEBUG trace lines. When DEBUG is disabled (the normal production configuration), the loop still runs: it allocates an `Iterator` per flush and walks the full list doing null checks for nothing.

### Changes

Wrap the trace loop in slog's lazy consumer form, `log.debug(e -> { ... })`, which returns immediately without invoking the consumer when DEBUG is disabled — no iteration, no iterator. A local alias of `toFlush` is captured since the field variable is reassigned after the hand-off to the force-write thread (not effectively final).

Verified with `BookieJournalTest` and `BookieJournalForceTest` (22/22 pass) and module checkstyle.
