### PR TITLE
Issue 4864: Respect User Color Scheme Preference for Website Theme

### DIFF
--- a/site3/website/docusaurus.config.js
+++ b/site3/website/docusaurus.config.js
@@ -288,6 +288,10 @@ const config = {
         darkTheme: darkCodeTheme,
       },
 
+      colorMode: {
+        respectPrefersColorScheme: true
+      }
+
     }),
     customFields: variables
 };


### PR DESCRIPTION
Descriptions of the changes in this PR:

<!-- Either this PR fixes an issue, -->

Fix #4864 4864

### Motivation

It's quite convenient when the website theme is auto-adjusted to the user prefernces set on their devise.
This feature is already supported by docosaurus, so it's easy and a minor change to add it here.

This avoids users with dark mode from encountering a light mode when loading the website and manually having to switch to it and vice versa.

### Changes

Very minor config change in the website's docosaurus config.
Documentation about the config option I've added can be found here: https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme
