### PR TITLE
Add reproducer for BufferedChannel partial flush position drift

### DIFF
--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BufferedChannelTest.java
@@ -25,8 +25,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import java.io.File;
+import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
@@ -68,6 +74,87 @@ public class BufferedChannelTest {
     @Test
     public void testBufferedChannelFlushForceWrite() throws Exception {
         testBufferedChannel(5000, 30, 0, true, true);
+    }
+
+    @Test
+    public void testPositionCanLagFileChannelAfterPartialFlushFailure() throws Exception {
+        File newLogFile = File.createTempFile("test", "log");
+        newLogFile.deleteOnExit();
+        FileChannel delegate = new RandomAccessFile(newLogFile, "rw").getChannel();
+        PartialFailingFileChannel fileChannel = new PartialFailingFileChannel(delegate, 8);
+
+        BufferedChannel logChannel = new BufferedChannel(UnpooledByteBufAllocator.DEFAULT, fileChannel,
+                16, INTERNAL_BUFFER_READ_CAPACITY, 0);
+
+        try {
+            logChannel.write(Unpooled.wrappedBuffer(new byte[16]));
+            Assert.fail("Expected the internal flush to fail");
+        } catch (IOException expected) {
+            // Expected.
+        }
+
+        Assert.assertEquals(0, logChannel.position());
+        Assert.assertEquals(8, fileChannel.position());
+
+        logChannel.write(Unpooled.wrappedBuffer(new byte[1]));
+
+        Assert.assertEquals(1, logChannel.position());
+        Assert.assertEquals(24, fileChannel.position());
+        Assert.assertEquals(23, fileChannel.position() - logChannel.position());
+
+        logChannel.close();
+    }
+
+    @Test
+    public void testLedgersMapHeaderUsesStalePositionAfterPartialFlushFailure() throws Exception {
+        File newLogFile = File.createTempFile("test", "log");
+        newLogFile.deleteOnExit();
+        FileChannel delegate = new RandomAccessFile(newLogFile, "rw").getChannel();
+        delegate.position(DefaultEntryLogger.LOGFILE_HEADER_SIZE);
+        PartialFailingFileChannel fileChannel = new PartialFailingFileChannel(delegate, 8);
+
+        DefaultEntryLogger.BufferedLogChannel logChannel = new DefaultEntryLogger.BufferedLogChannel(
+                UnpooledByteBufAllocator.DEFAULT, fileChannel, 16, INTERNAL_BUFFER_READ_CAPACITY, 1L, newLogFile, 0);
+
+        try {
+            logChannel.write(Unpooled.wrappedBuffer(new byte[16]));
+            Assert.fail("Expected the internal flush to fail");
+        } catch (IOException expected) {
+            // Expected.
+        }
+
+        logChannel.write(Unpooled.wrappedBuffer(new byte[] { 1 }));
+        logChannel.flush();
+
+        long staleMapOffset = logChannel.position();
+        long actualMapOffset = fileChannel.position();
+        Assert.assertTrue(actualMapOffset > staleMapOffset);
+
+        logChannel.registerWrittenEntry(1234L, 99L);
+        logChannel.appendLedgersMap();
+
+        ByteBuffer mapInfo = ByteBuffer.allocate(Long.BYTES + Integer.BYTES);
+        Assert.assertEquals(mapInfo.capacity(),
+                fileChannel.read(mapInfo, DefaultEntryLogger.LEDGERS_MAP_OFFSET_POSITION));
+        mapInfo.flip();
+        Assert.assertEquals(staleMapOffset, mapInfo.getLong());
+        Assert.assertEquals(1, mapInfo.getInt());
+
+        ByteBuffer actualMap = ByteBuffer.allocate(DefaultEntryLogger.LEDGERS_MAP_HEADER_SIZE);
+        Assert.assertEquals(actualMap.capacity(), fileChannel.read(actualMap, actualMapOffset));
+        actualMap.flip();
+        Assert.assertEquals(DefaultEntryLogger.LEDGERS_MAP_HEADER_SIZE + DefaultEntryLogger.LEDGERS_MAP_ENTRY_SIZE
+                - Integer.BYTES, actualMap.getInt());
+        Assert.assertEquals(DefaultEntryLogger.INVALID_LID, actualMap.getLong());
+        Assert.assertEquals(DefaultEntryLogger.LEDGERS_MAP_ENTRY_ID, actualMap.getLong());
+        Assert.assertEquals(1, actualMap.getInt());
+
+        ByteBuffer staleBytes = ByteBuffer.allocate(DefaultEntryLogger.LEDGERS_MAP_HEADER_SIZE);
+        Assert.assertEquals(staleBytes.capacity(), fileChannel.read(staleBytes, staleMapOffset));
+        staleBytes.flip();
+        Assert.assertNotEquals(DefaultEntryLogger.INVALID_LID, staleBytes.getLong(Integer.BYTES));
+
+        logChannel.close();
     }
 
     public void testBufferedChannel(int byteBufLength, int numOfWrites, int unpersistedBytesBound, boolean flush,
@@ -132,5 +219,115 @@ public class BufferedChannelTest {
         rand.nextBytes(data);
         bb.writeBytes(data);
         return bb;
+    }
+
+    private static final class PartialFailingFileChannel extends FileChannel {
+        private final FileChannel delegate;
+        private final int bytesBeforeFailure;
+        private boolean partialWriteDone;
+        private boolean failureInjected;
+
+        private PartialFailingFileChannel(FileChannel delegate, int bytesBeforeFailure) {
+            this.delegate = delegate;
+            this.bytesBeforeFailure = bytesBeforeFailure;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            if (!partialWriteDone) {
+                int oldLimit = src.limit();
+                src.limit(src.position() + bytesBeforeFailure);
+                int written = delegate.write(src);
+                src.limit(oldLimit);
+                partialWriteDone = true;
+                return written;
+            } else if (!failureInjected) {
+                failureInjected = true;
+                throw new IOException("simulated write failure after partial write");
+            }
+            return delegate.write(src);
+        }
+
+        @Override
+        public long position() throws IOException {
+            return delegate.position();
+        }
+
+        @Override
+        public FileChannel position(long newPosition) throws IOException {
+            delegate.position(newPosition);
+            return this;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            return delegate.read(dst);
+        }
+
+        @Override
+        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            return delegate.read(dsts, offset, length);
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            return delegate.write(srcs, offset, length);
+        }
+
+        @Override
+        public long size() throws IOException {
+            return delegate.size();
+        }
+
+        @Override
+        public FileChannel truncate(long size) throws IOException {
+            delegate.truncate(size);
+            return this;
+        }
+
+        @Override
+        public void force(boolean metaData) throws IOException {
+            delegate.force(metaData);
+        }
+
+        @Override
+        public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+            return delegate.transferTo(position, count, target);
+        }
+
+        @Override
+        public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+            return delegate.transferFrom(src, position, count);
+        }
+
+        @Override
+        public int read(ByteBuffer dst, long position) throws IOException {
+            return delegate.read(dst, position);
+        }
+
+        @Override
+        public int write(ByteBuffer src, long position) throws IOException {
+            return delegate.write(src, position);
+        }
+
+        @Override
+        public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+            return delegate.map(mode, position, size);
+        }
+
+        @Override
+        public FileLock lock(long position, long size, boolean shared) throws IOException {
+            return delegate.lock(position, size, shared);
+        }
+
+        @Override
+        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+            return delegate.tryLock(position, size, shared);
+        }
+
+        @Override
+        protected void implCloseChannel() throws IOException {
+            delegate.close();
+        }
     }
 }


### PR DESCRIPTION
### Related issue

- Reproducer for #4855.
- This PR intentionally does not fix or close #4855.

### Motivation

This draft PR adds a focused reproducer for a `BufferedChannel` failure mode that can leave the logical `BufferedChannel.position()` behind the underlying `FileChannel.position()` after a partial flush failure.

The suspected production impact is stale entry locations and stale `ledgersMapOffset` being published by `DefaultEntryLogger` after the same channel is reused.

This is intentionally a reproducer-only draft, not the final fix.

### Changes

- Add a fault-injected `PartialFailingFileChannel` for tests.
- Add a test showing `BufferedChannel.position()` can lag behind `FileChannel.position()` after a partial flush `IOException`.
- Add a test showing `BufferedLogChannel.appendLedgersMap()` can write a stale `ledgersMapOffset` after that position drift.

### Verification

Passed on `release-4.16.7` baseline:

```text
/home/stephen/github/java/pulsar/mvnw -pl bookkeeper-server -Dtest=BufferedChannelTest test
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

After rebasing onto current `branch-4.16`, running with `-am` did not reach tests in this local environment due to a Maven resource copy error in `buildtools`:

```text
Failed to copy buildtools/src/main/resources/bookkeeper/checkstyle.xml ... Cannot allocate memory
```

### Notes

This PR is intentionally scoped to the minimal unit-level reproducer. Higher-level cluster/E2E reproductions are kept separate from this PR to avoid adding environment-specific setup to the code review.

If maintainers agree with the failure model, the follow-up fix should likely make the main entrylog writer fail closed after non-recoverable write/flush/force failures, and prevent `appendLedgersMap()` from publishing a stale header offset.
