### PR TITLE
Fix read throttling deadlock on Netty IO threads

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BatchedReadEntryProcessor.java
@@ -42,7 +42,6 @@ public class BatchedReadEntryProcessor extends ReadEntryProcessor {
         rep.fenceThreadPool = fenceThreadPool;
         rep.throttleReadResponses = throttleReadResponses;
         rep.maxBatchReadSize = maxBatchReadSize;
-        requestProcessor.onReadRequestStart(requestHandler.ctx().channel());
         return rep;
     }
 

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieRequestProcessor.java
@@ -551,7 +551,6 @@ public class BookieRequestProcessor implements RequestProcessor {
                         .setEntryId(r.getReadRequest().getEntryId())
                         .setStatus(StatusCode.ETOOMANYREQUESTS);
                 read.sendResponse(StatusCode.ETOOMANYREQUESTS, resp, requestStats.getReadRequestStats());
-                onReadRequestFinish();
             }
         }
     }
@@ -707,7 +706,6 @@ public class BookieRequestProcessor implements RequestProcessor {
                     BookieProtocol.ETOOMANYREQUESTS,
                     ResponseBuilder.buildErrorResponse(BookieProtocol.ETOOMANYREQUESTS, r),
                     requestStats.getReadRequestStats());
-                onReadRequestFinish();
                 read.recycle();
             }
         }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessor.java
@@ -51,8 +51,13 @@ class ReadEntryProcessor extends PacketProcessorBase<ReadRequest> {
         rep.init(request, requestHandler, requestProcessor);
         rep.fenceThreadPool = fenceThreadPool;
         rep.throttleReadResponses = throttleReadResponses;
-        requestProcessor.onReadRequestStart(requestHandler.ctx().channel());
         return rep;
+    }
+
+    @Override
+    public void run() {
+        requestProcessor.onReadRequestStart(requestHandler.ctx().channel());
+        super.run();
     }
 
     @Override

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/ReadEntryProcessorV3.java
@@ -54,7 +54,6 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
                                 BookieRequestProcessor requestProcessor,
                                 ExecutorService fenceThreadPool) {
         super(request, requestHandler, requestProcessor);
-        requestProcessor.onReadRequestStart(requestHandler.ctx().channel());
 
         this.readRequest = request.getReadRequest();
         this.ledgerId = readRequest.getLedgerId();
@@ -267,6 +266,7 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
 
     @Override
     public void run() {
+        requestProcessor.onReadRequestStart(requestHandler.ctx().channel());
         requestProcessor.getRequestStats().getReadEntrySchedulingDelayStats().registerSuccessfulEvent(
             MathUtils.elapsedNanos(enqueueNanos), TimeUnit.NANOSECONDS);
         if (!requestHandler.ctx().channel().isOpen()) {
@@ -374,4 +374,3 @@ class ReadEntryProcessorV3 extends PacketProcessorBaseV3 {
         return RequestUtils.toSafeString(request);
     }
 }
-

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -20,11 +20,13 @@ package org.apache.bookkeeper.proto;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,12 +35,18 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.bookie.Bookie;
 import org.apache.bookkeeper.bookie.BookieException;
@@ -196,5 +204,81 @@ public class ReadEntryProcessorTest {
         assertEquals(ledgerId, response.getLedgerId());
         assertEquals(BookieProtocol.READENTRY, response.getOpCode());
         assertEquals(BookieProtocol.EOK, response.getErrorCode());
+    }
+    
+    /**
+     * Blocking request creation on the event loop can starve write completion that would release a read permit.
+     */
+    @Test
+    public void testCreateDoesNotStarveWriteCompletionThatReleasesReadPermit() throws Exception {
+        EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(1);
+        ExecutorService service = Executors.newSingleThreadExecutor();
+        Semaphore readsSemaphore = new Semaphore(1);
+        CountDownLatch secondReadBlocked = new CountDownLatch(1);
+        CountDownLatch writeCompleted = new CountDownLatch(1);
+        CountDownLatch secondCreateReturned = new CountDownLatch(1);
+        ReadEntryProcessor[] processor = new ReadEntryProcessor[1];
+        try {
+            EventLoop eventLoop = eventLoopGroup.next();
+            when(channel.eventLoop()).thenReturn(eventLoop);
+            ChannelPromise writePromise = new DefaultChannelPromise(channel, eventLoop);
+            when(channel.writeAndFlush(any())).thenReturn(writePromise);
+
+            doAnswer(inv -> {
+                if (!readsSemaphore.tryAcquire()) {
+                    secondReadBlocked.countDown();
+                    readsSemaphore.acquireUninterruptibly();
+                }
+                return null;
+            }).when(requestProcessor).onReadRequestStart(any(Channel.class));
+            doAnswer(inv -> {
+                readsSemaphore.release();
+                return null;
+            }).when(requestProcessor).onReadRequestFinish();
+
+            requestProcessor.onReadRequestStart(channel);
+            Future<?> firstResponse = service.submit(() -> {
+                channel.writeAndFlush(new Object()).get();
+                requestProcessor.onReadRequestFinish();
+                writeCompleted.countDown();
+                return null;
+            });
+
+            long ledgerId = System.currentTimeMillis();
+            ReadRequest request = ReadRequest.create(
+                    BookieProtocol.CURRENT_PROTOCOL_VERSION, ledgerId, 1, (short) 0, new byte[]{});
+            eventLoop.execute(() -> {
+                processor[0] = ReadEntryProcessor.create(request, requestHandler, requestProcessor, null, true);
+                secondCreateReturned.countDown();
+            });
+
+            long waitUntilNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while (secondReadBlocked.getCount() > 0
+                    && secondCreateReturned.getCount() > 0
+                    && System.nanoTime() < waitUntilNanos) {
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+            assertTrue("second read create should either return or start waiting for a permit",
+                    secondReadBlocked.getCount() == 0 || secondCreateReturned.getCount() == 0);
+            eventLoop.execute(() -> writePromise.setSuccess());
+
+            try {
+                assertTrue("write completion must not be starved behind a blocked read create",
+                        writeCompleted.await(1, TimeUnit.SECONDS));
+            } finally {
+                if (writeCompleted.getCount() > 0) {
+                    readsSemaphore.release();
+                }
+            }
+            assertTrue("second read create should return without blocking the event loop",
+                    secondCreateReturned.await(1, TimeUnit.SECONDS));
+            firstResponse.get(1, TimeUnit.SECONDS);
+        } finally {
+            if (processor[0] != null) {
+                processor[0].recycle();
+            }
+            service.shutdownNow();
+            eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
+        }
     }
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/proto/ReadEntryProcessorTest.java
@@ -207,10 +207,11 @@ public class ReadEntryProcessorTest {
     }
     
     /**
-     * Blocking request creation on the event loop can starve write completion that would release a read permit.
+     * Blocking request creation on the event loop can starve the write future
+     * that a throttled V2 read waits on before releasing a read permit.
      */
     @Test
-    public void testCreateDoesNotStarveWriteCompletionThatReleasesReadPermit() throws Exception {
+    public void testCreateDoesNotStarveV2WriteCompletionNeededToReleaseReadPermit() throws Exception {
         EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(1);
         ExecutorService service = Executors.newSingleThreadExecutor();
         Semaphore readsSemaphore = new Semaphore(1);
@@ -263,7 +264,7 @@ public class ReadEntryProcessorTest {
             eventLoop.execute(() -> writePromise.setSuccess());
 
             try {
-                assertTrue("write completion must not be starved behind a blocked read create",
+                assertTrue("V2 write future completion must not be starved behind a blocked read create",
                         writeCompleted.await(1, TimeUnit.SECONDS));
             } finally {
                 if (writeCompleted.getCount() > 0) {


### PR DESCRIPTION
## Motivation

Read throttling can block Netty IO/EventLoop threads when read permits are exhausted. Once the IO threads are blocked, the server may stop dispatching new requests and Netty write completions may not make progress, preventing read permits from being released.

## Changes

- Move read permit acquisition out of `ReadEntryProcessor.create()` and related construction paths.
- Acquire read permits when the read processor actually runs on the worker thread.
- Avoid releasing read permits in rejected-execution paths where no permit has been acquired.
- Add a regression test to verify request creation does not block Netty write completion when read permits are exhausted.

## Validation

Added regression test fails on the old implementation and passes with this change:

```text
testCreateDoesNotStarveWriteCompletionThatReleasesReadPermit