### PR TITLE
Add support for cancelling LocationIndex RocksDB compactions

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -272,6 +272,25 @@ public interface LedgerStorage {
         return false;
     }
 
+    /**
+     * Cancel running entry-location index compactions.
+     *
+     * @return whether a cancellation request was accepted for each entry-location database
+     */
+    default Map<String, Boolean> cancelEntryLocationCompaction() {
+        return cancelEntryLocationCompaction(getEntryLocationDBPath());
+    }
+
+    /**
+     * Cancel running entry-location index compactions for specified databases.
+     *
+     * @param locations entry-location database paths to cancel
+     * @return whether a cancellation request was accepted for each database
+     */
+    default Map<String, Boolean> cancelEntryLocationCompaction(List<String> locations) {
+        return Collections.emptyMap();
+    }
+
     default Map<String, Boolean> isEntryLocationCompacting(List<String> locations) {
         return Collections.emptyMap();
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorage.java
@@ -571,6 +571,18 @@ public class DbLedgerStorage implements LedgerStorage {
     }
 
     @Override
+    public Map<String, Boolean> cancelEntryLocationCompaction(List<String> locations) {
+        HashMap<String, Boolean> cancelledCompactions = Maps.newHashMap();
+        for (SingleDirectoryDbLedgerStorage ledgerStorage : ledgerStorageList) {
+            String entryLocation = ledgerStorage.getEntryLocationDBPath().get(0);
+            if (locations.contains(entryLocation)) {
+                cancelledCompactions.put(entryLocation, ledgerStorage.cancelEntryLocationCompact());
+            }
+        }
+        return cancelledCompactions;
+    }
+
+    @Override
     public Map<String, Boolean> isEntryLocationCompacting(List<String> locations) {
         HashMap<String, Boolean> isCompacting = Maps.newHashMap();
         for (SingleDirectoryDbLedgerStorage ledgerStorage : ledgerStorageList) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndex.java
@@ -206,9 +206,16 @@ public class EntryLocationIndex implements Closeable {
         try {
             isCompacting = true;
             locationsDb.compact();
+        } catch (EntryLocationIndexCompactionCancelledException e) {
+            log.info().attr("directory", getEntryLocationDBPath())
+                    .log("Entry location index RocksDB compaction cancelled");
         } finally {
             isCompacting = false;
         }
+    }
+
+    public boolean cancelCompaction() {
+        return locationsDb.cancelCompaction();
     }
 
     public boolean isCompacting() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexCompactionCancelledException.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexCompactionCancelledException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.bookie.storage.ldb;
+
+import java.io.IOException;
+
+/**
+ * Signals that an operator cancelled a manually triggered entry-location index RocksDB compaction.
+ */
+class EntryLocationIndexCompactionCancelledException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    EntryLocationIndexCompactionCancelledException(Throwable cause) {
+        super("Manually triggered entry-location index RocksDB compaction cancelled", cause);
+    }
+}

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
@@ -112,6 +112,15 @@ public interface KeyValueStorage extends Closeable {
     default void compact() throws IOException {}
 
     /**
+     * Cancel the active full-range compaction.
+     *
+     * @return true if there was a compaction to cancel
+     */
+    default boolean cancelCompaction() {
+        return false;
+    }
+
+    /**
      * Get storage path.
      */
     String getDBPath();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -49,6 +49,7 @@ import org.rocksdb.Cache;
 import org.rocksdb.ChecksumType;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.CompactRangeOptions;
 import org.rocksdb.CompressionType;
 import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
@@ -64,6 +65,7 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksObject;
 import org.rocksdb.Slice;
+import org.rocksdb.Status;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
@@ -90,6 +92,8 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
     private final ReadOptions optionDontCache;
     private final WriteBatch emptyBatch;
     private final int writeBatchMaxSize;
+    private final Object compactionLock = new Object();
+    private CompactRangeOptions currentCompactRangeOptions;
 
     private String dbPath;
 
@@ -408,6 +412,8 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
 
     @Override
     public void compact() throws IOException {
+        // setCanceled(false) initializes the native atomic flag before CompactRange receives its options copy.
+        CompactRangeOptions compactRangeOptions = new CompactRangeOptions().setCanceled(false);
         try {
             final long start = System.currentTimeMillis();
             final int oriRocksDBFileCount = db.getLiveFilesMetaData().size();
@@ -417,7 +423,10 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
                     .attr("fileCount", oriRocksDBFileCount)
                     .attr("sizeBytes", oriRocksDBSize).log("Starting RocksDB compact");
 
-            db.compactRange();
+            synchronized (compactionLock) {
+                currentCompactRangeOptions = compactRangeOptions;
+            }
+            db.compactRange(db.getDefaultColumnFamily(), null, null, compactRangeOptions);
 
             final long end = System.currentTimeMillis();
             final int rocksDBFileCount = db.getLiveFilesMetaData().size();
@@ -429,8 +438,46 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
                     .attr("fileCount", rocksDBFileCount).attr("sizeBytes", rocksDBSize)
                     .log("RocksDB compact finished");
         } catch (RocksDBException e) {
+            if (isCurrentCompactionCancellation(compactRangeOptions, e)) {
+                throw new EntryLocationIndexCompactionCancelledException(e);
+            }
             throw new IOException("Error in RocksDB compact", e);
+        } finally {
+            synchronized (compactionLock) {
+                if (currentCompactRangeOptions == compactRangeOptions) {
+                    currentCompactRangeOptions = null;
+                }
+                compactRangeOptions.close();
+            }
         }
+    }
+
+    @Override
+    public boolean cancelCompaction() {
+        synchronized (compactionLock) {
+            if (currentCompactRangeOptions == null) {
+                return false;
+            }
+            currentCompactRangeOptions.setCanceled(true);
+            return true;
+        }
+    }
+
+    private boolean isCurrentCompactionCancellation(CompactRangeOptions compactRangeOptions,
+                                                    RocksDBException exception) {
+        synchronized (compactionLock) {
+            return currentCompactRangeOptions == compactRangeOptions
+                    && compactRangeOptions.canceled()
+                    && isCompactionCancellationStatus(exception);
+        }
+    }
+
+    static boolean isCompactionCancellationStatus(RocksDBException exception) {
+        if (exception.getStatus() == null) {
+            return false;
+        }
+        Status.Code statusCode = exception.getStatus().getCode();
+        return statusCode == Status.Code.Incomplete || statusCode == Status.Code.Aborted;
     }
 
     private long getRocksDBSize() {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -335,6 +335,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         return entryLocationIndex.isCompacting();
     }
 
+    public boolean cancelEntryLocationCompact() {
+        return entryLocationIndex.cancelCompaction();
+    }
+
     @Override
     public List<String> getEntryLocationDBPath() {
         return Lists.newArrayList(entryLocationIndex.getEntryLocationDBPath());

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactService.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/server/http/service/TriggerLocationCompactService.java
@@ -44,6 +44,8 @@ import org.apache.commons.lang3.StringUtils;
  * <p>The PUT method will trigger entry location compact on current bookie.
  *
  * <p>The GET method will get the entry location compact running or not.
+ *
+ * <p>The DELETE method will request cancellation of running entry location compactions.
  * Output would be like:
  *        {
  *           "/data1/bookkeeper/ledgers/current/locations" : "false",
@@ -128,10 +130,35 @@ public class TriggerLocationCompactService implements HttpEndpointService {
             response.setBody(jsonResponse);
             response.setCode(HttpServer.StatusCode.OK);
             return response;
+        } else if (HttpServer.Method.DELETE == request.getMethod()) {
+            Map<String, String> params = request.getParams();
+            String entryLocations = params == null ? "" : params.getOrDefault("entryLocations", "");
+            List<String> locations = entryLocationDBPath;
+            if (StringUtils.isNotBlank(entryLocations)) {
+                Set<String> specifiedLocations = Sets.newHashSet(entryLocations.trim().split(","));
+                if (!CollectionUtils.isSubCollection(specifiedLocations, entryLocationDBPath)) {
+                    String output = String.format("Specified cancel compact entryLocations: %s is invalid. "
+                                    + "Bookie entry location RocksDB path: %s.",
+                            entryLocations, entryLocationDBPath);
+                    response.setBody(JsonUtil.toJson(output));
+                    response.setCode(HttpServer.StatusCode.BAD_REQUEST);
+                    return response;
+                }
+                locations = Lists.newArrayList(specifiedLocations);
+            }
+            Map<String, Boolean> cancelledCompactions = ledgerStorage.cancelEntryLocationCompaction(locations);
+            log.info().attr("bookieId", bookieServer.getBookieId()).attr("locations", locations)
+                    .attr("cancelledCompactions", cancelledCompactions)
+                    .log("Requested entry location index RocksDB compaction cancellation");
+            String jsonResponse = JsonUtil.toJson(cancelledCompactions);
+            log.debug().attr("body", jsonResponse).log("output body");
+            response.setBody(jsonResponse);
+            response.setCode(HttpServer.StatusCode.OK);
+            return response;
         } else {
             response.setCode(HttpServer.StatusCode.METHOD_NOT_ALLOWED);
             response.setBody("Not found method. Should be PUT to trigger entry location compact,"
-                    + " Or GET to get entry location compact state.");
+                    + " GET to get entry location compact state, or DELETE to request its cancellation.");
             return response;
         }
     }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/EntryLocationIndexTest.java
@@ -21,10 +21,18 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider;
@@ -230,5 +238,68 @@ public class EntryLocationIndexTest {
         assertEquals(0, idx.getLocation(12345, 1));
         assertEquals(1, lookupEntryLocationOpStats.getFailureCount());
         assertEquals(1, lookupEntryLocationOpStats.getSuccessCount());
+    }
+
+    @Test
+    public void testCancelCompaction() throws Exception {
+        CountDownLatch compactStarted = new CountDownLatch(1);
+        CountDownLatch allowCompactionToFinish = new CountDownLatch(1);
+        AtomicBoolean cancellationRequested = new AtomicBoolean();
+        KeyValueStorage storage = (KeyValueStorage) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {KeyValueStorage.class}, (proxy, method, args) -> {
+                    if (method.getName().equals("compact")) {
+                        compactStarted.countDown();
+                        allowCompactionToFinish.await();
+                    } else if (method.getName().equals("cancelCompaction")) {
+                        cancellationRequested.set(true);
+                        return true;
+                    }
+                    return null;
+                });
+
+        KeyValueStorageFactory storageFactory = (basePath, subPath, dbConfigType, conf) -> storage;
+        EntryLocationIndex index = new EntryLocationIndex(serverConfiguration, storageFactory, "test",
+                NullStatsLogger.INSTANCE);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> compaction = executor.submit(() -> {
+                index.compact();
+                return null;
+            });
+            assertTrue(compactStarted.await(10, TimeUnit.SECONDS));
+
+            assertTrue(index.cancelCompaction());
+            assertTrue(index.isCompacting());
+            assertTrue(cancellationRequested.get());
+
+            allowCompactionToFinish.countDown();
+            compaction.get(10, TimeUnit.SECONDS);
+            assertFalse(index.isCompacting());
+        } finally {
+            allowCompactionToFinish.countDown();
+            executor.shutdownNow();
+            index.close();
+        }
+    }
+
+    @Test
+    public void testCancelledCompactionIsHandledAsNormalCompletion() throws Exception {
+        KeyValueStorage storage = (KeyValueStorage) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {KeyValueStorage.class}, (proxy, method, args) -> {
+                    if (method.getName().equals("compact")) {
+                        throw new EntryLocationIndexCompactionCancelledException(null);
+                    }
+                    return null;
+                });
+
+        KeyValueStorageFactory storageFactory = (basePath, subPath, dbConfigType, conf) -> storage;
+        EntryLocationIndex index = new EntryLocationIndex(serverConfiguration, storageFactory, "test",
+                NullStatsLogger.INSTANCE);
+        try {
+            index.compact();
+            assertFalse(index.isCompacting());
+        } finally {
+            index.close();
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.bookie.storage.ldb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -30,17 +31,104 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.junit.Test;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ChecksumType;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactRangeOptions;
 import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
+import org.rocksdb.FlushOptions;
 import org.rocksdb.Options;
+import org.rocksdb.RateLimiter;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Status;
 
 public class KeyValueStorageRocksDBTest {
+
+    @Test
+    public void testCancelledCompactRangeReturnsIncompleteStatus() throws Exception {
+        RocksDB.loadLibrary();
+        File tmpDir = Files.createTempDirectory("bk-kv-rocksdbtest-cancelled-compact").toFile();
+        try (Options options = new Options().setCreateIfMissing(true);
+                RocksDB rocksDB = RocksDB.open(options, tmpDir.toString());
+                CompactRangeOptions compactRangeOptions = new CompactRangeOptions().setCanceled(true)) {
+            rocksDB.put(new byte[] {1}, new byte[] {1});
+
+            RocksDBException exception = assertThrows(RocksDBException.class,
+                    () -> rocksDB.compactRange(rocksDB.getDefaultColumnFamily(), null, null, compactRangeOptions));
+            assertNotNull(exception.getStatus());
+            assertEquals(Status.Code.Incomplete, exception.getStatus().getCode());
+            assertTrue(KeyValueStorageRocksDB.isCompactionCancellationStatus(exception));
+        }
+    }
+
+    @Test
+    public void testCancelInProgressCompactRangeReturnsIncompleteStatus() throws Exception {
+        RocksDB.loadLibrary();
+        File tmpDir = Files.createTempDirectory("bk-kv-rocksdbtest-in-progress-cancel").toFile();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (RateLimiter rateLimiter = new RateLimiter(1024L * 1024 * 1024);
+                Options options = new Options()
+                        .setCreateIfMissing(true)
+                        .setCompressionType(CompressionType.NO_COMPRESSION)
+                        .setDisableAutoCompactions(true)
+                        .setLevelZeroFileNumCompactionTrigger(1000)
+                        .setWriteBufferSize(64 * 1024)
+                        .setTargetFileSizeBase(64 * 1024)
+                        .setMaxBackgroundJobs(1)
+                        .setRateLimiter(rateLimiter);
+                RocksDB rocksDB = RocksDB.open(options, tmpDir.toString());
+                FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true);
+                CompactRangeOptions compactRangeOptions = new CompactRangeOptions()
+                        .setCanceled(false)
+                        .setMaxSubcompactions(1)
+                        .setBottommostLevelCompaction(CompactRangeOptions.BottommostLevelCompaction.kForce)) {
+            byte[] value = new byte[1024 * 1024];
+            for (int i = 0; i < 16; i++) {
+                rocksDB.put(new byte[] {0, 0, 0, (byte) i}, value);
+                rocksDB.flush(flushOptions);
+            }
+
+            rateLimiter.setBytesPerSecond(4L * 1024 * 1024);
+            Future<?> compactRange = executor.submit(() -> {
+                rocksDB.compactRange(rocksDB.getDefaultColumnFamily(), null, null, compactRangeOptions);
+                return null;
+            });
+            Thread.sleep(100);
+            compactRangeOptions.setCanceled(true);
+
+            ExecutionException exception = assertThrows(ExecutionException.class,
+                    () -> compactRange.get(10, TimeUnit.SECONDS));
+            assertTrue(exception.getCause() instanceof RocksDBException);
+            RocksDBException rocksDBException = (RocksDBException) exception.getCause();
+            assertEquals(Status.Code.Incomplete, rocksDBException.getStatus().getCode());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCancelCompactionWhenNoCompactionIsRunning() throws Exception {
+        ServerConfiguration configuration = new ServerConfiguration();
+        File tmpDir = Files.createTempDirectory("bk-kv-rocksdbtest-cancel").toFile();
+        Files.createDirectory(Paths.get(tmpDir.toString(), "subDir"));
+        KeyValueStorageRocksDB rocksDB = new KeyValueStorageRocksDB(tmpDir.toString(), "subDir",
+                KeyValueStorageFactory.DbConfigType.EntryLocation, configuration);
+        try {
+            assertFalse(rocksDB.cancelCompaction());
+        } finally {
+            rocksDB.close();
+        }
+    }
 
     @Test
     public void testRocksDBInitiateWithBookieConfiguration() throws Exception {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
@@ -31,11 +31,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.junit.Test;
 import org.rocksdb.BlockBasedTableConfig;
@@ -47,7 +42,6 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.FlushOptions;
 import org.rocksdb.Options;
-import org.rocksdb.RateLimiter;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
@@ -68,51 +62,6 @@ public class KeyValueStorageRocksDBTest {
             assertNotNull(exception.getStatus());
             assertEquals(Status.Code.Incomplete, exception.getStatus().getCode());
             assertTrue(KeyValueStorageRocksDB.isCompactionCancellationStatus(exception));
-        }
-    }
-
-    @Test
-    public void testCancelInProgressCompactRangeReturnsIncompleteStatus() throws Exception {
-        RocksDB.loadLibrary();
-        File tmpDir = Files.createTempDirectory("bk-kv-rocksdbtest-in-progress-cancel").toFile();
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        try (RateLimiter rateLimiter = new RateLimiter(1024L * 1024 * 1024);
-                Options options = new Options()
-                        .setCreateIfMissing(true)
-                        .setCompressionType(CompressionType.NO_COMPRESSION)
-                        .setDisableAutoCompactions(true)
-                        .setLevelZeroFileNumCompactionTrigger(1000)
-                        .setWriteBufferSize(64 * 1024)
-                        .setTargetFileSizeBase(64 * 1024)
-                        .setMaxBackgroundJobs(1)
-                        .setRateLimiter(rateLimiter);
-                RocksDB rocksDB = RocksDB.open(options, tmpDir.toString());
-                FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true);
-                CompactRangeOptions compactRangeOptions = new CompactRangeOptions()
-                        .setCanceled(false)
-                        .setMaxSubcompactions(1)
-                        .setBottommostLevelCompaction(CompactRangeOptions.BottommostLevelCompaction.kForce)) {
-            byte[] value = new byte[1024 * 1024];
-            for (int i = 0; i < 16; i++) {
-                rocksDB.put(new byte[] {0, 0, 0, (byte) i}, value);
-                rocksDB.flush(flushOptions);
-            }
-
-            rateLimiter.setBytesPerSecond(4L * 1024 * 1024);
-            Future<?> compactRange = executor.submit(() -> {
-                rocksDB.compactRange(rocksDB.getDefaultColumnFamily(), null, null, compactRangeOptions);
-                return null;
-            });
-            Thread.sleep(100);
-            compactRangeOptions.setCanceled(true);
-
-            ExecutionException exception = assertThrows(ExecutionException.class,
-                    () -> compactRange.get(10, TimeUnit.SECONDS));
-            assertTrue(exception.getCause() instanceof RocksDBException);
-            RocksDBException rocksDBException = (RocksDBException) exception.getCause();
-            assertEquals(Status.Code.Incomplete, rocksDBException.getStatus().getCode());
-        } finally {
-            executor.shutdownNow();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/server/http/TestHttpService.java
@@ -1210,6 +1210,16 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         statusMap.put("/data2/bookkeeper/ledgers/current/locations", true);
         when(spyLedgerStorage.isEntryLocationCompacting(dbLocationPath))
                 .thenReturn(statusMap);
+        HashMap<String, Boolean> cancelledCompactions = Maps.newHashMap();
+        cancelledCompactions.put("/data1/bookkeeper/ledgers/current/locations", true);
+        cancelledCompactions.put("/data2/bookkeeper/ledgers/current/locations", false);
+        when(spyLedgerStorage.cancelEntryLocationCompaction(dbLocationPath))
+                .thenReturn(cancelledCompactions);
+        List<String> selectedLocation = Lists.newArrayList("/data1/bookkeeper/ledgers/current/locations");
+        HashMap<String, Boolean> selectedCancelledCompactions = Maps.newHashMap();
+        selectedCancelledCompactions.put("/data1/bookkeeper/ledgers/current/locations", true);
+        when(spyLedgerStorage.cancelEntryLocationCompaction(selectedLocation))
+                .thenReturn(selectedCancelledCompactions);
 
         Field ledgerStorageField = bookieServer.getBookie().getClass().getDeclaredField("ledgerStorage");
         ledgerStorageField.setAccessible(true);
@@ -1265,9 +1275,32 @@ public class TestHttpService extends BookKeeperClusterTestCase {
         assertTrue(response6.getBody().contains("\"/data2/bookkeeper/ledgers/current/locations\" : true"));
         assertTrue(response6.getBody().contains("\"/data1/bookkeeper/ledgers/current/locations\" : false"));
 
-        // 3. POST, should return NOT_FOUND
+        // 3. POST, should return METHOD_NOT_ALLOWED
         HttpServiceRequest request7 = new HttpServiceRequest(null, HttpServer.Method.POST, null);
         HttpServiceResponse response7 = triggerEntryLocationCompactService.handle(request7);
         assertEquals(HttpServer.StatusCode.METHOD_NOT_ALLOWED.getValue(), response7.getStatusCode());
+
+        // 4. DELETE, should cancel the specified running RocksDB compaction
+        Map<String, String> deleteParams = Maps.newHashMap();
+        deleteParams.put("entryLocations", "/data1/bookkeeper/ledgers/current/locations");
+        HttpServiceRequest request8 = new HttpServiceRequest(null, HttpServer.Method.DELETE, deleteParams);
+        HttpServiceResponse response8 = triggerEntryLocationCompactService.handle(request8);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response8.getStatusCode());
+        assertTrue(response8.getBody().contains("\"/data1/bookkeeper/ledgers/current/locations\" : true"));
+        assertFalse(response8.getBody().contains("/data2/bookkeeper/ledgers/current/locations"));
+
+        // 5. DELETE without entryLocations, should request cancellation on all directories
+        HttpServiceRequest request9 = new HttpServiceRequest(null, HttpServer.Method.DELETE, null);
+        HttpServiceResponse response9 = triggerEntryLocationCompactService.handle(request9);
+        assertEquals(HttpServer.StatusCode.OK.getValue(), response9.getStatusCode());
+        assertTrue(response9.getBody().contains("\"/data1/bookkeeper/ledgers/current/locations\" : true"));
+        assertTrue(response9.getBody().contains("\"/data2/bookkeeper/ledgers/current/locations\" : false"));
+
+        // 6. DELETE with an invalid location, should return BAD_REQUEST
+        Map<String, String> invalidDeleteParams = Maps.newHashMap();
+        invalidDeleteParams.put("entryLocations", "/invalid1/locations");
+        HttpServiceRequest request10 = new HttpServiceRequest(null, HttpServer.Method.DELETE, invalidDeleteParams);
+        HttpServiceResponse response10 = triggerEntryLocationCompactService.handle(request10);
+        assertEquals(HttpServer.StatusCode.BAD_REQUEST.getValue(), response10.getStatusCode());
     }
 }

--- a/site3/website/docs/admin/http.md
+++ b/site3/website/docs/admin/http.md
@@ -522,6 +522,32 @@ Currently all the HTTP endpoints could be divided into these 5 components:
        }
        ```
 
+3. Method: DELETE
+    * Description: Request cancellation of running manually triggered entry location index RocksDB compactions.
+      Provide `entryLocations` to cancel selected directories; omit it to cancel all directories on the bookie.
+    * Parameters:
+
+      | Name | Type | Required | Description |
+      |:-----|:-----|:---------|:------------|
+      |entryLocations | String | no | Comma-separated entry location RocksDB paths. |
+
+    * Example: `DELETE /api/v1/bookie/entry_location_compact?entryLocations=/data1/bookkeeper/ledgers/current/locations`
+    * Response:
+
+      | Code   | Description |
+      |:-------|:------------|
+      |200 | Successful operation |
+      |403 | Permission denied |
+      |405 | Method Not Allowed |
+    * Body: The value for each entry location database is true when its cancellation request was accepted. Cancellation
+      is asynchronous; use GET to confirm that the compaction has stopped.
+       ```json
+       {
+          "/data1/bookkeeper/ledgers/current/locations" : true,
+          "/data2/bookkeeper/ledgers/current/locations" : false
+       }
+       ```
+
 ### Endpoint: /api/v1/bookie/state/readonly
 1. Method: GET
     * Description: Get bookie readOnly state.


### PR DESCRIPTION
## Motivation

Allow operators to stop an in-flight manually triggered entry-location index RocksDB compaction.

## Changes

- Add a DELETE endpoint for requesting cancellation, optionally scoped with `entryLocations`.
- Initialize and use RocksDB `CompactRangeOptions` cancellation before starting `CompactRange`; handle RocksDB `Incomplete`/`Aborted` statuses as normal index-compaction cancellation.
- Log the request and the completed cancellation, document asynchronous GET confirmation, and add cancellation coverage.

## Testing

- `mvn -q -pl bookkeeper-server -Dtest=KeyValueStorageRocksDBTest,EntryLocationIndexTest,TestHttpService#testTriggerEntryLocationCompactService test`
- Validated on home3 Linux.