### PR TITLE
Generate 4.18.1 release note

### DIFF
--- a/site3/website/src/pages/release-notes.md
+++ b/site3/website/src/pages/release-notes.md
@@ -4,6 +4,44 @@ format: md
 <!-- markdown-link-check-disable -->
 # Release notes
 
+## 4.18.1
+
+Release 4.18.1 includes a few new client APIs, several performance improvements, bug fixes and dependency updates.
+
+Apache BookKeeper users are encouraged to upgrade to 4.18.1 if you are using 4.18.x.
+The technical details of this release are summarized below.
+
+### Features
+
+* Pin a ledger's callbacks to a caller-chosen worker thread via `withOrderingKey` [PR #4881](https://github.com/apache/bookkeeper/pull/4881)
+* Add `OpenBuilder.withKeepUpdateMetadata` and `DeleteBuilder.withLoggerContext` to the builder API [PR #4834](https://github.com/apache/bookkeeper/pull/4834)
+
+### Improvements
+
+* Add `SingleThreadExecutor.executeOrRun` and issue reads inline from the ledger's own thread [PR #4883](https://github.com/apache/bookkeeper/pull/4883)
+* Avoid per-checksum boxing in Java9IntHash by using MethodHandle.invokeExact [PR #4876](https://github.com/apache/bookkeeper/pull/4876)
+* Use batch-draining queues in SingleThreadExecutor [PR #4836](https://github.com/apache/bookkeeper/pull/4836)
+* Skip journal flush-trace loop when debug logging is disabled [PR #4835](https://github.com/apache/bookkeeper/pull/4835)
+* Write journal entry length prefix and payload in a single BufferedChannel write [PR #4833](https://github.com/apache/bookkeeper/pull/4833)
+* Use ThreadLocalRandom for thread selection in OrderedExecutor [PR #4832](https://github.com/apache/bookkeeper/pull/4832)
+* Add spin-wait hint to BlockingMpscQueue producer-side busy loops [PR #4831](https://github.com/apache/bookkeeper/pull/4831)
+
+### Bugs
+
+* Revert "Fix read thread blocking in sendResponseAndWait causing READ_ENTRY_REQUEST p99 latency spike (#4730)" [PR #4830](https://github.com/apache/bookkeeper/pull/4830)
+* Prevent thread leak when BookKeeper client constructor fails [PR #4798](https://github.com/apache/bookkeeper/pull/4798)
+
+### Dependency updates
+
+* Bump Jetty to 12.1.10 and fix binary license metadata [PR #4871](https://github.com/apache/bookkeeper/pull/4871)
+* Bump org.apache.thrift:libthrift from 0.23.0 to 0.24.0 [PR #4874](https://github.com/apache/bookkeeper/pull/4874)
+* Bump at.yawk.lz4:lz4-java from 1.10.2 to 1.11.1 [PR #4869](https://github.com/apache/bookkeeper/pull/4869)
+* Bump bytes from 1.5.0 to 1.11.1 in native-io Rust module [PR #4747](https://github.com/apache/bookkeeper/pull/4747)
+
+#### Details
+
+https://github.com/apache/bookkeeper/pulls?q=is%3Apr+label%3Arelease%2F4.18.1+is%3Amerged
+
 ## 4.17.4
 
 Release 4.17.4 includes multiple bug fixes and few dependency updates.


### PR DESCRIPTION
### Motivation

Release notes for 4.18.1 (release candidate 0).

### Changes

Add the 4.18.1 section to the release notes page, covering the changes on `branch-4.18` since 4.18.0. CI-only changes (#4828, #4851) are omitted.