### PR TITLE
Upgrade RocksDB JNI to 10.10.1.1 while preserving 7.9.2 index compatibility

### DIFF
--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -277,7 +277,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.ee8-jetty-ee8-security-12.1.10.jar [22]
 - lib/org.eclipse.jetty.ee8-jetty-ee8-servlet-12.1.10.jar [22]
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
-- lib/org.rocksdb-rocksdbjni-10.10.1.jar [23]
+- lib/org.rocksdb-rocksdbjni-10.10.1.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
 - lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
@@ -624,7 +624,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-10.10.1.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-10.10.1.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-all.bin.txt
@@ -277,7 +277,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.ee8-jetty-ee8-security-12.1.10.jar [22]
 - lib/org.eclipse.jetty.ee8-jetty-ee8-servlet-12.1.10.jar [22]
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
-- lib/org.rocksdb-rocksdbjni-9.9.3.jar [23]
+- lib/org.rocksdb-rocksdbjni-10.10.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
 - lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
@@ -364,7 +364,7 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/jetty/jetty.project/tree/jetty-12.1.10
-[23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
+[23] Source available at https://github.com/facebook/rocksdb/tree/v10.10.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/apache/datasketches-java/tree/7.0.1
 [26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
@@ -624,7 +624,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-9.9.3.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-10.10.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -277,7 +277,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.ee8-jetty-ee8-security-12.1.10.jar [22]
 - lib/org.eclipse.jetty.ee8-jetty-ee8-servlet-12.1.10.jar [22]
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
-- lib/org.rocksdb-rocksdbjni-10.10.1.jar [23]
+- lib/org.rocksdb-rocksdbjni-10.10.1.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
 - lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
@@ -620,7 +620,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-10.10.1.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-10.10.1.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
+++ b/bookkeeper-dist/src/main/resources/LICENSE-server.bin.txt
@@ -277,7 +277,7 @@ Apache Software License, Version 2.
 - lib/org.eclipse.jetty.ee8-jetty-ee8-security-12.1.10.jar [22]
 - lib/org.eclipse.jetty.ee8-jetty-ee8-servlet-12.1.10.jar [22]
 - lib/org.eclipse.jetty.toolchain-jetty-servlet-api-4.0.9.jar [22]
-- lib/org.rocksdb-rocksdbjni-9.9.3.jar [23]
+- lib/org.rocksdb-rocksdbjni-10.10.1.jar [23]
 - lib/com.beust-jcommander-1.82.jar [24]
 - lib/org.apache.datasketches-datasketches-java-7.0.1.jar [25]
 - lib/org.apache.datasketches-datasketches-memory-4.1.0.jar [27]
@@ -360,7 +360,7 @@ Apache Software License, Version 2.
 [20] Source available at https://github.com/apache/commons-lang/tree/LANG_3_6
 [21] Source available at https://github.com/apache/zookeeper/tree/release-3.8.0
 [22] Source available at https://github.com/jetty/jetty.project/tree/jetty-12.1.10
-[23] Source available at https://github.com/facebook/rocksdb/tree/v9.9.3
+[23] Source available at https://github.com/facebook/rocksdb/tree/v10.10.1
 [24] Source available at https://github.com/cbeust/jcommander/tree/1.82
 [25] Source available at https://github.com/apache/datasketches-java/tree/7.0.1
 [26] Source available at https://github.com/yawkat/lz4-java/tree/v1.10.2
@@ -620,7 +620,7 @@ This private header is also used by Apple's open source
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 
 ------------------------------------------------------------------------------------
-lib/org.rocksdb-rocksdbjni-9.9.3.jar is derived from leveldb, which is under the following license.
+lib/org.rocksdb-rocksdbjni-10.10.1.jar is derived from leveldb, which is under the following license.
 
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDBTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.bookie.storage.ldb;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -27,11 +28,18 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ChecksumType;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -41,6 +49,53 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.Options;
 
 public class KeyValueStorageRocksDBTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testCompatibleSstFormatWithAndWithoutConfigurationFiles() throws Exception {
+        for (boolean useConfigurationFile : new boolean[]{false, true}) {
+            for (KeyValueStorageFactory.DbConfigType type : KeyValueStorageFactory.DbConfigType.values()) {
+                File directory = temporaryFolder.newFolder();
+                ServerConfiguration configuration = new ServerConfiguration();
+                // Explicit nonexistent paths ensure that the fallback does not load local operator settings.
+                String defaultConf = new File(directory, "default.conf").toString();
+                String ledgerConf = new File(directory, "ledger.conf").toString();
+                String entryConf = new File(directory, "entry.conf").toString();
+                if (useConfigurationFile) {
+                    defaultConf = getClass().getClassLoader().getResource("conf/default_rocksdb.conf").getPath();
+                    ledgerConf = getClass().getClassLoader().getResource("conf/ledger_metadata_rocksdb.conf").getPath();
+                    entryConf = getClass().getClassLoader().getResource("conf/entry_location_rocksdb.conf").getPath();
+                }
+                configuration.setDefaultRocksDBConf(defaultConf);
+                configuration.setLedgerMetadataRocksdbConf(ledgerConf);
+                configuration.setEntryLocationRocksdbConf(entryConf);
+                byte[] key = new byte[]{1};
+                byte[] value = new byte[]{2};
+                try (KeyValueStorageRocksDB storage = new KeyValueStorageRocksDB(
+                        directory.toString(), "db", type, configuration)) {
+                    storage.put(key, value);
+                    storage.sync();
+                    storage.compact();
+                    assertArrayEquals(value, storage.get(key));
+                    List<Path> ssts;
+                    try (Stream<Path> files = Files.list(directory.toPath().resolve("db"))) {
+                        ssts = files.filter(path -> path.toString().endsWith(".sst")).collect(Collectors.toList());
+                    }
+                    assertTrue("Compaction must produce an SST", !ssts.isEmpty());
+                    for (Path sst : ssts) {
+                        byte[] bytes = Files.readAllBytes(sst);
+                        // The footer stores a little-endian format version before the 8-byte magic number.
+                        // TableProperties.getFormatVersion() is not the block-based table footer version.
+                        int format = ByteBuffer.wrap(bytes, bytes.length - 12, 4)
+                                .order(ByteOrder.LITTLE_ENDIAN).getInt();
+                        assertEquals("SST must be readable by RocksDB 7.9.2: " + sst, 5, format);
+                    }
+                }
+            }
+        }
+    }
 
     @Test
     public void testRocksDBInitiateWithBookieConfiguration() throws Exception {

--- a/bookkeeper-server/src/test/resources/conf/default_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/default_rocksdb.conf
@@ -17,6 +17,13 @@
 # */
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -30,7 +37,14 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/entry_location_rocksdb.conf
@@ -17,6 +17,13 @@
 # */
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -57,12 +64,29 @@
 [TableOptions/BlockBasedTable "default"]
  # set by jni: tableOptions.setBlockSize
  block_size=65536
-# set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
+ # An explicit LRU cache preserves the current memory/performance policy.
+ # Consider a HyperClockCache to reduce contention on concurrent reads; cache
+ # choice does not change the on-disk format. See:
+ # https://github.com/facebook/rocksdb/wiki/Block-Cache
+ # set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
  block_cache=206150041
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
+ # Ribbon filters can reduce filter memory at higher construction CPU cost
+ # and are readable by 7.9.2. Partitioned filters can reduce metadata cache
+ # pressure; decouple_partitioned_filters=true (the new default since 10.6)
+ # is also readable by 7.9.2 and need not be disabled for downgrade safety.
+ # https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
+ # https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]
  filter_policy=rocksdb.BloomFilter:10:false
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks

--- a/bookkeeper-server/src/test/resources/conf/ledger_metadata_rocksdb.conf
+++ b/bookkeeper-server/src/test/resources/conf/ledger_metadata_rocksdb.conf
@@ -17,6 +17,13 @@
 # */
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -30,7 +37,14 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/conf/default_rocksdb.conf.default
+++ b/conf/default_rocksdb.conf.default
@@ -21,6 +21,13 @@
 # test case to ensure unit test coverage.
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -34,7 +41,14 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/conf/entry_location_rocksdb.conf.default
+++ b/conf/entry_location_rocksdb.conf.default
@@ -21,6 +21,13 @@
 # test case to ensure unit test coverage.
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -61,12 +68,29 @@
 [TableOptions/BlockBasedTable "default"]
  # set by jni: tableOptions.setBlockSize
  block_size=65536
+ # An explicit LRU cache preserves the current memory/performance policy.
+ # Consider a HyperClockCache to reduce contention on concurrent reads; cache
+ # choice does not change the on-disk format. See:
+ # https://github.com/facebook/rocksdb/wiki/Block-Cache
  # set by jni: tableOptions.setBlockCache, default value is: maxDirectMemory() / ledgerDirsSize / 10;
  block_cache=206150041
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
+ # Ribbon filters can reduce filter memory at higher construction CPU cost
+ # and are readable by 7.9.2. Partitioned filters can reduce metadata cache
+ # pressure; decouple_partitioned_filters=true (the new default since 10.6)
+ # is also readable by 7.9.2 and need not be disabled for downgrade safety.
+ # https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
+ # https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]
  filter_policy=rocksdb.BloomFilter:10:false
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks

--- a/conf/ledger_metadata_rocksdb.conf.default
+++ b/conf/ledger_metadata_rocksdb.conf.default
@@ -21,6 +21,13 @@
 # test case to ensure unit test coverage.
 
 [DBOptions]
+ # Keep WAL records readable by RocksDB 7.9.2 (BookKeeper 4.17.0 / Pulsar 4.0.x).
+ # Enabling track_and_verify_wals adds predecessor records (since 9.11) that
+ # 7.9.2 cannot replay. Enable only after the downgrade window has closed to
+ # detect missing/truncated WALs during recovery. This option is unknown to
+ # 7.9.2: use that release's configuration files when downgrading.
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h
+ track_and_verify_wals=false
  # set by jni: options.setCreateIfMissing
  create_if_missing=true
  # set by jni: options.setInfoLogLevel
@@ -34,7 +41,14 @@
  #no default setting in CFOptions
 
 [TableOptions/BlockBasedTable "default"]
- # set by jni: tableOptions.setFormatVersion
+ # Keep newly flushed/compacted SSTs readable by RocksDB 7.9.2.
+ # Format 5 supports modern Bloom filters (readable since RocksDB 6.6).
+ # After the downgrade window closes, format 6 (requires >= 8.6) improves
+ # detection of misplaced data and protects the footer with a checksum;
+ # format 7 (requires >= 10.4) additionally supports custom compression.
+ # Changing this setting only affects new SSTs; lowering it does not convert
+ # existing files. set by jni: tableOptions.setFormatVersion
+ # https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h
  format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <protoc.version>${protobuf.version}</protoc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>10.10.1</rocksdb.version>
+    <rocksdb.version>10.10.1.1</rocksdb.version>
     <shrinkwrap.version>3.3.0</shrinkwrap.version>
     <slf4j.version>2.0.12</slf4j.version>
     <slog.version>0.9.9</slog.version>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <protoc.version>${protobuf.version}</protoc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <reflections.version>0.9.11</reflections.version>
-    <rocksdb.version>9.9.3</rocksdb.version>
+    <rocksdb.version>10.10.1</rocksdb.version>
     <shrinkwrap.version>3.3.0</shrinkwrap.version>
     <slf4j.version>2.0.12</slf4j.version>
     <slog.version>0.9.9</slog.version>


### PR DESCRIPTION
### Motivation

Upgrade RocksDB JNI from 9.9.3 to **10.10.1.1**, the latest version published on [Maven Central](https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/maven-metadata.xml) as checked on 2026-09-10, while preserving the bookie's RocksDB index data compatibility with **7.9.2**. BookKeeper [4.17.0](https://github.com/apache/bookkeeper/blob/release-4.17.0/pom.xml) uses 7.9.2; later 4.17.x patches use 7.10.2, so 7.9.2 is the conservative compatibility baseline for Pulsar 4.0.x deployments.

Upstream's latest release is [11.8.1](https://github.com/facebook/rocksdb/releases/tag/v11.8.1), but its rocksdbjni artifact is not available on Maven Central. This PR deliberately targets the latest consumable JNI release, rather than introducing an unresolvable dependency.

The JNI-only 10.10.1.1 release fixes the Windows native-symbol failure reported in [RocksDB #14537](https://github.com/facebook/rocksdb/issues/14537). Its Java sources are unchanged from 10.10.1; upstream RocksDB source/documentation links therefore retain the v10.10.1 tag.

### Changes

- Upgrade `rocksdb.version` to 10.10.1.1 and update RocksDB artifact/source references in both binary distribution LICENSE files.
- Retain `format_version=5` in all three `conf/*_rocksdb.conf.default` templates and document the benefits and minimum reader versions of formats 6 and 7.
- Explicitly set `track_and_verify_wals=false` to preserve WAL recovery by 7.9.2, with comments explaining when the newer integrity checks can be enabled.
- Document compatible HyperClockCache, Ribbon filter, and partitioned-filter optimizations with upstream documentation links. Keep the existing checksum, compression and entry-location tuning.
- Update the corresponding test configurations and add a test that writes/compacts data and checks the actual SST footer version for every database type, with both configuration files and Java defaults.

### Backwards compatibility at the storage format level

**The default bookie ledger-metadata and entry-location indexes remain readable and writable by RocksDB 7.9.2 after upgrading to 10.10.1.1. No index migration or rewrite is required for this configuration.** This concerns RocksDB indexes; the BookKeeper journal and entry-log formats are unchanged.

| Component | Compatibility decision |
| --- | --- |
| SST files | Continue writing format 5, readable since RocksDB 6.6. Format 6 requires >= 8.6 and adds location-dependent checksums/footer protection; format 7 requires >= 10.4 and supports custom compression. Neither is suitable while 7.9.2 rollback is required. See [table options](https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/table.h). |
| WAL | Keep `track_and_verify_wals=false` (also the native default used by the Java fallback). The feature introduced in 9.11 writes predecessor-WAL records that the [7.9.2 reader](https://github.com/facebook/rocksdb/blob/v7.9.2/db/log_reader.cc) does not recognize. Existing ordinary write batches remain recoverable. |
| MANIFEST | Ordinary index metadata remains compatible. The 10.9 release fixes range-deletion boundary metadata that could previously persist a version-dependent internal value type and break older readers. Round-trip validation includes range deletion followed by compaction. |
| Compression, checksums and filters | Existing LZ4/Snappy compression and xxHash checksums are readable by 7.9.2. Modern Bloom filters and optional Ribbon filters are supported. Decoupled partitioned filters, enabled by default since 10.6, retain the old readable format; disabling them would unnecessarily forgo optimizations. |

Storage compatibility does **not** mean configuration files can be copied unchanged between releases: 7.9.2 rejects the new `track_and_verify_wals` option even when false. Use the older release's configuration on rollback, retaining compatible format/compression settings; do not load the newer generated `OPTIONS-*` file into the older strict parser. Operators using custom options must preserve these constraints. Lowering `format_version` does not convert SSTs already written in a newer format; those need rewriting with a capable RocksDB version before rollback. Enabling newer WAL records likewise cannot be undone merely by changing the option back.

This compatibility statement is scoped to the bookie's `KeyValueStorageRocksDB` indexes and their supplied/default settings, not the separate stream state-store implementation or arbitrary opt-in RocksDB features.

### Release-note review

Reviewed the [published release notes since 9.9.3](https://github.com/facebook/rocksdb/releases) and [cumulative history through 11.8.1](https://github.com/facebook/rocksdb/blob/v11.8.1/HISTORY.md), including patch-release notes. Relevant changes:

- **9.10–9.11:** WAL tracking is opt-in; manual leveled compactions respect `max_compaction_bytes` more strictly.
- **10.0–10.2:** removed obsolete compression/API options are not used by the supplied configuration; writing SST formats below 2 is unsupported; OPTIONS persistence errors now always fail the operation. Custom configurations must remove deleted options such as `fail_if_options_file_error` and `max_write_buffer_number_to_maintain`.
- **10.4–10.6:** format 7 is opt-in; file-size validation on open is strengthened; periodic compaction scheduling changes; decoupled partitioned filters become the default without breaking SST compatibility.
- **10.7–10.10:** native default cache changes to HyperClockCache, parallel compression improves, the LZ4 performance regression is fixed, MANIFEST auto-tuning is added, and the range-deletion compatibility bug is fixed. Explicit entry-location LRU caches remain explicit. These cache/compaction changes do not require an index-format migration.
- **Beyond this PR (10.11–11.8.1):** format 7 becomes the upstream default; 11.0 drops reads of SST formats 0/1, which would require pre-upgrade compaction for such legacy files; 11.5 changes default compression to LZ4, still readable by 7.9.2. New custom compression, embedded blobs and other experimental formats are not enabled by this PR. A future 11.x JNI upgrade needs its own validation.

### Validation

- Passed 13 focused tests, including all six database-type/configuration combinations in the new SST-format test:
  `mvn -B -pl bookkeeper-server,stream/statelib -am test -Dtest=KeyValueStorageRocksDBTest,KeyValueStorageTest,EntryLocationIndexTest,LedgerMetadataIndexTest -Dsurefire.failIfNoSpecifiedTests=false`
- Passed `mvn -B -pl bookkeeper-server -am checkstyle:check apache-rat:check`.
- Passed an additional standalone JNI test for each of the three templates: **7.9.2 → 10.10.1.1 → 7.9.2 → 10.10.1.1**, using separate JVMs/native libraries. Wrote 2,000 initial records, upgraded and applied point/range deletions plus 2,000 new records, flushed/compacted, then halted the JVM after an additional synced but unflushed write. The older version successfully recovered that WAL, verified all expected values/deletions, and wrote/compacted more data; the upgraded version then reopened and verified again. Older JVMs used the previous configuration files.
- Full [BookKeeper CI](https://github.com/apache/bookkeeper/actions/runs/34512295940) passed on `b787f29832`: all test groups, integration and backward-compatibility tests, Java 17/21 compatibility, Windows/macOS builds, binary license validation, and the aggregate CI check. [CodeQL](https://github.com/apache/bookkeeper/actions/runs/34512295996) also passed. No flaky-test retries were needed for this commit.


