### PR TITLE
Avoid per-checksum boxing in Java9IntHash by using MethodHandle.invokeExact

### DIFF
--- a/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
+++ b/circe-checksum/src/main/java/com/scurrilous/circe/checksum/Java9IntHash.java
@@ -20,15 +20,22 @@ package com.scurrilous.circe.checksum;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import lombok.CustomLog;
 
 @CustomLog
 public class Java9IntHash implements IntHash {
     static final boolean HAS_JAVA9_CRC32C;
-    private static final Method UPDATE_BYTES;
-    private static final Method UPDATE_DIRECT_BYTEBUFFER;
+
+    // Method handles rather than java.lang.reflect.Method: Method.invoke takes its arguments as an
+    // Object[], so every call boxes the checksum, the address and the offsets and allocates the
+    // array. Since this runs once per checksummed buffer, that showed up as ~9% of all allocation
+    // in a broker under a write-heavy workload. invokeExact on a static final handle passes the
+    // primitives straight through and lets the JIT inline the target, allocating nothing.
+    private static final MethodHandle UPDATE_BYTES;
+    private static final MethodHandle UPDATE_DIRECT_BYTEBUFFER;
 
     private static final String CRC32C_CLASS_NAME = "java.util.zip.CRC32C";
 
@@ -41,16 +48,25 @@ public class Java9IntHash implements IntHash {
 
     static {
         boolean hasJava9CRC32C = false;
-        Method updateBytes = null;
-        Method updateDirectByteBuffer = null;
+        MethodHandle updateBytes = null;
+        MethodHandle updateDirectByteBuffer = null;
 
         try {
             Class<?> c = Class.forName(CRC32C_CLASS_NAME);
-            updateBytes = c.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class, int.class);
-            updateBytes.setAccessible(true);
-            updateDirectByteBuffer =
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+            // The methods are private to java.util.zip, so they are made accessible first and then
+            // unreflected: Lookup.unreflect skips its own access check for a method whose accessible
+            // flag is already set, which is what lets this reach them without a Java 9+ lookup API.
+            Method updateBytesMethod =
+                    c.getDeclaredMethod("updateBytes", int.class, byte[].class, int.class, int.class);
+            updateBytesMethod.setAccessible(true);
+            updateBytes = lookup.unreflect(updateBytesMethod);
+
+            Method updateDirectByteBufferMethod =
                     c.getDeclaredMethod("updateDirectByteBuffer", int.class, long.class, int.class, int.class);
-            updateDirectByteBuffer.setAccessible(true);
+            updateDirectByteBufferMethod.setAccessible(true);
+            updateDirectByteBuffer = lookup.unreflect(updateDirectByteBufferMethod);
 
             hasJava9CRC32C = true;
         } catch (Exception e) {
@@ -76,9 +92,11 @@ public class Java9IntHash implements IntHash {
 
     private int updateDirectByteBuffer(int current, long address, int offset, int length) {
         try {
-            return (int) UPDATE_DIRECT_BYTEBUFFER.invoke(null, current, address, offset, offset + length);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
+            // The argument and return types have to match the handle's type exactly for
+            // invokeExact: (int, long, int, int)int.
+            return (int) UPDATE_DIRECT_BYTEBUFFER.invokeExact(current, address, offset, offset + length);
+        } catch (Throwable t) {
+            throw asUnchecked(t);
         }
     }
 
@@ -97,10 +115,28 @@ public class Java9IntHash implements IntHash {
 
     private static int updateBytes(int current, byte[] array, int offset, int length) {
         try {
-            return (int) UPDATE_BYTES.invoke(null, current, array, offset, offset + length);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
+            // The argument and return types have to match the handle's type exactly for
+            // invokeExact: (int, byte[], int, int)int.
+            return (int) UPDATE_BYTES.invokeExact(current, array, offset, offset + length);
+        } catch (Throwable t) {
+            throw asUnchecked(t);
         }
+    }
+
+    /**
+     * Adapts a failure from {@link MethodHandle#invokeExact}, which is declared to throw
+     * {@link Throwable}, to something this method can throw. Unlike {@code Method.invoke}, an
+     * exception raised by the target is not wrapped, so it is passed through unchanged when it
+     * already is unchecked.
+     */
+    private static RuntimeException asUnchecked(Throwable t) {
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        if (t instanceof RuntimeException) {
+            return (RuntimeException) t;
+        }
+        return new RuntimeException(t);
     }
 
     @Override

--- a/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
+++ b/circe-checksum/src/test/java/com/scurrilous/circe/checksum/Java9IntHashTest.java
@@ -25,6 +25,7 @@ import io.netty.buffer.DuplicatedByteBuf;
 import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 @Slf4j
@@ -100,6 +101,51 @@ public class Java9IntHashTest {
         bTotal.release();
         b1.release();
         b2.release();
+    }
+
+    /**
+     * The three ways {@link Java9IntHash#resume(int, ByteBuf, int, int)} can reach the data, checked
+     * against {@link Java8IntHash} as an independent implementation of the same algorithm.
+     *
+     * <p>The direct path is the one worth pinning: it is the only caller of the JDK's
+     * {@code updateDirectByteBuffer}, whose {@code (int, long, int, int)int} shape has to be matched
+     * exactly by the method handle invocation. Getting that wrong is not a compile error — it fails
+     * at runtime with a {@code WrongMethodTypeException} — and none of the other cases would catch
+     * it, since they take the {@code updateBytes} path instead.
+     */
+    @Test
+    public void matchesJava8ImplementationOnEveryBufferKind() {
+        Assume.assumeTrue("java.util.zip.CRC32C is not reachable, so Java9IntHash is not in use",
+                Java9IntHash.HAS_JAVA9_CRC32C);
+
+        byte[] data = new byte[8192];
+        new Random(42).nextBytes(data);
+
+        ByteBuf direct = ByteBufAllocator.DEFAULT.directBuffer(data.length);
+        ByteBuf heap = ByteBufAllocator.DEFAULT.heapBuffer(data.length);
+        try {
+            direct.writeBytes(data);
+            heap.writeBytes(data);
+            Assert.assertTrue("expected a buffer with a memory address to cover the direct path",
+                    direct.hasMemoryAddress());
+
+            Java9IntHash java9 = new Java9IntHash();
+            Java8IntHash java8 = new Java8IntHash();
+
+            Assert.assertEquals(java8.calculate(direct), java9.calculate(direct));
+            Assert.assertEquals(java8.calculate(heap), java9.calculate(heap));
+            Assert.assertEquals(java8.calculate(new NoArrayNoMemoryAddrByteBuff(heap)),
+                    java9.calculate(new NoArrayNoMemoryAddrByteBuff(heap)));
+
+            // Resuming has to agree too: it is the incremental form the ledger write path uses.
+            int half = data.length / 2;
+            int java9Resumed = java9.resume(java9.calculate(direct.slice(0, half)),
+                    direct.slice(half, data.length - half));
+            Assert.assertEquals(java8.calculate(direct), java9Resumed);
+        } finally {
+            direct.release();
+            heap.release();
+        }
     }
 
     public static class NoArrayNoMemoryAddrByteBuff extends DuplicatedByteBuf {


### PR DESCRIPTION
### Motivation

`Java9IntHash` reaches `java.util.zip.CRC32C`'s private `updateBytes` and `updateDirectByteBuffer`
through `java.lang.reflect.Method.invoke`. `Method.invoke` takes its arguments as an `Object[]`, so
every checksum boxes the running CRC, the buffer address and both offsets, and allocates the array to
hold them. That happens once per checksummed buffer, on the ledger write path.

**This is the fallback used on every platform without the SSE 4.2 native library, which is every
platform except x86-64 Linux.** `Crc32cIntChecksum` picks `JniIntHash` only when
`Sse42Crc32C.isSupported()`, and the published `circe-checksum` jar contains exactly one native
library:

```
$ unzip -l circe-checksum-4.18.0.jar | grep lib/
        0  lib/
    16936  lib/libcirce-checksum.so

$ file lib/libcirce-checksum.so
lib/libcirce-checksum.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), ...
```

It is built from `crc32c_sse42.cpp`, so it is x86-only by construction. On **ARM** — Graviton,
Ampere, Apple Silicon — the load fails on the wrong architecture; on **macOS** and **Windows** there
is no `.dylib`/`.dll` in the jar at all. All of them fall through to `Java9IntHash` and pay the boxing
on every entry. Deployments on x86-64 Linux take the native path and never see this.

I found it profiling a Pulsar broker on aarch64 under a write-heavy workload: allocation sampling put
**9% of all broker allocation** in `Java9IntHash.updateDirectByteBuffer` → `Long.valueOf` /
`Integer.valueOf`, and the broker was GC-bound.

### Changes

Bind the two methods to `MethodHandle`s and call them with `invokeExact`. The arguments are passed as
primitives, nothing is allocated, and the JIT can inline through a `static final` handle.

`Lookup.unreflect` skips its own access check for a `Method` whose accessible flag is already set,
which is what the existing code establishes with `setAccessible(true)`. So this needs no Java 9+
lookup API (no `privateLookupIn`) and **still compiles at source level 8**, which matters for
branch-4.17 and earlier if this is worth backporting. Behaviour when `java.util.zip.CRC32C` cannot be
reached is unchanged — `HAS_JAVA9_CRC32C` stays false and `Crc32cIntChecksum` falls back to
`Java8IntHash`.

One behavioural difference worth noting: `invokeExact` does not wrap an exception raised by the
target the way `Method.invoke` does with `InvocationTargetException`, so an unchecked exception now
propagates unchanged instead of nested inside a `RuntimeException`.

#### Results

`DigestTypeBenchmark`, `digest=CRC32_C`, `bufferType=BYTE_BUF_DEFAULT_ALLOC`, JDK 21.0.11 on
aarch64 (so the JNI path is unavailable and `Java9IntHash` is in use), `-f 2 -wi 5 -i 5`:

| entry size | throughput before | throughput after | allocation before | allocation after |
|---:|---:|---:|---:|---:|
| 64 | 350,622 ± 6,010 ops/ms | **510,521 ± 3,182 ops/ms** (+46%) | 24 B/op, 8,024 MB/s | ~0 B/op, 0.004 MB/s |
| 1024 | 20,765 ± 311 ops/ms | 21,050 ± 75 ops/ms (+1%) | 40 B/op, 792 MB/s | ~0 B/op, 0.004 MB/s |

Larger entries are dominated by the checksum computation itself, so there the win is the allocation
rather than the throughput — 8 GB/s of garbage at 64-byte entries becomes none at all, and
`gc.count` for that run goes from 240 to 0.

#### Tests

`Java9IntHashTest` gains a case that checks `Java9IntHash` against `Java8IntHash` — an independent
implementation of the same algorithm — over a direct buffer, a heap buffer and a buffer with neither
an array nor a memory address, plus the incremental `resume` form.

The direct-buffer case is the one that needed adding: it is the only caller of
`updateDirectByteBuffer`, whose `(int, long, int, int)int` shape has to be matched exactly by
`invokeExact`, and a mismatch fails at runtime with `WrongMethodTypeException` rather than at compile
time. No existing test reached it — I confirmed that by swapping the two offset arguments, which the
new test catches and the pre-existing tests do not.

`mvn -pl circe-checksum test` passes (79 tests), as do the `bookkeeper-server` digest tests.
