### PR TITLE
Use ASF-allowlisted dtolnay/rust-toolchain revision in setup-native-build

### DIFF
--- a/.github/actions/setup-native-build/action.yml
+++ b/.github/actions/setup-native-build/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+      uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       with:
         # Cross-compilation targets: Linux amd64 and arm64 (glibc)
         targets: >-


### PR DESCRIPTION
### Motivation
Last update  PR https://github.com/apache/bookkeeper/pull/4828

CI fails on all workflows that use the `setup-native-build` composite action (`bk-ci.yml`, `codeql.yml`, `java21-daily-build.yml`, `windows-daily-build.yml`, `bk-streamstorage-python.yml`, `website-pr-validation.yml`) with:

https://github.com/apache/bookkeeper/actions/runs/30416112341/job/90462887407?pr=4850
```
Error: The action dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 is not allowed in apache/bookkeeper because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: 1Password/load-secrets-action/configure@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556, 1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259, 1Password/load-secrets-action/configure@eb2efd0703da22a93c467f2d1ffbb6826c11e19c, 1Password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556, 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259, 1Password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe, DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25, DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9, DavidA...
```

The ASF approved actions allowlist ([apache/infrastructure-actions](https://github.com/apache/infrastructure-actions/blob/main/actions.yml)) only permits `dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4` (tag: `stable`).

The allowlisted revision is also newer (2026-07-19) than the currently pinned one (2026-06-30); both point at the stable toolchain, so this is a plain upgrade.

### Changes

- Pin `dtolnay/rust-toolchain` in `.github/actions/setup-native-build/action.yml` to the ASF-allowlisted revision `4cda84d5c5c54efe2404f9d843567869ab1699d4`.
