### PR TITLE
Add journal force-write metrics

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -501,10 +501,12 @@ public class Journal implements CheckpointSource {
             final ForceWriteRequest[] localRequests = new ForceWriteRequest[conf.getJournalQueueSize()];
 
             while (running) {
+                long forceWriteThreadStartTime = 0L;
                 try {
                     int numEntriesInLastForceWrite = 0;
 
                     int requestsCount = forceWriteRequests.takeAll(localRequests);
+                    forceWriteThreadStartTime = MathUtils.nowInNano();
 
                     journalStats.getForceWriteQueueSize().addCount(-requestsCount);
 
@@ -534,6 +536,11 @@ public class Journal implements CheckpointSource {
                     Thread.currentThread().interrupt();
                     log.info("ForceWrite thread interrupted");
                     running = false;
+                } finally {
+                    if (forceWriteThreadStartTime != 0L) {
+                        forceWriteThreadTime.addLatency(MathUtils.elapsedNanos(forceWriteThreadStartTime),
+                                TimeUnit.NANOSECONDS);
+                    }
                 }
             }
             // Regardless of what caused us to exit, we should notify the
@@ -1181,8 +1188,19 @@ public class Journal implements CheckpointSource {
                                 || shouldRolloverJournal
                                 || (System.currentTimeMillis() - lastFlushTimeMs
                                 >= journalPageCacheFlushIntervalMSec)) {
-                            forceWriteRequests.put(createForceWriteRequest(logFile, logId, lastFlushPosition,
-                                    toFlush, shouldRolloverJournal));
+                            long enqueueStartTime = MathUtils.nowInNano();
+                            try {
+                                forceWriteRequests.put(createForceWriteRequest(logFile, logId, lastFlushPosition,
+                                        toFlush, shouldRolloverJournal));
+                                journalStats.getFwEnqueueTimeStats()
+                                        .registerSuccessfulEvent(MathUtils.elapsedNanos(enqueueStartTime),
+                                                TimeUnit.NANOSECONDS);
+                            } catch (InterruptedException ie) {
+                                journalStats.getFwEnqueueTimeStats()
+                                        .registerFailedEvent(MathUtils.elapsedNanos(enqueueStartTime),
+                                                TimeUnit.NANOSECONDS);
+                                throw ie;
+                            }
                             lastFlushTimeMs = System.currentTimeMillis();
                         }
                         toFlush = entryListRecycler.newInstance();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieJournalForceTest.java
@@ -20,6 +20,7 @@
  */
 package org.apache.bookkeeper.bookie;
 
+import static org.apache.bookkeeper.bookie.BookKeeperServerStats.JOURNAL_FORCE_WRITE_ENQUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +71,51 @@ public class BookieJournalForceTest {
 
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void testForceWriteMetrics() throws Exception {
+        File journalDir = tempDir.newFolder();
+        BookieImpl.checkDirectoryStructure(BookieImpl.getCurrentDirectory(journalDir));
+
+        String statsScope = "journal";
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration conf = TestBKConfiguration.newServerConfiguration()
+            .setJournalDirName(journalDir.getPath())
+            .setMetadataServiceUri(null)
+            .setJournalAdaptiveGroupWrites(false);
+
+        LedgerDirsManager ledgerDirsManager = mock(LedgerDirsManager.class);
+        Journal journal = spy(new Journal(0, journalDir, conf, ledgerDirsManager,
+                statsProvider.getStatsLogger(statsScope), UnpooledByteBufAllocator.DEFAULT));
+        JournalChannel jc = spy(new JournalChannel(journalDir, 1));
+        doAnswer((Answer<Void>) invocation -> {
+            Thread.sleep(10);
+            invocation.callRealMethod();
+            return null;
+        }).when(jc).forceWrite(false);
+        doReturn(jc).when(journal).newLogFile(anyLong(), nullable(Long.class));
+
+        journal.start();
+
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            journal.logAddEntry(1, 0, DATA, false /* ackBeforeSync */, new WriteCallback() {
+                @Override
+                public void writeComplete(int rc, long ledgerId, long entryId, BookieId addr, Object ctx) {
+                    latch.countDown();
+                }
+            }, null);
+
+            assertTrue(latch.await(20, TimeUnit.SECONDS));
+
+            String journalStatsPath = statsScope + ".journalIndex_0.";
+            assertEquals(1, statsProvider.getOpStatsLogger(journalStatsPath + JOURNAL_FORCE_WRITE_ENQUEUE)
+                    .getSuccessCount());
+            assertTrue(statsProvider.getCounter(journalStatsPath + "force-write-thread-time").get() > 0);
+        } finally {
+            journal.shutdown();
+        }
+    }
 
     @Test
     public void testAckAfterSync() throws Exception {


### PR DESCRIPTION
### Motivation

The journal force-write path already defines metrics for force-write enqueue latency and force-write thread time, but the code does not record them. This makes it harder to distinguish time spent enqueueing force-write requests from time spent syncing or processing callbacks.

### Changes

- Record successful and failed latency for enqueueing force-write requests.
- Record active processing time for each ForceWriteThread batch.
- Add unit coverage for the force-write enqueue metric and thread-time counter.

### Tests

- `mvn -pl bookkeeper-server -Dtest=BookieJournalForceTest test`
- `mvn -pl bookkeeper-server -DskipTests checkstyle:checkstyle`
