### PR TITLE
Fix DbLedgerStorage checkpoint losing ledger metadata when write cache is empty

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/SingleDirectoryDbLedgerStorage.java
@@ -807,6 +807,10 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
 
         try {
             if (writeCache.isEmpty()) {
+                // Ledger metadata updates can be journaled without any pending entry data.
+                // Persist them before allowing the journal checkpoint mark to advance.
+                flushLedgerIndex();
+                lastCheckpoint = thisCheckpoint;
                 return;
             }
             // Swap the write cache so that writes can continue to happen while the flush is
@@ -840,9 +844,7 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                         .log("DB batch flushed");
             }
 
-            long ledgerIndexStartTime = MathUtils.nowInNano();
-            ledgerIndex.flush();
-            recordSuccessfulEvent(dbLedgerStorageStats.getFlushLedgerIndexStats(), ledgerIndexStartTime);
+            flushLedgerIndex();
 
             lastCheckpoint = thisCheckpoint;
 
@@ -883,6 +885,12 @@ public class SingleDirectoryDbLedgerStorage implements CompactableLedgerStorage 
                 flushMutex.unlock();
             }
         }
+    }
+
+    private void flushLedgerIndex() throws IOException {
+        long ledgerIndexStartTime = MathUtils.nowInNano();
+        ledgerIndex.flush();
+        recordSuccessfulEvent(dbLedgerStorageStats.getFlushLedgerIndexStats(), ledgerIndexStartTime);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/DbLedgerStorageTest.java
@@ -108,6 +108,21 @@ public class DbLedgerStorageTest {
         tmpDir.delete();
     }
 
+    private void addEntryAndFlush(long ledgerId, long entryId) throws Exception {
+        storage.setMasterKey(ledgerId, "key".getBytes());
+
+        ByteBuf entry = Unpooled.buffer(1024);
+        entry.writeLong(ledgerId);
+        entry.writeLong(entryId);
+        entry.writeLong(entryId - 1);
+        entry.writeBytes(("entry-" + entryId).getBytes());
+
+        storage.addEntry(entry);
+        storage.flush();
+
+        assertFalse(storage.isFlushRequired());
+    }
+
     @Test
     public void simple() throws Exception {
         assertEquals(false, storage.ledgerExists(3));
@@ -230,6 +245,57 @@ public class DbLedgerStorageTest {
         } catch (Bookie.NoLedgerException e) {
             // ok
         }
+    }
+
+    @Test
+    public void testFlushPersistsFencedMetadataWithoutPendingEntries() throws Exception {
+        long ledgerId = 1;
+        addEntryAndFlush(ledgerId, 0);
+
+        assertTrue(storage.setFenced(ledgerId));
+        assertFalse(storage.isFlushRequired());
+
+        storage.flush();
+        storage.shutdown();
+
+        Bookie restartedBookie = new TestBookieImpl(conf);
+        DbLedgerStorage restartedStorage = (DbLedgerStorage) restartedBookie.getLedgerStorage();
+        try {
+            assertTrue(restartedStorage.isFenced(ledgerId));
+        } finally {
+            restartedStorage.shutdown();
+        }
+
+        storage = (DbLedgerStorage) new TestBookieImpl(conf).getLedgerStorage();
+    }
+
+    @Test
+    public void testFlushPersistsExplicitLacMetadataWithoutPendingEntries() throws Exception {
+        long ledgerId = 1;
+        addEntryAndFlush(ledgerId, 0);
+
+        ByteBuf explicitLac = Unpooled.buffer(Long.BYTES * 2);
+        explicitLac.writeLong(ledgerId);
+        explicitLac.writeLong(0);
+        storage.setExplicitLac(ledgerId, explicitLac);
+        assertFalse(storage.isFlushRequired());
+
+        storage.flush();
+        storage.shutdown();
+
+        Bookie restartedBookie = new TestBookieImpl(conf);
+        DbLedgerStorage restartedStorage = (DbLedgerStorage) restartedBookie.getLedgerStorage();
+        ByteBuf recoveredExplicitLac = null;
+        try {
+            recoveredExplicitLac = restartedStorage.getExplicitLac(ledgerId);
+            Assert.assertNotNull(recoveredExplicitLac);
+            assertEquals(0, ByteBufUtil.compare(explicitLac, recoveredExplicitLac));
+        } finally {
+            ReferenceCountUtil.release(recoveredExplicitLac);
+            restartedStorage.shutdown();
+        }
+
+        storage = (DbLedgerStorage) new TestBookieImpl(conf).getLedgerStorage();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
DbLedgerStorage checkpoint returned early when the write cache was empty, which skipped ledgerIndex.flush(). Ledger metadata updates such as fenced state and explicitLac can be journaled without pending entry data, so checkpointComplete could advance the journal lastMark before those metadata updates were persisted.

### Changes
- Flush the ledger metadata index before returning from an empty-write-cache checkpoint.
- Update the shard checkpoint after the metadata-only flush completes.
- Add regression tests for fenced state and explicitLac persistence after flush/restart with no pending entries.

### Tests
- mvn -pl bookkeeper-server -Dtest=DbLedgerStorageTest#testFlushPersistsFencedMetadataWithoutPendingEntries,DbLedgerStorageTest#testFlushPersistsExplicitLacMetadataWithoutPendingEntries test
- mvn -pl bookkeeper-server -Dtest=DbLedgerStorageTest test
- mvn -pl bookkeeper-server -DskipTests checkstyle:checkstyle