### PR TITLE
build: update 4.17.4 to latest_release

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const baseUrl = process.env.BASE_URL || "/"
 const deployUrl = process.env.DEPLOY_URL || "https://bookkeeper.apache.org";
 const variables = {
   /** They are used in .md files*/
-  latest_release: "4.17.3",
+  latest_release: "4.17.4",
   stable_release: "4.16.7",
   github_repo: "https://github.com/apache/bookkeeper",
   github_master: "https://github.com/apache/bookkeeper/tree/master",


### PR DESCRIPTION
https://bookkeeper.apache.org/community/release-guide/#update-website
Update the latest_release and stable_release in the docusaurus.config.js file if needed. Once run the above commands, please send a pull request for it and get approval from any committers, then merge it. The CI job will automatically update the website in a few minutes. Please review the website to make sure the documentation for ${VERSION} is live.