### PR TITLE
Bump branch-4.17 to 4.17.5-SNAPSHOT

### DIFF
--- a/bookkeeper-benchmark/pom.xml
+++ b/bookkeeper-benchmark/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>bookkeeper-benchmark</artifactId>

--- a/bookkeeper-common-allocator/pom.xml
+++ b/bookkeeper-common-allocator/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-common-allocator</artifactId>
   <name>Apache BookKeeper :: Common :: Allocator</name>

--- a/bookkeeper-common/pom.xml
+++ b/bookkeeper-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-common</artifactId>
   <name>Apache BookKeeper :: Common</name>

--- a/bookkeeper-dist/all/pom.xml
+++ b/bookkeeper-dist/all/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/bookkeeper-dist/bkctl/pom.xml
+++ b/bookkeeper-dist/bkctl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/bookkeeper-dist/pom.xml
+++ b/bookkeeper-dist/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>bookkeeper-dist</artifactId>

--- a/bookkeeper-dist/server/pom.xml
+++ b/bookkeeper-dist/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>bookkeeper-dist</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/bookkeeper-http/http-server/pom.xml
+++ b/bookkeeper-http/http-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/bookkeeper-http/pom.xml
+++ b/bookkeeper-http/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper.http</groupId>

--- a/bookkeeper-http/servlet-http-server/pom.xml
+++ b/bookkeeper-http/servlet-http-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>bookkeeper</artifactId>
         <groupId>org.apache.bookkeeper</groupId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/bookkeeper-http/vertx-http-server/pom.xml
+++ b/bookkeeper-http/vertx-http-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/bookkeeper-proto/pom.xml
+++ b/bookkeeper-proto/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-proto</artifactId>
   <name>Apache BookKeeper :: Protocols</name>

--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-server</artifactId>
   <name>Apache BookKeeper :: Server</name>

--- a/bookkeeper-slogger/api/pom.xml
+++ b/bookkeeper-slogger/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>bookkeeper-slogger-parent</artifactId>
         <groupId>org.apache.bookkeeper</groupId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>org.apache.bookkeeper</groupId>

--- a/bookkeeper-slogger/pom.xml
+++ b/bookkeeper-slogger/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.bookkeeper</groupId>
         <artifactId>bookkeeper</artifactId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/bookkeeper-slogger/slf4j/pom.xml
+++ b/bookkeeper-slogger/slf4j/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>bookkeeper-slogger-parent</artifactId>
         <groupId>org.apache.bookkeeper</groupId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>org.apache.bookkeeper</groupId>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -20,9 +20,9 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>buildtools</artifactId>
   <name>Apache BookKeeper :: Build Tools</name>
-  <version>4.17.4-SNAPSHOT</version>
+  <version>4.17.5-SNAPSHOT</version>
 </project>

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/cpu-affinity/pom.xml
+++ b/cpu-affinity/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/metadata-drivers/etcd/pom.xml
+++ b/metadata-drivers/etcd/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.metadata.drivers</groupId>
     <artifactId>metadata-drivers-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/metadata-drivers/jetcd-core-shaded/pom.xml
+++ b/metadata-drivers/jetcd-core-shaded/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.metadata.drivers</groupId>
     <artifactId>metadata-drivers-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.metadata.drivers</groupId>

--- a/metadata-drivers/pom.xml
+++ b/metadata-drivers/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>bookkeeper</artifactId>
         <groupId>org.apache.bookkeeper</groupId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.bookkeeper.metadata.drivers</groupId>

--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>microbenchmarks</artifactId>
   <name>Apache BookKeeper :: microbenchmarks</name>

--- a/native-io/pom.xml
+++ b/native-io/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper</groupId>
-  <version>4.17.4-SNAPSHOT</version>
+  <version>4.17.5-SNAPSHOT</version>
   <artifactId>bookkeeper</artifactId>
   <packaging>pom</packaging>
   <name>Apache BookKeeper :: Parent</name>

--- a/shaded/bookkeeper-server-shaded/pom.xml
+++ b/shaded/bookkeeper-server-shaded/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-shaded</artifactId>

--- a/shaded/bookkeeper-server-tests-shaded/pom.xml
+++ b/shaded/bookkeeper-server-tests-shaded/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-tests-shaded</artifactId>

--- a/shaded/distributedlog-core-shaded/pom.xml
+++ b/shaded/distributedlog-core-shaded/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>shaded-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.distributedlog</groupId>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>
   <artifactId>shaded-parent</artifactId>

--- a/stats/bookkeeper-stats-api/pom.xml
+++ b/stats/bookkeeper-stats-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-stats-parent</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>bookkeeper-stats-api</artifactId>

--- a/stats/bookkeeper-stats-providers/codahale-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/codahale-metrics-provider/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-stats-providers</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>codahale-metrics-provider</artifactId>

--- a/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/otel-metrics-provider/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-stats-providers</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
 
 

--- a/stats/bookkeeper-stats-providers/pom.xml
+++ b/stats/bookkeeper-stats-providers/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>bookkeeper-stats-parent</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>bookkeeper-stats-providers</artifactId>

--- a/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/stats/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-stats-providers</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>prometheus-metrics-provider</artifactId>

--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <groupId>org.apache.bookkeeper.stats</groupId>

--- a/stats/utils/pom.xml
+++ b/stats/utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>bookkeeper-stats-parent</artifactId>
     <groupId>org.apache.bookkeeper.stats</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.stats</groupId>
   <artifactId>bookkeeper-stats-utils</artifactId>

--- a/stream/api/pom.xml
+++ b/stream/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/bk-grpc-name-resolver/pom.xml
+++ b/stream/bk-grpc-name-resolver/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/clients/java/all/pom.xml
+++ b/stream/clients/java/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-client</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client </name>

--- a/stream/clients/java/base/pom.xml
+++ b/stream/clients/java/base/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-client-base</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client :: Base</name>

--- a/stream/clients/java/kv/pom.xml
+++ b/stream/clients/java/kv/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-java-client-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-java-kv-client</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Clients :: Java Client :: KV</name>

--- a/stream/clients/java/pom.xml
+++ b/stream/clients/java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-clients-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-java-client-parent</artifactId>

--- a/stream/clients/pom.xml
+++ b/stream/clients/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-clients-parent</artifactId>

--- a/stream/common/pom.xml
+++ b/stream/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/distributedlog/common/pom.xml
+++ b/stream/distributedlog/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>distributedlog-common</artifactId>
   <name>Apache BookKeeper :: DistributedLog :: Common</name>

--- a/stream/distributedlog/core/pom.xml
+++ b/stream/distributedlog/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>distributedlog-core</artifactId>
   <name>Apache BookKeeper :: DistributedLog :: Core Library</name>

--- a/stream/distributedlog/io/dlfs/pom.xml
+++ b/stream/distributedlog/io/dlfs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>distributedlog</artifactId>
     <groupId>org.apache.distributedlog</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.apache.distributedlog</groupId>

--- a/stream/distributedlog/io/pom.xml
+++ b/stream/distributedlog/io/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>distributedlog-io</artifactId>

--- a/stream/distributedlog/pom.xml
+++ b/stream/distributedlog/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.apache.distributedlog</groupId>

--- a/stream/distributedlog/protocol/pom.xml
+++ b/stream/distributedlog/protocol/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.distributedlog</groupId>
     <artifactId>distributedlog</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>distributedlog-protocol</artifactId>
   <name>Apache BookKeeper :: DistributedLog :: Protocol</name>

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <packaging>pom</packaging>

--- a/stream/proto/pom.xml
+++ b/stream/proto/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/server/pom.xml
+++ b/stream/server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-server</artifactId>
   <name>Apache BookKeeper :: Stream Storage :: Server</name>

--- a/stream/statelib/pom.xml
+++ b/stream/statelib/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>stream-storage-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper</groupId>

--- a/stream/storage/api/pom.xml
+++ b/stream/storage/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-api</artifactId>

--- a/stream/storage/impl/pom.xml
+++ b/stream/storage/impl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-service-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-impl</artifactId>

--- a/stream/storage/pom.xml
+++ b/stream/storage/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>stream-storage-service-parent</artifactId>

--- a/stream/tests-common/pom.xml
+++ b/stream/tests-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>stream-storage-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/backward-compat/bc-non-fips/pom.xml
+++ b/tests/backward-compat/bc-non-fips/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/current-server-old-clients/pom.xml
+++ b/tests/backward-compat/current-server-old-clients/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/hierarchical-ledger-manager/pom.xml
+++ b/tests/backward-compat/hierarchical-ledger-manager/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/hostname-bookieid/pom.xml
+++ b/tests/backward-compat/hostname-bookieid/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/old-cookie-new-cluster/pom.xml
+++ b/tests/backward-compat/old-cookie-new-cluster/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/pom.xml
+++ b/tests/backward-compat/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>integration-tests-base-groovy</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../integration-tests-base-groovy</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/backward-compat/recovery-no-password/pom.xml
+++ b/tests/backward-compat/recovery-no-password/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/upgrade-direct/pom.xml
+++ b/tests/backward-compat/upgrade-direct/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/upgrade/pom.xml
+++ b/tests/backward-compat/upgrade/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/backward-compat/yahoo-custom-version/pom.xml
+++ b/tests/backward-compat/yahoo-custom-version/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>backward-compat</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/docker-images/all-released-versions-image/pom.xml
+++ b/tests/docker-images/all-released-versions-image/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>docker-images</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/docker-images/all-versions-image/pom.xml
+++ b/tests/docker-images/all-versions-image/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>docker-images</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/docker-images/current-version-image/pom.xml
+++ b/tests/docker-images/current-version-image/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>docker-images</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/docker-images/pom.xml
+++ b/tests/docker-images/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>docker-images</artifactId>

--- a/tests/integration-tests-base-groovy/pom.xml
+++ b/tests/integration-tests-base-groovy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>integration-tests-base</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>../integration-tests-base</relativePath>
   </parent>
 

--- a/tests/integration-tests-base/pom.xml
+++ b/tests/integration-tests-base/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/integration-tests-topologies/pom.xml
+++ b/tests/integration-tests-topologies/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/integration-tests-utils/pom.xml
+++ b/tests/integration-tests-utils/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/integration/cluster/pom.xml
+++ b/tests/integration/cluster/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>integration</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>integration</artifactId>

--- a/tests/integration/smoke/pom.xml
+++ b/tests/integration/smoke/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>integration</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/integration/standalone/pom.xml
+++ b/tests/integration/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>integration</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.bookkeeper.tests</groupId>
   <artifactId>tests-parent</artifactId>

--- a/tests/scripts/pom.xml
+++ b/tests/scripts/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.bookkeeper.tests</groupId>

--- a/tests/shaded/bookkeeper-server-shaded-test/pom.xml
+++ b/tests/shaded/bookkeeper-server-shaded-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests.shaded</groupId>
     <artifactId>shaded-tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-shaded-test</artifactId>

--- a/tests/shaded/bookkeeper-server-tests-shaded-test/pom.xml
+++ b/tests/shaded/bookkeeper-server-tests-shaded-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests.shaded</groupId>
     <artifactId>shaded-tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>bookkeeper-server-tests-shaded-test</artifactId>

--- a/tests/shaded/distributedlog-core-shaded-test/pom.xml
+++ b/tests/shaded/distributedlog-core-shaded-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests.shaded</groupId>
     <artifactId>shaded-tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>distributedlog-core-shaded-test</artifactId>

--- a/tests/shaded/pom.xml
+++ b/tests/shaded/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper.tests</groupId>
     <artifactId>tests-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.apache.bookkeeper.tests.shaded</groupId>

--- a/testtools/pom.xml
+++ b/testtools/pom.xml
@@ -20,11 +20,11 @@
     <parent>
         <groupId>org.apache.bookkeeper</groupId>
         <artifactId>bookkeeper</artifactId>
-        <version>4.17.4-SNAPSHOT</version>
+        <version>4.17.5-SNAPSHOT</version>
     </parent>
     <artifactId>testtools</artifactId>
     <name>Apache BookKeeper :: Test Tools</name>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/tools/all/pom.xml
+++ b/tools/all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools</artifactId>
   <name>Apache BookKeeper :: Tools</name>

--- a/tools/framework/pom.xml
+++ b/tools/framework/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-framework</artifactId>
   <name>Apache BookKeeper :: Tools :: Framework</name>

--- a/tools/ledger/pom.xml
+++ b/tools/ledger/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper-tools-parent</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-ledger</artifactId>
   <name>Apache BookKeeper :: Tools :: Ledger</name>

--- a/tools/perf/pom.xml
+++ b/tools/perf/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-perf</artifactId>
   <name>Apache BookKeeper :: Tools :: Perf</name>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>bookkeeper</artifactId>
     <groupId>org.apache.bookkeeper</groupId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>bookkeeper-tools-parent</artifactId>
   <name>Apache BookKeeper :: Tools :: Parent</name>

--- a/tools/stream/pom.xml
+++ b/tools/stream/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.bookkeeper</groupId>
     <artifactId>bookkeeper-tools-parent</artifactId>
-    <version>4.17.4-SNAPSHOT</version>
+    <version>4.17.5-SNAPSHOT</version>
   </parent>
   <artifactId>stream-storage-cli</artifactId>
   <name>Apache BookKeeper :: Tools :: Stream</name>


### PR DESCRIPTION
https://bookkeeper.apache.org/community/release-guide/#advance-version-on-release-branch
Use the Maven Release plugin in order to advance the version in all poms.

This command will upgrade the <version> tag on every pom.xml locally to your workspace.

```
mvn release:update-versions
    -DdevelopmentVersion=${DEVELOPMENT_VERSION}
    -Dstream
```

For instance if you have released 4.5.1, you have to change version to 4.5.2-SNAPSHOT. Then you have to create a PR and submit it for review.

Example PR: [release-4.7.0](https://github.com/apache/bookkeeper/pull/1350)