### PR TITLE
Update bc tests to include versions up to 4.17.4

### DIFF
--- a/tests/docker-images/all-released-versions-image/scripts/download-released-versions.sh
+++ b/tests/docker-images/all-released-versions-image/scripts/download-released-versions.sh
@@ -104,8 +104,8 @@ download_tarball \
     "https://archive.apache.org/dist/bookkeeper/bookkeeper-4.16.7" \
     "bookkeeper-server-4.16.7-bin.tar.gz" sha512 asc
 download_tarball \
-    "https://archive.apache.org/dist/bookkeeper/bookkeeper-4.17.2" \
-    "bookkeeper-server-4.17.2-bin.tar.gz" sha512 asc
+    "https://archive.apache.org/dist/bookkeeper/bookkeeper-4.17.4" \
+    "bookkeeper-server-4.17.4-bin.tar.gz" sha512 asc
 
 # GPG key files
 download_if_missing \

--- a/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/bookkeeper/tests/integration/utils/BookKeeperClusterUtils.java
@@ -52,7 +52,7 @@ public class BookKeeperClusterUtils {
     public static final String VERSION_4_14_x = "4.14.8";
     public static final String VERSION_4_15_x = "4.15.5";
     public static final String VERSION_4_16_x = "4.16.7";
-    public static final String VERSION_4_17_x = "4.17.2";
+    public static final String VERSION_4_17_x = "4.17.4";
 
     public static final List<String> OLD_CLIENT_VERSIONS =
             Arrays.asList(VERSION_4_8_x, VERSION_4_9_x, VERSION_4_10_x, VERSION_4_11_x, VERSION_4_12_x,


### PR DESCRIPTION
https://bookkeeper.apache.org/community/release-guide/#verify-docker-image
Once the new docker image is built, update BC tests to include new docker image. 