### PR TITLE
Improve scan-and-compare GC metadata cache

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollector.java
@@ -34,6 +34,16 @@ public interface GarbageCollector {
     void gc(GarbageCleaner garbageCleaner);
 
     /**
+     * Do the garbage collector work.
+     *
+     * @param garbageCleaner cleaner used to clean selected garbages
+     * @param force whether this gc cycle is explicitly forced
+     */
+    default void gc(GarbageCleaner garbageCleaner, boolean force) {
+        gc(garbageCleaner);
+    }
+
+    /**
      * A interface used to define customised garbage cleaner.
      */
     interface GarbageCleaner {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -461,7 +461,7 @@ public class GarbageCollectorThread implements Runnable {
         try {
             // gc inactive/deleted ledgers
             // this is used in extractMetaFromEntryLogs to calculate the usage of entry log
-            doGcLedgers();
+            doGcLedgers(force);
 
             long extractMetaStart = MathUtils.nowInNano();
             try {
@@ -577,10 +577,10 @@ public class GarbageCollectorThread implements Runnable {
     /**
      * Do garbage collection ledger index files.
      */
-    private void doGcLedgers() {
+    private void doGcLedgers(boolean force) {
         long gcLedgersStart = MathUtils.nowInNano();
         try {
-            garbageCollector.gc(garbageCleaner);
+            garbageCollector.gc(garbageCleaner, force);
             gcStats.getGcLedgerRuntime()
                     .registerSuccessfulEvent(MathUtils.elapsedNanos(gcLedgersStart), TimeUnit.NANOSECONDS);
         } catch (Throwable t) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.PrimitiveIterator.OfLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -95,6 +97,8 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
 
     // A sorted map to stored all active ledger ids
     protected final SnapshotMap<Long, Boolean> activeLedgers;
+    private LedgerManager ledgerManager;
+    private final Set<Long> notifiedLocalLedgers = ConcurrentHashMap.newKeySet();
 
     // This is the thread that garbage collects the entry logs that do not
     // contain any active ledgers in them; and compacts the entry logs that
@@ -183,6 +187,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         checkNotNull(checkpointer, "invalid null checkpointer");
         this.entryLogger = (DefaultEntryLogger) entryLogger;
         this.entryLogger.addListener(this);
+        this.ledgerManager = ledgerManager;
         ledgerCache = new LedgerCacheImpl(conf, activeLedgers,
                 null == indexDirsManager ? ledgerDirsManager : indexDirsManager, statsLogger);
         gcThread = new GarbageCollectorThread(conf, ledgerManager, ledgerDirsManager,
@@ -337,6 +342,13 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     @Override
     public void setMasterKey(long ledgerId, byte[] masterKey) throws IOException {
         ledgerCache.setMasterKey(ledgerId, masterKey);
+        notifyLedgerAddedToLocalStorage(ledgerId);
+    }
+
+    private void notifyLedgerAddedToLocalStorage(long ledgerId) {
+        if (ledgerManager != null && notifiedLocalLedgers.add(ledgerId)) {
+            ledgerManager.onLedgerAddedToLocalStorage(ledgerId);
+        }
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -509,6 +509,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     @Override
     public void deleteLedger(long ledgerId) throws IOException {
         activeLedgers.remove(ledgerId);
+        notifiedLocalLedgers.remove(ledgerId);
         ledgerCache.deleteLedger(ledgerId);
 
         for (LedgerDeletionListener listener : ledgerDeletionListeners) {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -43,6 +43,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManager.LedgerMetadataCacheResult;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
@@ -117,6 +118,11 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
 
     @Override
     public void gc(GarbageCleaner garbageCleaner) {
+        gc(garbageCleaner, false);
+    }
+
+    @Override
+    public void gc(GarbageCleaner garbageCleaner, boolean force) {
         if (null == ledgerManager) {
             // if ledger manager is null, the bookie is not started to connect to metadata store.
             // so skip garbage collection
@@ -128,6 +134,7 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             NavigableSet<Long> bkActiveLedgers = Sets.newTreeSet(ledgerStorage.getActiveLedgersInRange(0,
                     Long.MAX_VALUE));
             this.activeLedgerCounter = bkActiveLedgers.size();
+            ledgerManager.retainLedgerMetadataBucketsForLedgers(bkActiveLedgers);
 
             long curTime = System.currentTimeMillis();
             boolean checkOverreplicatedLedgers = (enableGcOverReplicatedLedger && curTime
@@ -151,6 +158,11 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
 
             // Iterate over all the ledger on the metadata store
             long zkOpTimeoutMs = this.conf.getZkTimeout() * 2;
+            if (gcLedgersUsingMetadataCache(bkActiveLedgers, garbageCleaner, zkOpTimeoutMs, force)) {
+                return;
+            }
+
+            // Iterate over all the ledger on the metadata store
             LedgerRangeIterator ledgerRangeIterator = ledgerManager
                     .getLedgerRanges(zkOpTimeoutMs);
             Set<Long> ledgersInMetadata = null;
@@ -228,6 +240,80 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             // ignore exception, collecting garbage next time
             log.warn().exception(t).log("Exception when iterating over the metadata");
         }
+    }
+
+    private boolean gcLedgersUsingMetadataCache(NavigableSet<Long> bkActiveLedgers, GarbageCleaner garbageCleaner,
+                                                long zkOpTimeoutMs, boolean force) throws Exception {
+        if (!ledgerManager.supportsLedgerMetadataCache()) {
+            return false;
+        }
+
+        if (force) {
+            ledgerManager.refreshLedgerMetadataBucketsForLedgers(bkActiveLedgers);
+        }
+
+        for (Long bkLid : bkActiveLedgers) {
+            ledgerManager.ensureLedgerMetadataBucketWatched(bkLid);
+            LedgerMetadataCacheResult cacheResult = ledgerManager.lookupLedgerMetadataInCache(bkLid);
+            if (cacheResult == LedgerMetadataCacheResult.UNKNOWN) {
+                continue;
+            }
+            if (cacheResult == LedgerMetadataCacheResult.PRESENT && !verifyMetadataOnGc) {
+                continue;
+            }
+            if (cacheResult == LedgerMetadataCacheResult.PRESENT && !isBookieMissingFromMetadata(bkLid,
+                    zkOpTimeoutMs)) {
+                continue;
+            }
+            if (cacheResult == LedgerMetadataCacheResult.MISSING
+                    && verifyMetadataOnGc && !isBookieMissingFromMetadata(bkLid, zkOpTimeoutMs)) {
+                continue;
+            }
+            if (cacheResult == LedgerMetadataCacheResult.MISSING || verifyMetadataOnGc) {
+                garbageCleaner.clean(bkLid);
+            }
+        }
+        return true;
+    }
+
+    private boolean isBookieMissingFromMetadata(long ledgerId, long zkOpTimeoutMs) throws Exception {
+        AtomicBoolean isBookieInEnsembles = new AtomicBoolean(false);
+        Versioned<LedgerMetadata> metadata = null;
+        int rc = BKException.Code.OK;
+        try {
+            metadata = result(ledgerManager.readLedgerMetadata(ledgerId), zkOpTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (BKException | TimeoutException e) {
+            if (e instanceof BKException) {
+                rc = ((BKException) e).getCode();
+            } else {
+                log.warn()
+                        .attr("ledgerId", ledgerId)
+                        .attr("error", e.getMessage())
+                        .log("Time-out while fetching metadata for ledger");
+                return false;
+            }
+        }
+
+        if (metadata != null && metadata.getValue() != null) {
+            metadata.getValue().getAllEnsembles().forEach((entryId, ensembles) -> {
+                if (ensembles != null && ensembles.contains(selfBookieAddress)) {
+                    isBookieInEnsembles.set(true);
+                }
+            });
+            return !isBookieInEnsembles.get();
+        } else if (!isNoSuchLedgerInMetadataStore(rc)) {
+            log.warn()
+                    .attr("ledgerId", ledgerId)
+                    .attr("rc", rc)
+                    .log("Ledger missing in metadata cache, but ledgerManager returned unexpected rc");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isNoSuchLedgerInMetadataStore(int rc) {
+        return rc == BKException.Code.NoSuchLedgerExistsException
+                || rc == BKException.Code.NoSuchLedgerExistsOnMetadataServerException;
     }
 
     private Set<Long> removeOverReplicatedledgers(Set<Long> bkActiveledgers, final GarbageCleaner garbageCleaner)

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/ScanAndCompareGarbageCollector.java
@@ -258,18 +258,14 @@ public class ScanAndCompareGarbageCollector implements GarbageCollector {
             if (cacheResult == LedgerMetadataCacheResult.UNKNOWN) {
                 continue;
             }
-            if (cacheResult == LedgerMetadataCacheResult.PRESENT && !verifyMetadataOnGc) {
-                continue;
-            }
-            if (cacheResult == LedgerMetadataCacheResult.PRESENT && !isBookieMissingFromMetadata(bkLid,
-                    zkOpTimeoutMs)) {
+            if (cacheResult == LedgerMetadataCacheResult.PRESENT) {
                 continue;
             }
             if (cacheResult == LedgerMetadataCacheResult.MISSING
                     && verifyMetadataOnGc && !isBookieMissingFromMetadata(bkLid, zkOpTimeoutMs)) {
                 continue;
             }
-            if (cacheResult == LedgerMetadataCacheResult.MISSING || verifyMetadataOnGc) {
+            if (cacheResult == LedgerMetadataCacheResult.MISSING) {
                 garbageCleaner.clean(bkLid);
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.PrimitiveIterator.OfLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -150,6 +152,8 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     private final boolean singleLedgerDirs;
     private final String ledgerBaseDir;
     private final String indexBaseDir;
+    private final LedgerManager ledgerManager;
+    private final Set<Long> notifiedLocalLedgers = ConcurrentHashMap.newKeySet();
 
     public SingleDirectoryDbLedgerStorage(ServerConfiguration conf, LedgerManager ledgerManager,
                                           LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
@@ -182,6 +186,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
         this.writeCache = new WriteCache(allocator, writeCacheMaxSize / 2);
         this.writeCacheBeingFlushed = new WriteCache(allocator, writeCacheMaxSize / 2);
         this.singleLedgerDirs = conf.getLedgerDirs().length == 1;
+        this.ledgerManager = ledgerManager;
 
         readCacheMaxSize = readCacheSize;
         this.readAheadCacheBatchSize = readAheadCacheBatchSize;
@@ -457,6 +462,13 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
     public void setMasterKey(long ledgerId, byte[] masterKey) throws IOException {
         log.debug().attr("ledgerId", ledgerId).log("Set master key");
         ledgerIndex.setMasterKey(ledgerId, masterKey);
+        notifyLedgerAddedToLocalStorage(ledgerId);
+    }
+
+    private void notifyLedgerAddedToLocalStorage(long ledgerId) {
+        if (ledgerManager != null && notifiedLocalLedgers.add(ledgerId)) {
+            ledgerManager.onLedgerAddedToLocalStorage(ledgerId);
+        }
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -941,6 +941,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         entryLocationIndex.delete(ledgerId);
         ledgerIndex.delete(ledgerId);
+        notifiedLocalLedgers.remove(ledgerId);
 
         for (int i = 0, size = ledgerDeletionListeners.size(); i < size; i++) {
             LedgerDeletionListener listener = ledgerDeletionListeners.get(i);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/AbstractZkLedgerManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.LedgerMetadataBuilder;
@@ -83,6 +84,37 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
             new ConcurrentHashMap<Long, Set<LedgerMetadataListener>>();
     // we use this to prevent long stack chains from building up in callbacks
     protected ScheduledExecutorService scheduler;
+    private final ConcurrentMap<String, LedgerMetadataBucketSnapshot> ledgerMetadataBucketSnapshots =
+            new ConcurrentHashMap<>();
+    private final Watcher ledgerMetadataBucketWatcher = event -> {
+        if (Event.EventType.None == event.getType()) {
+            if (Event.KeeperState.Expired == event.getState()) {
+                markLedgerMetadataBucketSnapshotsStale();
+            }
+            return;
+        }
+        if (event.getPath() != null) {
+            refreshLedgerMetadataBucket(event.getPath());
+        }
+    };
+
+    private enum LedgerMetadataBucketState {
+        REFRESHING,
+        WATCHED,
+        ABSENT,
+        STALE
+    }
+
+    private static class LedgerMetadataBucketSnapshot {
+        final String bucketPath;
+        final AtomicBoolean refreshing = new AtomicBoolean(false);
+        volatile LedgerMetadataBucketState state = LedgerMetadataBucketState.STALE;
+        volatile NavigableSet<Long> ledgerIds = new TreeSet<>();
+
+        LedgerMetadataBucketSnapshot(String bucketPath) {
+            this.bucketPath = bucketPath;
+        }
+    }
 
     /**
      * ReadLedgerMetadataTask class.
@@ -209,11 +241,149 @@ public abstract class AbstractZkLedgerManager implements LedgerManager, Watcher 
     protected abstract long getLedgerId(String ledgerPath) throws IOException;
 
     @Override
+    public boolean supportsLedgerMetadataCache() {
+        return true;
+    }
+
+    @Override
+    public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+        String bucketPath = getLedgerMetadataBucketPath(ledgerId);
+        LedgerMetadataBucketSnapshot snapshot = ledgerMetadataBucketSnapshots.computeIfAbsent(
+                bucketPath, LedgerMetadataBucketSnapshot::new);
+        if (snapshot.state == LedgerMetadataBucketState.STALE) {
+            refreshLedgerMetadataBucket(bucketPath);
+        }
+    }
+
+    @Override
+    public void onLedgerAddedToLocalStorage(long ledgerId) {
+        refreshLedgerMetadataBucket(getLedgerMetadataBucketPath(ledgerId));
+    }
+
+    @Override
+    public void retainLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+        Set<String> activeBuckets = new HashSet<>();
+        for (Long ledgerId : ledgerIds) {
+            activeBuckets.add(getLedgerMetadataBucketPath(ledgerId));
+        }
+        ledgerMetadataBucketSnapshots.keySet().retainAll(activeBuckets);
+    }
+
+    @Override
+    public void refreshLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+        Set<String> activeBuckets = new HashSet<>();
+        for (Long ledgerId : ledgerIds) {
+            activeBuckets.add(getLedgerMetadataBucketPath(ledgerId));
+        }
+        for (String bucketPath : activeBuckets) {
+            refreshLedgerMetadataBucketSync(bucketPath);
+        }
+    }
+
+    @Override
+    public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+        String bucketPath = getLedgerMetadataBucketPath(ledgerId);
+        LedgerMetadataBucketSnapshot snapshot = ledgerMetadataBucketSnapshots.get(bucketPath);
+        if (snapshot == null) {
+            return LedgerMetadataCacheResult.UNKNOWN;
+        }
+        if (snapshot.state == LedgerMetadataBucketState.WATCHED) {
+            return snapshot.ledgerIds.contains(ledgerId)
+                    ? LedgerMetadataCacheResult.PRESENT : LedgerMetadataCacheResult.MISSING;
+        }
+        if (snapshot.state == LedgerMetadataBucketState.ABSENT) {
+            return LedgerMetadataCacheResult.MISSING;
+        }
+        return LedgerMetadataCacheResult.UNKNOWN;
+    }
+
+    private String getLedgerMetadataBucketPath(long ledgerId) {
+        String ledgerPath = getLedgerPath(ledgerId);
+        int lastSlash = ledgerPath.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return ledgerRootPath;
+        }
+        return ledgerPath.substring(0, lastSlash);
+    }
+
+    private void markLedgerMetadataBucketSnapshotsStale() {
+        ledgerMetadataBucketSnapshots.values().forEach(snapshot -> {
+            snapshot.state = LedgerMetadataBucketState.STALE;
+        });
+    }
+
+    private void refreshLedgerMetadataBucket(String bucketPath) {
+        LedgerMetadataBucketSnapshot snapshot = ledgerMetadataBucketSnapshots.computeIfAbsent(
+                bucketPath, LedgerMetadataBucketSnapshot::new);
+        if (!snapshot.refreshing.compareAndSet(false, true)) {
+            return;
+        }
+        snapshot.state = LedgerMetadataBucketState.REFRESHING;
+        zk.getChildren(bucketPath, ledgerMetadataBucketWatcher, (rc, path, ctx, children, stat) -> {
+            try {
+                if (rc == Code.OK.intValue()) {
+                    snapshot.ledgerIds = ledgerListToSet(children, bucketPath);
+                    snapshot.state = LedgerMetadataBucketState.WATCHED;
+                } else if (rc == Code.NONODE.intValue()) {
+                    snapshot.ledgerIds = new TreeSet<>();
+                    snapshot.state = LedgerMetadataBucketState.ABSENT;
+                } else {
+                    log.warn()
+                            .attr("bucketPath", bucketPath)
+                            .attr("rc", Code.get(rc))
+                            .log("Failed to refresh ledger metadata bucket");
+                    snapshot.state = LedgerMetadataBucketState.STALE;
+                }
+            } catch (Throwable t) {
+                log.warn()
+                        .attr("bucketPath", bucketPath)
+                        .exception(t)
+                        .log("Exception while refreshing ledger metadata bucket");
+                snapshot.state = LedgerMetadataBucketState.STALE;
+            } finally {
+                snapshot.refreshing.set(false);
+            }
+        }, null);
+    }
+
+    private void refreshLedgerMetadataBucketSync(String bucketPath) {
+        LedgerMetadataBucketSnapshot snapshot = ledgerMetadataBucketSnapshots.computeIfAbsent(
+                bucketPath, LedgerMetadataBucketSnapshot::new);
+        snapshot.refreshing.set(true);
+        snapshot.state = LedgerMetadataBucketState.REFRESHING;
+        try {
+            snapshot.ledgerIds = ledgerListToSet(zk.getChildren(bucketPath, ledgerMetadataBucketWatcher), bucketPath);
+            snapshot.state = LedgerMetadataBucketState.WATCHED;
+        } catch (KeeperException.NoNodeException e) {
+            snapshot.ledgerIds = new TreeSet<>();
+            snapshot.state = LedgerMetadataBucketState.ABSENT;
+        } catch (KeeperException e) {
+            log.warn()
+                    .attr("bucketPath", bucketPath)
+                    .attr("rc", e.code())
+                    .log("Failed to refresh ledger metadata bucket");
+            snapshot.state = LedgerMetadataBucketState.STALE;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            snapshot.state = LedgerMetadataBucketState.STALE;
+        } catch (Throwable t) {
+            log.warn()
+                    .attr("bucketPath", bucketPath)
+                    .exception(t)
+                    .log("Exception while refreshing ledger metadata bucket");
+            snapshot.state = LedgerMetadataBucketState.STALE;
+        } finally {
+            snapshot.refreshing.set(false);
+        }
+    }
+
+    @Override
     public void process(WatchedEvent event) {
         log.debug().attr("event", event).log("Received watched event from zookeeper based ledger manager");
         if (Event.EventType.None == event.getType()) {
             if (Event.KeeperState.Expired == event.getState()) {
-                log.info("ZooKeeper client expired on ledger manager.");
+                log.info("ZooKeeper client expired on ledger manager");
+                markLedgerMetadataBucketSnapshotsStale();
                 Set<Long> keySet = new HashSet<Long>(listeners.keySet());
                 for (Long lid : keySet) {
                     scheduler.submit(new ReadLedgerMetadataTask(lid));

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
@@ -226,6 +226,36 @@ public class CleanupLedgerManager implements LedgerManager {
     }
 
     @Override
+    public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+        underlying.ensureLedgerMetadataBucketWatched(ledgerId);
+    }
+
+    @Override
+    public void onLedgerAddedToLocalStorage(long ledgerId) {
+        underlying.onLedgerAddedToLocalStorage(ledgerId);
+    }
+
+    @Override
+    public void retainLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+        underlying.retainLedgerMetadataBucketsForLedgers(ledgerIds);
+    }
+
+    @Override
+    public void refreshLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+        underlying.refreshLedgerMetadataBucketsForLedgers(ledgerIds);
+    }
+
+    @Override
+    public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+        return underlying.lookupLedgerMetadataInCache(ledgerId);
+    }
+
+    @Override
+    public boolean supportsLedgerMetadataCache() {
+        return underlying.supportsLedgerMetadataCache();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public void close() throws IOException {
         Set<GenericCallback> keys;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
@@ -160,6 +160,32 @@ public interface LedgerManager extends Closeable {
      */
     LedgerRangeIterator getLedgerRanges(long zkOpTimeOutMs);
 
+    enum LedgerMetadataCacheResult {
+        PRESENT,
+        MISSING,
+        UNKNOWN
+    }
+
+    default void ensureLedgerMetadataBucketWatched(long ledgerId) {
+    }
+
+    default void onLedgerAddedToLocalStorage(long ledgerId) {
+    }
+
+    default void retainLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+    }
+
+    default void refreshLedgerMetadataBucketsForLedgers(Iterable<Long> ledgerIds) {
+    }
+
+    default LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+        return LedgerMetadataCacheResult.UNKNOWN;
+    }
+
+    default boolean supportsLedgerMetadataCache() {
+        return false;
+    }
+
     /**
      * Used to represent the Ledgers range returned from the
      * current scan.

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -316,11 +316,10 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
                 storage.gcThread.enableForceGC();
                 storage.gcThread.triggerGC().get(); //major
                 storage.gcThread.triggerGC().get(); //minor
-                // Minor and Major compaction times should be larger than when we started
-                // this test.
+                // Minor and Major compaction times should not be earlier than when we started this test.
                 assertTrue("Minor or major compaction did not trigger even on forcing.",
-                    storage.gcThread.lastMajorCompactionTime > startTime
-                        && storage.gcThread.lastMinorCompactionTime > startTime);
+                    storage.gcThread.lastMajorCompactionTime >= startTime
+                        && storage.gcThread.lastMinorCompactionTime >= startTime);
                 storage.shutdown();
             } catch (Exception e) {
                 throw new UncheckedExecutionException(e.getMessage(), e);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
@@ -24,6 +24,9 @@ import static org.apache.bookkeeper.bookie.BookKeeperServerStats.BOOKIE_SCOPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -38,6 +41,7 @@ import java.util.stream.IntStream;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.junit.Before;
@@ -55,6 +59,7 @@ public class SortedLedgerStorageTest {
     ServerConfiguration conf = TestBKConfiguration.newServerConfiguration();
     LedgerDirsManager ledgerDirsManager;
     SortedLedgerStorage sortedLedgerStorage = new SortedLedgerStorage();
+    LedgerManager ledgerManager = mock(LedgerManager.class);
 
     final long numWrites = 2000;
     final long moreNumOfWrites = 3000;
@@ -105,10 +110,20 @@ public class SortedLedgerStorageTest {
         conf.setLedgerDirNames(new String[] { tmpDir.toString() });
         ledgerDirsManager = new LedgerDirsManager(conf, conf.getLedgerDirs(),
                 new DiskChecker(conf.getDiskUsageThreshold(), conf.getDiskUsageWarnThreshold()));
-        sortedLedgerStorage.initialize(conf, null, ledgerDirsManager, ledgerDirsManager,
+        sortedLedgerStorage.initialize(conf, ledgerManager, ledgerDirsManager, ledgerDirsManager,
                                        statsProvider.getStatsLogger(BOOKIE_SCOPE), UnpooledByteBufAllocator.DEFAULT);
         sortedLedgerStorage.setCheckpointSource(checkpointSource);
         sortedLedgerStorage.setCheckpointer(checkpointer);
+    }
+
+    @Test
+    public void testSetMasterKeyNotifiesLedgerAddedToLocalStorageOnce() throws Exception {
+        sortedLedgerStorage.setMasterKey(123L, "ledger-123".getBytes());
+        sortedLedgerStorage.setMasterKey(123L, "ledger-123".getBytes());
+        sortedLedgerStorage.setMasterKey(124L, "ledger-124".getBytes());
+
+        verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(123L);
+        verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(124L);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/SortedLedgerStorageTest.java
@@ -124,6 +124,11 @@ public class SortedLedgerStorageTest {
 
         verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(123L);
         verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(124L);
+
+        sortedLedgerStorage.deleteLedger(123L);
+        sortedLedgerStorage.setMasterKey(123L, "ledger-123".getBytes());
+
+        verify(ledgerManager, times(2)).onLedgerAddedToLocalStorage(123L);
     }
 
     @Test

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -68,6 +68,7 @@ import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieProtocol;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.DiskChecker;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -264,9 +265,14 @@ public class DbLedgerStorageTest {
 
             verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(123L);
             verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(124L);
+
+            dbStorage.deleteLedger(123L);
+            dbStorage.setMasterKey(123L, "ledger-123".getBytes());
+
+            verify(ledgerManager, times(2)).onLedgerAddedToLocalStorage(123L);
         } finally {
             dbStorage.shutdown();
-            dbTmpDir.delete();
+            FileUtils.deleteDirectory(dbTmpDir);
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -24,11 +24,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import java.io.File;
 import java.io.FileInputStream;
@@ -60,7 +64,9 @@ import org.apache.bookkeeper.bookie.TestBookieImpl;
 import org.apache.bookkeeper.bookie.storage.EntryLogger;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.proto.BookieProtocol;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.util.DiskChecker;
 import org.junit.After;
 import org.junit.Assert;
@@ -229,6 +235,38 @@ public class DbLedgerStorageTest {
             fail("Should have thrown exception since the ledger was deleted");
         } catch (Bookie.NoLedgerException e) {
             // ok
+        }
+    }
+
+    @Test
+    public void testSetMasterKeyNotifiesLedgerAddedToLocalStorageOnce() throws Exception {
+        File dbTmpDir = File.createTempFile("bkDbTest", ".dir");
+        dbTmpDir.delete();
+        dbTmpDir.mkdir();
+        File curDir = BookieImpl.getCurrentDirectory(dbTmpDir);
+        BookieImpl.checkDirectoryStructure(curDir);
+
+        ServerConfiguration dbConf = TestBKConfiguration.newServerConfiguration();
+        dbConf.setGcWaitTime(1000);
+        dbConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        dbConf.setLedgerDirNames(new String[] { dbTmpDir.toString() });
+        LedgerDirsManager dbLedgerDirsManager = new LedgerDirsManager(dbConf, dbConf.getLedgerDirs(),
+                ledgerDirsManager.getDiskChecker());
+        DbLedgerStorage dbStorage = new DbLedgerStorage();
+        LedgerManager ledgerManager = mock(LedgerManager.class);
+        try {
+            dbStorage.initialize(dbConf, ledgerManager, dbLedgerDirsManager, dbLedgerDirsManager,
+                    NullStatsLogger.INSTANCE, UnpooledByteBufAllocator.DEFAULT);
+
+            dbStorage.setMasterKey(123L, "ledger-123".getBytes());
+            dbStorage.setMasterKey(123L, "ledger-123".getBytes());
+            dbStorage.setMasterKey(124L, "ledger-124".getBytes());
+
+            verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(123L);
+            verify(ledgerManager, times(1)).onLedgerAddedToLocalStorage(124L);
+        } finally {
+            dbStorage.shutdown();
+            dbTmpDir.delete();
         }
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/AbstractZkLedgerManagerTest.java
@@ -845,4 +845,177 @@ public class AbstractZkLedgerManagerTest extends MockZooKeeperTestCase {
             .getData(anyString(), any(Watcher.class), any(DataCallback.class), any());
     }
 
+    @Test
+    public void testLedgerMetadataBucketCacheRefreshesOnChildrenChanged() throws Exception {
+        long ledgerId = 123L;
+        String ledgerPath = "/ledgers/00/0000/L0123";
+        String bucketPath = "/ledgers/00/0000";
+
+        doAnswer(invocationOnMock -> ledgerPath).when(ledgerManager).getLedgerPath(ledgerId);
+        doAnswer(invocationOnMock -> {
+            String ledgerStr = invocationOnMock.getArgument(0);
+            return ledgerStr.endsWith("L0123") ? ledgerId : 124L;
+        }).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0123"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0124"), new Stat());
+        assertTrue(notifyWatchedEvent(EventType.NodeChildrenChanged, KeeperState.SyncConnected, bucketPath));
+        zkCallbackController.advance(Duration.ZERO);
+
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.MISSING,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+    }
+
+    @Test
+    public void testLocalLedgerAddedRefreshesStaleWatchedBucket() throws Exception {
+        long ledgerId = 123L;
+        String ledgerPath = "/ledgers/00/0000/L0123";
+        String bucketPath = "/ledgers/00/0000";
+
+        doAnswer(invocationOnMock -> ledgerPath).when(ledgerManager).getLedgerPath(ledgerId);
+        doAnswer(invocationOnMock -> {
+            String ledgerStr = invocationOnMock.getArgument(0);
+            return ledgerStr.endsWith("L0123") ? ledgerId : 122L;
+        }).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0122"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.MISSING,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0122", "L0123"), new Stat());
+
+        ledgerManager.onLedgerAddedToLocalStorage(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+    }
+
+    @Test
+    public void testLocalLedgerAddedMarksBucketUnknownWhenRefreshFails() throws Exception {
+        long ledgerId = 123L;
+        String ledgerPath = "/ledgers/00/0000/L0123";
+        String bucketPath = "/ledgers/00/0000";
+
+        doAnswer(invocationOnMock -> ledgerPath).when(ledgerManager).getLedgerPath(ledgerId);
+        doAnswer(invocationOnMock -> {
+            String ledgerStr = invocationOnMock.getArgument(0);
+            return ledgerStr.endsWith("L0123") ? ledgerId : 122L;
+        }).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0122"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.MISSING,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.CONNECTIONLOSS.intValue(),
+                Lists.newArrayList(), new Stat());
+
+        ledgerManager.onLedgerAddedToLocalStorage(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.UNKNOWN,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+    }
+
+    @Test
+    public void testLedgerMetadataBucketCacheReturnsUnknownAfterSessionExpired() throws Exception {
+        long ledgerId = 123L;
+        String ledgerPath = "/ledgers/00/0000/L0123";
+        String bucketPath = "/ledgers/00/0000";
+
+        doAnswer(invocationOnMock -> ledgerPath).when(ledgerManager).getLedgerPath(ledgerId);
+        doAnswer(invocationOnMock -> 122L).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0122"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.MISSING,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+
+        notifyWatchedEvent(EventType.None, KeeperState.Expired, bucketPath);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.UNKNOWN,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+    }
+
+    @Test
+    public void testLedgerMetadataBucketCachePrunesInactiveBuckets() throws Exception {
+        long ledgerId = 123L;
+        long inactiveLedgerId = 987L;
+        String bucketPath = "/ledgers/00/0000";
+        String inactiveBucketPath = "/ledgers/00/0001";
+
+        doAnswer(invocationOnMock -> {
+            long id = invocationOnMock.getArgument(0);
+            return id == ledgerId ? bucketPath + "/L0123" : inactiveBucketPath + "/L0987";
+        }).when(ledgerManager).getLedgerPath(anyLong());
+        doAnswer(invocationOnMock -> {
+            String ledgerStr = invocationOnMock.getArgument(0);
+            return ledgerStr.endsWith("L0123") ? ledgerId : inactiveLedgerId;
+        }).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0123"), new Stat());
+        mockGetChildren(inactiveBucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0987"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        ledgerManager.ensureLedgerMetadataBucketWatched(inactiveLedgerId);
+        zkCallbackController.advance(Duration.ZERO);
+
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(inactiveLedgerId));
+
+        ledgerManager.retainLedgerMetadataBucketsForLedgers(Lists.newArrayList(ledgerId));
+
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.UNKNOWN,
+                ledgerManager.lookupLedgerMetadataInCache(inactiveLedgerId));
+    }
+
+    @Test
+    public void testLedgerMetadataBucketCacheMarksDeletedBucketAbsent() throws Exception {
+        long ledgerId = 123L;
+        String ledgerPath = "/ledgers/00/0000/L0123";
+        String bucketPath = "/ledgers/00/0000";
+
+        doAnswer(invocationOnMock -> ledgerPath).when(ledgerManager).getLedgerPath(ledgerId);
+        doAnswer(invocationOnMock -> ledgerId).when(ledgerManager).getLedgerId(anyString());
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.OK.intValue(),
+                Lists.newArrayList("L0123"), new Stat());
+
+        ledgerManager.ensureLedgerMetadataBucketWatched(ledgerId);
+        zkCallbackController.advance(Duration.ZERO);
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.PRESENT,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+
+        mockGetChildren(bucketPath, true, KeeperException.Code.NONODE.intValue(),
+                Lists.newArrayList(), new Stat());
+        assertTrue(notifyWatchedEvent(EventType.NodeDeleted, KeeperState.SyncConnected, bucketPath));
+        zkCallbackController.advance(Duration.ZERO);
+
+        assertEquals(LedgerManager.LedgerMetadataCacheResult.MISSING,
+                ledgerManager.lookupLedgerMetadataInCache(ledgerId));
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -70,6 +70,7 @@ import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.util.Watcher;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.meta.LedgerManager.LedgerMetadataCacheResult;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRange;
 import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
 import org.apache.bookkeeper.net.BookieId;
@@ -159,6 +160,15 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         getLedgerManager().removeLedgerMetadata(ledgerId, Version.ANY).get(10, TimeUnit.SECONDS);
     }
 
+    private LedgerManager newLedgerManagerWithoutMetadataCache() {
+        return new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return false;
+            }
+        };
+    }
+
     @Test
     public void testGarbageCollectLedgers() throws Exception {
         int numLedgers = 100;
@@ -186,7 +196,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         final CountDownLatch endLatch = new CountDownLatch(2);
         final CompactableLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         TestStatsProvider stats = new TestStatsProvider();
-        final ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(getLedgerManager(),
+        final ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
+                newLedgerManagerWithoutMetadataCache(),
                 mockLedgerStorage, baseConf, stats.getStatsLogger("gc"));
         Thread gcThread = new Thread() {
             @Override
@@ -214,7 +225,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
                         }
                         LOG.info("Garbage Collected ledger {}", ledgerId);
                     }
-                });
+                }, true);
                 LOG.info("Gc Thread quits.");
                 endLatch.countDown();
             }
@@ -263,7 +274,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         MockLedgerStorage mockLedgerStorage = new MockLedgerStorage();
         TestStatsProvider stats = new TestStatsProvider();
-        final ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(getLedgerManager(),
+        final ScanAndCompareGarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
+                newLedgerManagerWithoutMetadataCache(),
                 mockLedgerStorage, baseConf, stats.getStatsLogger("gc"));
         GarbageCollector.GarbageCleaner cleaner = new GarbageCollector.GarbageCleaner() {
                 @Override
@@ -279,7 +291,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
                 }
             };
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertNull("Should have cleaned nothing", cleaned.poll());
         assertTrue(
                 "Wrong ACTIVE_LEDGER_COUNT",
@@ -287,17 +299,17 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         long last = createdLedgers.last();
         removeLedger(last);
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertNotNull("Should have cleaned something", cleaned.peek());
         assertEquals("Should have cleaned last ledger" + last, (long) last, (long) cleaned.poll());
 
         long first = createdLedgers.first();
         removeLedger(first);
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertNotNull("Should have cleaned something", cleaned.peek());
         assertEquals("Should have cleaned first ledger" + first, (long) first, (long) cleaned.poll());
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertTrue(
                 "Wrong ACTIVE_LEDGER_COUNT",
                 garbageCollector.getNumActiveLedgers() == (numLedgers - 2));
@@ -314,8 +326,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         createLedgers(numLedgers, createdLedgers);
 
-        final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(getLedgerManager(),
-                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+        final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
+                newLedgerManagerWithoutMetadataCache(), new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
         GarbageCollector.GarbageCleaner cleaner = new GarbageCollector.GarbageCleaner() {
                 @Override
                 public void clean(long ledgerId) {
@@ -333,12 +345,12 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         assertEquals(createdLedgers, scannedLedgers);
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertTrue("Should have cleaned nothing", cleaned.isEmpty());
 
         long first = createdLedgers.first();
         removeLedger(first);
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertEquals("Should have cleaned something", 1, cleaned.size());
         assertEquals("Should have cleaned first ledger" + first, (long) first, (long) cleaned.get(0));
     }
@@ -362,7 +374,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         conf.setVerifyMetadataOnGc(true);
 
         final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
-                getLedgerManager(), new MockLedgerStorage(), conf, NullStatsLogger.INSTANCE);
+                newLedgerManagerWithoutMetadataCache(), new MockLedgerStorage(), conf, NullStatsLogger.INSTANCE);
 
         // delete created ledgers to simulate the garbage collection scenario
         Iterator<Long> createdLedgersIterator = createdLedgers.iterator();
@@ -401,8 +413,8 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         // no ledger created
 
-        final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(getLedgerManager(),
-                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+        final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(
+                newLedgerManagerWithoutMetadataCache(), new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
         AtomicBoolean cleanerCalled = new AtomicBoolean(false);
 
         GarbageCollector.GarbageCleaner cleaner = new GarbageCollector.GarbageCleaner() {
@@ -415,7 +427,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         validateLedgerRangeIterator(createdLedgers);
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertFalse("Should have cleaned nothing, since no ledger is created", cleanerCalled.get());
     }
 
@@ -443,14 +455,14 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         validateLedgerRangeIterator(createdLedgers);
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertTrue("Should have cleaned nothing", cleaned.isEmpty());
 
         for (long ledgerId : createdLedgers) {
             removeLedger(ledgerId);
         }
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertEquals("Should have cleaned all the created ledgers", createdLedgers, cleaned);
     }
 
@@ -477,6 +489,11 @@ public class GcLedgersTest extends LedgerManagerTestCase {
         createLedgers(numLedgers, createdLedgers);
 
         LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return false;
+            }
+
             @Override
             public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
                 return new LedgerRangeIterator() {
@@ -505,7 +522,7 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         validateLedgerRangeIterator(createdLedgers);
 
-        garbageCollector.gc(cleaner);
+        garbageCollector.gc(cleaner, true);
         assertTrue("Should have cleaned nothing", cleaned.isEmpty());
     }
 
@@ -803,6 +820,11 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
             @Override
+            public boolean supportsLedgerMetadataCache() {
+                return false;
+            }
+
+            @Override
             public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
                 return new LedgerRangeIterator() {
                     @Override
@@ -832,5 +854,236 @@ public class GcLedgersTest extends LedgerManagerTestCase {
 
         garbageCollector.gc(cleaner);
         assertEquals("Should have cleaned all ledgers", cleaned.size(), numLedgers);
+    }
+
+    @Test
+    public void testGcLedgersUsesMetadataCacheWhenAvailable() throws Exception {
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return LedgerMetadataCacheResult.MISSING;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                throw new AssertionError("GC should not read metadata when verifyMetadataOnGc is disabled");
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        final GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+        GarbageCollector.GarbageCleaner cleaner = new GarbageCollector.GarbageCleaner() {
+            @Override
+            public void clean(long ledgerId) {
+                cleaned.add(ledgerId);
+            }
+        };
+
+        garbageCollector.gc(cleaner);
+        assertEquals("Should clean ledger missing from metadata cache when metadata verification is disabled",
+                Collections.singleton(ledgerId), cleaned);
+    }
+
+    @Test
+    public void testGcLedgersDoesNotDeleteNewLedgerMissingFromStaleCache() throws Exception {
+        baseConf.setVerifyMetadataOnGc(true);
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+        LedgerMetadata metadata = newLedgerMetadata(ledgerId, BookieImpl.getBookieId(baseConf));
+        CompletableFuture<Versioned<LedgerMetadata>> existingLedger =
+                CompletableFuture.completedFuture(new Versioned<>(metadata, Version.NEW));
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return LedgerMetadataCacheResult.MISSING;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                return existingLedger;
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+
+        garbageCollector.gc(cleaned::add);
+        assertTrue("Should not clean ledger that still exists in metadata and contains self bookie",
+                cleaned.isEmpty());
+    }
+
+    @Test
+    public void testGcLedgersDeletesExpiredLedgerAfterCacheRefresh() throws Exception {
+        baseConf.setVerifyMetadataOnGc(true);
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+        AtomicInteger lookupCount = new AtomicInteger();
+        CompletableFuture<Versioned<LedgerMetadata>> noSuchLedger = new CompletableFuture<>();
+        noSuchLedger.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return lookupCount.incrementAndGet() == 1
+                        ? LedgerMetadataCacheResult.UNKNOWN : LedgerMetadataCacheResult.MISSING;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                return noSuchLedger;
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+
+        garbageCollector.gc(cleaned::add);
+        assertTrue("Should wait for metadata cache to refresh before cleaning", cleaned.isEmpty());
+
+        garbageCollector.gc(cleaned::add);
+        assertEquals("Should clean expired ledger after cache reports it missing",
+                Collections.singleton(ledgerId), cleaned);
+    }
+
+    @Test
+    public void testGcLedgersDoesNotCleanUnknownMetadataCacheResult() throws Exception {
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return LedgerMetadataCacheResult.UNKNOWN;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                throw new AssertionError("GC should not read metadata when metadata cache result is unknown");
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+
+        garbageCollector.gc(cleaned::add);
+        assertTrue("Should not clean ledger when metadata cache result is unknown", cleaned.isEmpty());
+    }
+
+    @Test
+    public void testGcLedgersDoesNotCleanWhenMetadataVerificationTimesOut() throws Exception {
+        baseConf.setVerifyMetadataOnGc(true);
+        baseConf.setZkTimeout(10);
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+        CompletableFuture<Versioned<LedgerMetadata>> pendingMetadata = new CompletableFuture<>();
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return LedgerMetadataCacheResult.MISSING;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                return pendingMetadata;
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+
+        garbageCollector.gc(cleaned::add);
+        assertTrue("Should not clean ledger when metadata verification times out", cleaned.isEmpty());
+    }
+
+    private LedgerMetadata newLedgerMetadata(long ledgerId, BookieId bookieId) {
+        return LedgerMetadataBuilder.create()
+                .withId(ledgerId)
+                .withDigestType(DigestType.CRC32C)
+                .withPassword(new byte[0])
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .newEnsembleEntry(0L, Lists.newArrayList(bookieId))
+                .build();
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/GcLedgersTest.java
@@ -947,6 +947,46 @@ public class GcLedgersTest extends LedgerManagerTestCase {
     }
 
     @Test
+    public void testGcLedgersDoesNotReadMetadataForPresentCacheResult() throws Exception {
+        baseConf.setVerifyMetadataOnGc(true);
+        final long ledgerId = 1234L;
+        activeLedgers.put(ledgerId, true);
+        final SortedSet<Long> cleaned = Collections.synchronizedSortedSet(new TreeSet<Long>());
+
+        LedgerManager mockLedgerManager = new CleanupLedgerManager(getLedgerManager()) {
+            @Override
+            public boolean supportsLedgerMetadataCache() {
+                return true;
+            }
+
+            @Override
+            public void ensureLedgerMetadataBucketWatched(long ledgerId) {
+            }
+
+            @Override
+            public LedgerMetadataCacheResult lookupLedgerMetadataInCache(long ledgerId) {
+                return LedgerMetadataCacheResult.PRESENT;
+            }
+
+            @Override
+            public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+                throw new AssertionError("GC should not read metadata when ledger is present in metadata cache");
+            }
+
+            @Override
+            public LedgerRangeIterator getLedgerRanges(long zkOpTimeout) {
+                throw new AssertionError("GC should not scan all ledger ranges when metadata cache is available");
+            }
+        };
+
+        GarbageCollector garbageCollector = new ScanAndCompareGarbageCollector(mockLedgerManager,
+                new MockLedgerStorage(), baseConf, NullStatsLogger.INSTANCE);
+
+        garbageCollector.gc(cleaned::add);
+        assertTrue("Should not clean ledger present in metadata cache", cleaned.isEmpty());
+    }
+
+    @Test
     public void testGcLedgersDeletesExpiredLedgerAfterCacheRefresh() throws Exception {
         baseConf.setVerifyMetadataOnGc(true);
         final long ledgerId = 1234L;

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/LedgerDeleteTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.bookie.InterleavedLedgerStorage;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
@@ -32,6 +33,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.util.TestUtils;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -107,6 +109,15 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
         return lhs;
     }
 
+    private void waitUntilEntryLogsDeleted(List<File> ledgerDirectories, Integer... logIds) {
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            for (File ledgerDirectory : ledgerDirectories) {
+                assertFalse("Found the entry log file that should have been deleted in ledgerDirectory: "
+                    + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, logIds));
+            }
+        });
+    }
+
     /**
      * This test writes enough ledger entries to roll over the entry log file.
      * It will then delete all of the ledgers from the client and let the
@@ -128,13 +139,9 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
             bkc.deleteLedger(lh.getId());
         }
         LOG.info("Finished deleting all ledgers so waiting for the GC thread to clean up the entryLogs");
-        Thread.sleep(5000);
 
         // Verify that the first entry log (0.log) has been deleted from all of the Bookie Servers.
-        for (File ledgerDirectory : ledgerDirectories) {
-            assertFalse("Found the entry log file (0.log) that should have been deleted in ledgerDirectory: "
-                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0));
-        }
+        waitUntilEntryLogsDeleted(ledgerDirectories, 0);
     }
 
     /**
@@ -162,7 +169,6 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
             bkc.deleteLedger(lh.getId());
         }
         LOG.info("Finished deleting all ledgers so waiting for the GC thread to clean up the entryLogs");
-        Thread.sleep(5000);
 
         /*
          * Verify that the first two entry logs ([0,1].log) have been deleted
@@ -170,10 +176,7 @@ public class LedgerDeleteTest extends BookKeeperClusterTestCase {
          * test, a new entry log is created. We know then that the first two
          * entry logs should be deleted.
          */
-        for (File ledgerDirectory : bookieLedgerDirs()) {
-            assertFalse("Found the entry log file ([0,1].log) that should have been deleted in ledgerDirectory: "
-                + ledgerDirectory, TestUtils.hasLogFiles(ledgerDirectory, true, 0, 1));
-        }
+        waitUntilEntryLogsDeleted(bookieLedgerDirs(), 0, 1);
     }
 
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
@@ -104,8 +104,11 @@ public class TestZkUtils extends TestCase {
         zkc.getChildren(parentPath, new Watcher() {
             @Override
             public void process(WatchedEvent event) {
-                eventRef.set(event);
-                eventReceived.countDown();
+                if (event.getType() == Watcher.Event.EventType.NodeChildrenChanged
+                        && parentPath.equals(event.getPath())) {
+                    eventRef.set(event);
+                    eventReceived.countDown();
+                }
             }
         });
 
@@ -130,8 +133,11 @@ public class TestZkUtils extends TestCase {
         zkc.exists(childPath, new Watcher() {
             @Override
             public void process(WatchedEvent event) {
-                eventRef.set(event);
-                eventReceived.countDown();
+                if (event.getType() == Watcher.Event.EventType.NodeDeleted
+                        && childPath.equals(event.getPath())) {
+                    eventRef.set(event);
+                    eventReceived.countDown();
+                }
             }
         });
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/TestZkUtils.java
@@ -21,10 +21,15 @@
 package org.apache.bookkeeper.util;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import junit.framework.TestCase;
 import org.apache.bookkeeper.test.ZooKeeperUtil;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
@@ -84,5 +89,57 @@ public class TestZkUtils extends TestCase {
                 null == zkc.exists(ledgerZnodePath, false));
         assertTrue("/ledgers/000" + " zNode should not exist, since it should be deleted recursively",
                 null == zkc.exists(ledgerZnodePath, false));
+    }
+
+    @Test
+    public void testParentChildrenWatchReceivesParentPathWhenChildDeleted() throws Exception {
+        ZooKeeper zkc = zkUtil.getZooKeeperClient();
+        String parentPath = "/parent-watch-test";
+        String childPath = parentPath + "/child";
+        zkc.create(parentPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        zkc.create(childPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        CountDownLatch eventReceived = new CountDownLatch(1);
+        AtomicReference<WatchedEvent> eventRef = new AtomicReference<>();
+        zkc.getChildren(parentPath, new Watcher() {
+            @Override
+            public void process(WatchedEvent event) {
+                eventRef.set(event);
+                eventReceived.countDown();
+            }
+        });
+
+        zkc.delete(childPath, -1);
+
+        assertTrue("parent children watch should fire",
+                eventReceived.await(10, TimeUnit.SECONDS));
+        assertEquals(Watcher.Event.EventType.NodeChildrenChanged, eventRef.get().getType());
+        assertEquals(parentPath, eventRef.get().getPath());
+    }
+
+    @Test
+    public void testChildExistsWatchReceivesChildPathWhenChildDeleted() throws Exception {
+        ZooKeeper zkc = zkUtil.getZooKeeperClient();
+        String parentPath = "/child-watch-test";
+        String childPath = parentPath + "/child";
+        zkc.create(parentPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        zkc.create(childPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+        CountDownLatch eventReceived = new CountDownLatch(1);
+        AtomicReference<WatchedEvent> eventRef = new AtomicReference<>();
+        zkc.exists(childPath, new Watcher() {
+            @Override
+            public void process(WatchedEvent event) {
+                eventRef.set(event);
+                eventReceived.countDown();
+            }
+        });
+
+        zkc.delete(childPath, -1);
+
+        assertTrue("child exists watch should fire",
+                eventReceived.await(10, TimeUnit.SECONDS));
+        assertEquals(Watcher.Event.EventType.NodeDeleted, eventRef.get().getType());
+        assertEquals(childPath, eventRef.get().getPath());
     }
 }


### PR DESCRIPTION
Descriptions of the changes in this PR:

Fixes: N/A

Main Issue: N/A

BP: N/A

### Motivation
<img width="2529" height="585" alt="image" src="https://github.com/user-attachments/assets/c7b95ca0-c324-45b0-8b8c-1f35bbfc3ae5" />

Scan-and-compare GC currently walks all ledger metadata ranges from ZooKeeper to decide whether locally active ledgers still exist in metadata. On deployments with many ledgers, fetching every ledger range can make `ScanAndCompareGarbageCollector.gc()` spend minutes in metadata operations even when the bookie only needs to check a small subset of local ledger buckets.

### Changes

- Add a ledger metadata bucket watch/cache API to `LedgerManager`, with ZooKeeper-backed support in `AbstractZkLedgerManager`.
- Cache child ledgers per metadata bucket and refresh bucket snapshots when ZooKeeper children watches fire, when a local ledger is first observed, when forced GC runs, or when the ZooKeeper session expires.
- Make scan-and-compare GC use the bucket cache before falling back to the full metadata range scan, while preserving metadata verification semantics controlled by `verifyMetadataOnGc`.
- Notify the ledger manager when ledgers first appear in interleaved and DbLedgerStorage local storage.
- Add tests for bucket refresh, stale/unknown cache behavior, deleted buckets, cache pruning, GC cache path behavior, compaction, and ledger deletion timing.
<img width="2880" height="3760" alt="image" src="https://github.com/user-attachments/assets/35ae251f-9a2a-46e7-9d99-106a2f9bb4b2" />


### Verifications

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl bookkeeper-server -am -Dmaven.test.skip=true -Dexec.skip=true -Dmaven.antrun.skip=true compile`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl bookkeeper-server -am -DskipTests -Dexec.skip=true -Dmaven.antrun.skip=true checkstyle:check`
- Previously ran targeted GC/compaction/ledger-delete coverage locally on this branch.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks.
>
> ---
> Be sure to do all the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
>
> - [x] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
>
> ---
